### PR TITLE
Fix/dropdown numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* **Dropdown:** Allows using numbers as items values and labels, and nodes as labels
+
 ## [2.0.0-rc.40] - 2018-04-26
 
 ### Fixed

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -166,7 +166,7 @@ Dropdown.propTypes = {
   /** Help text */
   helpText: PropTypes.node,
   /** Dropdown label */
-  label: PropTypes.string,
+  label: PropTypes.node,
   /** Dropdown placeholder value */
   placeholder: PropTypes.string,
   /** Dropdown size */

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -174,8 +174,8 @@ Dropdown.propTypes = {
   /** Dropdown options list */
   options: PropTypes.arrayOf(
     PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     })
   ),
   /** Prevent truncating large options texts on some devices/browsers, such as iOS */

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -168,7 +168,7 @@ Dropdown.propTypes = {
   /** Dropdown label */
   label: PropTypes.node,
   /** Dropdown placeholder value */
-  placeholder: PropTypes.string,
+  placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Dropdown size */
   size: PropTypes.oneOf(['regular', 'large', 'x-large']),
   /** Dropdown options list */

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -162,9 +162,9 @@ Dropdown.propTypes = {
   /** Error highlight */
   error: PropTypes.bool,
   /** Error message */
-  errorMessage: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  errorMessage: PropTypes.node,
   /** Help text */
-  helpText: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  helpText: PropTypes.node,
   /** Dropdown label */
   label: PropTypes.string,
   /** Dropdown placeholder value */


### PR DESCRIPTION
Allows using numbers as dropdown items labels and values, as well as other minor proptypes fixes.