### PR TITLE
Remove pointer class from input

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -57,7 +57,7 @@ class Input extends Component {
     if (disabled) {
       classes += 'bg-light-gray bg-silver silver '
     } else {
-      classes += 'pointer bg-white '
+      classes += 'bg-white '
     }
 
     return (


### PR DESCRIPTION
Hover on input brings the wrong type of cursor. Removing the class "pointer" fixes it. 