### PR TITLE
Update weight of icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2018-05-08
+
+### Changed
+
+* **Icon** `Upload` & `Download` weight
+
 ## [2.2.0] - 2018-05-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "predeploy": "npm run styleguide:build",

--- a/src/components/icon/Download/index.js
+++ b/src/components/icon/Download/index.js
@@ -12,15 +12,9 @@ class Download extends PureComponent {
         width={size}
         height={size}
       >
-        <g
-          fill="none"
-          stroke={color}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeMiterlimit="10"
-        >
-          <path d="M8.5.5v11M13.5 6.5l-5 5-5-5" />
-          <path data-color="color-2" d="M15.5 15.5h-14" />
+        <g fill={color}>
+          <path d="M8 12c.3 0 .5-.1.7-.3L14.4 6 13 4.6l-4 4V0H7v8.6l-4-4L1.6 6l5.7 5.7c.2.2.4.3.7.3z" />
+          <path data-color="color-2" d="M1 14h14v2H1z" />
         </g>
       </svg>
     )

--- a/src/components/icon/Upload/index.js
+++ b/src/components/icon/Upload/index.js
@@ -12,15 +12,9 @@ class Upload extends PureComponent {
         width={size}
         height={size}
       >
-        <g
-          fill="none"
-          stroke={color}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeMiterlimit="10"
-        >
-          <path d="M8.5 11.5V.5M13.5 5.5l-5-5-5 5" />
-          <path data-color="color-2" d="M15.5 15.5h-14" />
+        <g fill={color}>
+          <path d="M7 3.4V12h2V3.4l4 4L14.4 6 8.7.3c-.4-.4-1-.4-1.4 0L1.6 6 3 7.4l4-4z" />
+          <path data-color="color-2" d="M1 14h14v2H1z" />
         </g>
       </svg>
     )


### PR DESCRIPTION
<img width="55" alt="screen shot 2018-05-08 at 15 50 37" src="https://user-images.githubusercontent.com/2573602/39776542-9356f52a-52d7-11e8-80eb-8081db9777c4.png"> 
instead of:
<img width="62" alt="screen shot 2018-05-08 at 15 50 32" src="https://user-images.githubusercontent.com/2573602/39776553-97a9254e-52d7-11e8-859f-411396b165f9.png">
