### PR TITLE
Native dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* **Dropdown** Changed prop `optionsCaption` to `placeholder`
+* **Dropdown** Uses the native `select` instead of a custom one
+
 ## [2.0.0-rc.38] - 2018-04-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * **Dropdown** Changed prop `optionsCaption` to `placeholder`
 * **Dropdown** Uses the native `select` instead of a custom one
+* **Dropdown** Allows for `node` and `string` on the props `helpText` and `errorMessage`
 
 ## [2.0.0-rc.38] - 2018-04-18
 

--- a/src/components/Dropdown/README.md
+++ b/src/components/Dropdown/README.md
@@ -123,31 +123,36 @@ class Example extends React.Component {
     super(props)
 
     this.state = {
-        selectedPainter: {},
+      options: [
+        {value: 'painterChagall', label: 'Chagall'},
+        {value: 'painterDali', label: 'Dali'},
+        {value: 'painterGoya', label: 'Goya'},
+        {value: 'painterMonet', label: 'Monet'},
+        {value: 'painterPicasso', label: 'Picasso'},
+        {value: 'painterTolouseLautrec', label: 'Toulouse-Lautrec'}
+      ],
+      selectedPainter: '',
     }
     this.handleChange = this.handleChange.bind(this)
   }
 
-  handleChange(e, painter) {
-    this.setState({ selectedPainter: painter })
+  handleChange(e, value) {
+    this.setState({ selectedPainter: value })
   }
 
   render() {
+    const selectedPainter = this.state.options.find(painter => painter.value === this.state.selectedPainter)
+
+    const { label, value } = selectedPainter || {}
+
     return (
       <div className="w-40">
         <div>
           <Dropdown
             label="Painter"
-            options={[
-              {value: 'painterChagall', label: 'Chagall'},
-              {value: 'painterDali', label: 'Dali'},
-              {value: 'painterGoya', label: 'Goya'},
-              {value: 'painterMonet', label: 'Monet'},
-              {value: 'painterPicasso', label: 'Picasso'},
-              {value: 'painterTolouseLautrec', label: 'Toulouse-Lautrec'}
-            ]}
+            options={this.state.options}
             onChange={this.handleChange}
-            value={this.state.selectedPainter.value}
+            value={this.state.selectedPainter}
             {...this.props}
           />
         </div>
@@ -155,8 +160,8 @@ class Example extends React.Component {
           <div className="fw5 mb3">
             Selected Painter
           </div>
-          <p>Label: {this.state.selectedPainter.label || <span className="gray">undefined</span>}</p>
-          <p>Value: {this.state.selectedPainter.value || <span className="gray">undefined</span>}</p>
+          <p>Label: {label || <span className="gray">undefined</span>}</p>
+          <p>Value: {value || <span className="gray">undefined</span>}</p>
         </div>
       </div>
     )

--- a/src/components/Dropdown/README.md
+++ b/src/components/Dropdown/README.md
@@ -55,8 +55,8 @@ Variations
 <div className="w-40">
   <div className="mb5">
     <Dropdown
-      label="Caption"
-      optionsCaption="Select an artist"
+      label="Placeholder"
+      placeholder="Select an artist"
       options={[
         {value: 'chagall', label: 'Chagall'},
         {value: 'dali', label: 'Dali'},

--- a/src/components/Dropdown/README.md
+++ b/src/components/Dropdown/README.md
@@ -98,7 +98,7 @@ Variations
       value="tolouseLautrec"
       onChange={() => {}} />
   </div>
-  <div>
+  <div className="mb5">
     <Dropdown
       label="Help text"
       helpText={<span>Your help text goes here!</span>}
@@ -109,6 +109,21 @@ Variations
         {value: 'monet', label: 'Monet'},
         {value: 'picasso', label: 'Picasso'},
         {value: 'tolouseLautrec', label: 'Toulouse-Lautrec'}
+      ]}
+      value="tolouseLautrec"
+      onChange={() => {}} />
+  </div>
+  <div>
+    <Dropdown
+      label="Prevent truncate"
+      preventTruncate
+      options={[
+        {value: 'chagall', label: 'Marc Zakharovich Chagall, born Moishe Zakharovich Shagal'},
+        {value: 'dali', label: 'Salvador Domingo Felipe Jacinto Dalí i Domènech, Marquis of Dalí de Púbol, known professionally as Salvador Dalí'},
+        {value: 'goya', label: 'Francisco José de Goya y Lucientes'},
+        {value: 'monet', label: 'Oscar-Claude Monet'},
+        {value: 'picasso', label: 'Pablo Picasso'},
+        {value: 'tolouseLautrec', label: 'Henri Marie Raymond de Toulouse-Lautrec-Monfa, also known as Henri de Toulouse-Lautrec'}
       ]}
       value="tolouseLautrec"
       onChange={() => {}} />

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -4,14 +4,6 @@ import ArrowDownIcon from './ArrowDownIcon'
 import config from 'vtex-tachyons/config.json'
 
 class Dropdown extends Component {
-  setWrapperRef = node => {
-    this.wrapperRef = node
-  };
-
-  setSelectRef = el => {
-    this.select = el
-  };
-
   handleChange = e => {
     const { disabled, onChange } = this.props
     const { target: { value } } = e
@@ -97,7 +89,7 @@ class Dropdown extends Component {
     }
 
     return (
-      <div className="vtex-dropdown" ref={this.setWrapperRef}>
+      <div className="vtex-dropdown">
         <label>
           {label && (
             <span className="vtex-dropdown__label dib mb3 w-100">
@@ -107,7 +99,6 @@ class Dropdown extends Component {
           <div className={containerClasses} style={containerStyle}>
             <div
               id={id}
-              ref={this.setSelectRef}
               className={`vtex-dropdown__button ${classes}`}
             >
               <div className="flex">
@@ -157,7 +148,6 @@ class Dropdown extends Component {
         {helpText && (
           <div className="mid-gray f6 mt3 lh-title">{helpText}</div>
         )}
-
       </div>
     )
   }

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -135,7 +135,7 @@ class Dropdown extends Component {
               required={required}
             >
               {preventTruncate && (
-                <optgroup label={placeholder || label || helpText || ''}></optgroup>
+                <optgroup label={label || helpText || placeholder || ''}></optgroup>
               )}
               {options.map(option => (
                 <option key={option.value} value={option.value}>

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -134,6 +134,10 @@ class Dropdown extends Component {
               form={form}
               name={name}
               required={required}
+              style={{
+                // safari select height fix
+                webkitAppearance: 'menulist-button',
+              }}
             >
               {preventTruncate && (
                 <optgroup label={label || helpText || placeholder || ''}></optgroup>

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -79,6 +79,16 @@ class Dropdown extends Component {
       containerClasses += 'bg-white '
     }
 
+    if (error || errorMessage) {
+      containerClasses += 'ba b--red hover-b--red '
+    } else {
+      containerClasses += 'ba b--light-gray '
+    }
+
+    if (!disabled) {
+      containerClasses += 'hover-b--silver '
+    }
+
     return (
       <div className="vtex-dropdown" ref={this.setWrapperRef}>
         <label>

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -41,14 +41,11 @@ class Dropdown extends Component {
     } = this.props
 
     let width
-    let maxHeight
     let iconSize
 
     let classes = 'bg-transparent bn w-100 '
     let containerClasses = 'br2 bw1 relative '
     let selectClasses = 'o-0 absolute top-0 left-0 w-100 bottom-0 '
-    const optionsClasses = 'absolute bl br bb bw1 br2 br--bottom bg-white flex-column z-max overflow-y-auto '
-    let optionClasses = 'w-100 pointer flex bg-white hover-bg-near-white near-black tl bb-0 bl-0 br-0 bt b--near-white '
 
     const valueLabel = this.getValueLabel()
     const showCaption = !valueLabel
@@ -60,22 +57,16 @@ class Dropdown extends Component {
       case 'large':
         classes += 'f5 pv4 pl6 pr5 '
         selectClasses += 'f5 '
-        optionClasses += 'f5 pv4 ph6 '
-        maxHeight = '200px'
         iconSize = 18
         break
       case 'x-large':
         classes += 'f4 pv5 pl7 pr6 '
         selectClasses += 'f4 '
-        optionClasses += 'f4 pv5 ph7 '
-        maxHeight = '260px'
         iconSize = 22
         break
       default:
         classes += 'f6 pv3 pl5 pr4 '
-        optionClasses += 'f6 pv3 ph5 '
         selectClasses += 'f6 '
-        maxHeight = '150px'
         iconSize = 16
         break
     }

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -155,15 +155,16 @@ class Dropdown extends Component {
 
 Dropdown.defaultProps = {
   size: 'regular',
+  options: [],
 }
 
 Dropdown.propTypes = {
   /** Error highlight */
   error: PropTypes.bool,
   /** Error message */
-  errorMessage: PropTypes.string,
+  errorMessage: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   /** Help text */
-  helpText: PropTypes.node,
+  helpText: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   /** Dropdown label */
   label: PropTypes.string,
   /** Dropdown placeholder value */

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -38,6 +38,7 @@ class Dropdown extends Component {
       error,
       errorMessage,
       helpText,
+      placeholder,
     } = this.props
 
     let width
@@ -104,7 +105,7 @@ class Dropdown extends Component {
             >
               <div className="flex">
                 <div className="vtex-dropdown__caption flex-auto tl">
-                  {showCaption ? this.props.optionsCaption : valueLabel}
+                  {showCaption ? placeholder : valueLabel}
                 </div>
                 <div className="vtex-dropdown__arrow flex-none flex items-center pl6">
                   <ArrowDownIcon
@@ -154,6 +155,8 @@ Dropdown.propTypes = {
   helpText: PropTypes.node,
   /** Dropdown label */
   label: PropTypes.string,
+  /** Dropdown placeholder value */
+  placeholder: PropTypes.string,
   /** Dropdown size */
   size: PropTypes.oneOf(['regular', 'large', 'x-large']),
   /** Dropdown options list */
@@ -163,8 +166,6 @@ Dropdown.propTypes = {
       label: PropTypes.string.isRequired,
     })
   ),
-  /** Dropdown placeholder value */
-  optionsCaption: PropTypes.string,
   /** Spec attribute */
   id: PropTypes.string,
   /** Spec attribute */

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -16,7 +16,7 @@ class Dropdown extends Component {
     const { disabled, onChange } = this.props
     const { target: { value } } = e
 
-    !disabled && onChange && onChange(value)
+    !disabled && onChange && onChange(e, value)
   }
 
   getValueLabel() {

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -138,9 +138,12 @@ class Dropdown extends Component {
 
           </div>
         </label>
-        {errorMessage &&
-          <div className="red f6 mt3 lh-title">{errorMessage}</div>}
-        {helpText && <div className="mid-gray f6 mt3 lh-title">{helpText}</div>}
+        {errorMessage && (
+          <div className="red f6 mt3 lh-title">{errorMessage}</div>
+        )}
+        {helpText && (
+          <div className="mid-gray f6 mt3 lh-title">{helpText}</div>
+        )}
 
       </div>
     )

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -57,6 +57,7 @@ class Dropdown extends Component {
     const showCaption = !valueLabel
 
     classes += disabled ? 'bg-light-gray ' : 'pointer '
+    selectClasses += disabled ? '' : 'pointer '
     classes += !disabled && valueLabel ? 'near-black ' : 'gray '
 
     switch (size) {

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -106,10 +106,10 @@ class Dropdown extends Component {
               className={`vtex-dropdown__button ${classes}`}
             >
               <div className="flex">
-                <div className="vtex-dropdown__caption flex-auto tl">
+                <div className="vtex-dropdown__caption flex-auto tl truncate">
                   {showCaption ? placeholder : valueLabel}
                 </div>
-                <div className="vtex-dropdown__arrow flex-none flex items-center pl6">
+                <div className="vtex-dropdown__arrow flex-none flex items-center pl2">
                   <ArrowDownIcon
                     size={iconSize}
                     color={

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -39,6 +39,7 @@ class Dropdown extends Component {
       errorMessage,
       helpText,
       placeholder,
+      preventTruncate,
     } = this.props
 
     let width
@@ -124,6 +125,9 @@ class Dropdown extends Component {
               onChange={this.handleChange}
               value={value}
             >
+              {preventTruncate && (
+                <optgroup label={placeholder || label || helpText || ''}></optgroup>
+              )}
               {options.map(option => (
                 <option key={option.value} value={option.value}>
                   {option.label}
@@ -166,6 +170,8 @@ Dropdown.propTypes = {
       label: PropTypes.string.isRequired,
     })
   ),
+  /** Prevent truncating large options texts on some devices/browsers, such as iOS */
+  preventTruncate: PropTypes.bool,
   /** Spec attribute */
   id: PropTypes.string,
   /** Spec attribute */

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -94,10 +94,11 @@ class Dropdown extends Component {
     return (
       <div className="vtex-dropdown" ref={this.setWrapperRef}>
         <label>
-          {label &&
+          {label && (
             <span className="vtex-dropdown__label dib mb3 w-100">
               {label}
-            </span>}
+            </span>
+          )}
           <div className={containerClasses} style={containerStyle}>
             <div
               id={id}

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -40,7 +40,7 @@ class Dropdown extends Component {
       helpText,
       placeholder,
       preventTruncate,
-      autofocus,
+      autoFocus,
       form,
       name,
       required,
@@ -129,7 +129,7 @@ class Dropdown extends Component {
               className={selectClasses}
               onChange={this.handleChange}
               value={value}
-              autofocus={autofocus}
+              autoFocus={autoFocus}
               form={form}
               name={name}
               required={required}
@@ -187,7 +187,7 @@ Dropdown.propTypes = {
   /** Spec attribute */
   id: PropTypes.string,
   /** Spec attribute */
-  autofocus: PropTypes.bool,
+  autoFocus: PropTypes.bool,
   /** Spec attribute */
   value: PropTypes.string,
   /** Spec attribute */

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -40,6 +40,10 @@ class Dropdown extends Component {
       helpText,
       placeholder,
       preventTruncate,
+      autofocus,
+      form,
+      name,
+      required,
     } = this.props
 
     let width
@@ -125,6 +129,10 @@ class Dropdown extends Component {
               className={selectClasses}
               onChange={this.handleChange}
               value={value}
+              autofocus={autofocus}
+              form={form}
+              name={name}
+              required={required}
             >
               {preventTruncate && (
                 <optgroup label={placeholder || label || helpText || ''}></optgroup>


### PR DESCRIPTION
Use native dropdown instead of the custom one. 
Also changes the prop `optionsCaption` to `placeholder`.

Please test on a range of different devices and browsers.