### PR TITLE
Fix/radio click area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Radio** Make the entire container clickable instead of just the label and the radio button itself
+
 ## [4.1.0] - 2018-06-04
 
 ### Added

--- a/react/components/Radio/index.js
+++ b/react/components/Radio/index.js
@@ -3,10 +3,15 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 class Radio extends PureComponent {
-  handleContainerClick=e => {
-    const { disabled, checked } = this.props
-    if (!disabled && !checked) {
-      this.radio.click()
+  constructor(props) {
+    super(props)
+    this.radio = React.createRef()
+    this.container = React.createRef()
+  }
+  handleContainerClick = e => {
+    const { disabled } = this.props
+    if (!disabled && e.target === this.container.current) {
+      this.radio.current.click()
     }
   }
   render() {
@@ -26,6 +31,7 @@ class Radio extends PureComponent {
         className={classNames('flex items-center mb3 relative', {
           pointer: !disabled,
         })}
+        ref={this.container}
         onClick={this.handleContainerClick}
       >
         <div
@@ -71,7 +77,7 @@ class Radio extends PureComponent {
             height: '1.5rem',
             width: '1.5rem',
           }}
-          ref={el => { this.radio = el }}
+          ref={this.radio}
         />
         <label
           className={classNames({ silver: disabled }, { pointer: !disabled }, 'flex flex-auto')}

--- a/react/components/Radio/index.js
+++ b/react/components/Radio/index.js
@@ -3,6 +3,12 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 class Radio extends PureComponent {
+  handleContainerClick=e => {
+    const { disabled, checked } = this.props
+    if (!disabled && !checked) {
+      this.radio.click()
+    }
+  }
   render() {
     const {
       checked,
@@ -20,6 +26,7 @@ class Radio extends PureComponent {
         className={classNames('flex items-center mb3 relative', {
           pointer: !disabled,
         })}
+        onClick={this.handleContainerClick}
       >
         <div
           className={classNames(
@@ -64,6 +71,7 @@ class Radio extends PureComponent {
             height: '1.5rem',
             width: '1.5rem',
           }}
+          ref={el => { this.radio = el }}
         />
         <label
           className={classNames({ silver: disabled }, { pointer: !disabled })}

--- a/react/components/Radio/index.js
+++ b/react/components/Radio/index.js
@@ -74,7 +74,7 @@ class Radio extends PureComponent {
           ref={el => { this.radio = el }}
         />
         <label
-          className={classNames({ silver: disabled }, { pointer: !disabled })}
+          className={classNames({ silver: disabled }, { pointer: !disabled }, 'flex flex-auto')}
           htmlFor={id}
         >
           {label}

--- a/react/components/Radio/index.js
+++ b/react/components/Radio/index.js
@@ -8,12 +8,14 @@ class Radio extends PureComponent {
     this.radio = React.createRef()
     this.container = React.createRef()
   }
+
   handleContainerClick = e => {
     const { disabled } = this.props
     if (!disabled && e.target === this.container.current) {
       this.radio.current.click()
     }
   }
+
   render() {
     const {
       checked,


### PR DESCRIPTION
Fix https://github.com/vtex/styleguide/issues/154

The entire radio button container had a `pointer` class, meaning that it would look clickable, but only the width of the label and the radio button themselves had any action. This PR makes the entire container clickable.