### PR TITLE
Fix/modal close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * **Input:** Adds prop `onKeyPress` for event handling
 
+### Changed
+
+* **Modal:** Move close button into the modal padding, and increase its hit area.
+
 ## [2.0.0-rc.41] - 2018-04-30
 
 ### Changed

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -24,8 +24,8 @@ class Modal extends PureComponent {
             padding: '3rem',
           },
           closeIcon: {
-            top: '10px',
-            right: '10px',
+            top: '8px',
+            right: '8px',
             padding: '10px',
           },
         }}

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -24,8 +24,9 @@ class Modal extends PureComponent {
             padding: '3rem',
           },
           closeIcon: {
-            top: '30px',
-            right: '30px',
+            top: '10px',
+            right: '10px',
+            padding: '10px',
           },
         }}
         closeIconSize={18}


### PR DESCRIPTION
Move modal close button into its padding, and increase the button's hit area to make it easier to click.

Fixes https://github.com/vtex/styleguide/issues/86
