### PR TITLE
Allows node as radio labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Radio** Make the entire container clickable instead of just the label and the radio button itself
 
+### Changed
+
+- **Radio** Change label proptype from `string` to `node`
+
 ## [4.1.0] - 2018-06-04
 
 ### Added

--- a/react/components/Radio/index.js
+++ b/react/components/Radio/index.js
@@ -106,7 +106,7 @@ Radio.propTypes = {
   /** (Button spec attribute) */
   id: PropTypes.string.isRequired,
   /** Radio label */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
   /** (Button spec attribute) */
   name: PropTypes.string.isRequired,
   /** onChange event */


### PR DESCRIPTION
Title is self explanatory.

Use case:
<img width="304" alt="screen shot 2018-06-11 at 15 35 50" src="https://user-images.githubusercontent.com/5691711/41250387-26f96bd0-6d8d-11e8-8a57-ea7a6d964aef.png">
