### PR TITLE
Export Checkbox component as an render app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.2.1] - 2018-06-14
+
 - **Checkbox** Export Checkbox component as an app to render. 
 
 ## [4.2.0] - 2018-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- **Checkbox** Export Checkbox component as an app to render. 
+
 ## [4.2.0] - 2018-06-12
 
 ### Fixed
 
 - **Radio** Make the entire container clickable instead of just the label and the radio button itself
-- **Checkbox** Export Checkbox component as an app to render. 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.2.0] - 2018-06-12
+
 ### Fixed
 
 - **Radio** Make the entire container clickable instead of just the label and the radio button itself

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **Radio** Make the entire container clickable instead of just the label and the radio button itself
+- **Checkbox** Export Checkbox component as an app to render. 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Radio** Change label proptype from `string` to `node`
 - **Radio** Add animation on toggle
+- **Spinner** Add round linecap and make it spin a little faster
 
 ## [4.1.0] - 2018-06-04
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,8 @@
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
-  "registries": ["smartcheckout"],
+  "registries": [
+    "smartcheckout"
+  ],
   "settingsSchema": {}
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,9 @@
   "builders": {
     "react": "2.x"
   },
+ "scripts": {
+    "postreleasy": "vtex publish --verbose"
+  },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
   "registries": ["smartcheckout"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/Checkbox.js
+++ b/react/Checkbox.js
@@ -1,0 +1,3 @@
+import Checkbox from './components/Checkbox/index'
+
+export default Checkbox

--- a/react/components/Spinner/index.js
+++ b/react/components/Spinner/index.js
@@ -16,6 +16,7 @@ const Spinner = ({ secondary, size }) => (
       fill="none"
       stroke={secondary ? config.colors.white : config.colors.blue}
       strokeWidth="10"
+      strokeLinecap="round"
       r="40"
       strokeDasharray="188.49555921538757 64.83185307179586"
       transform="rotate(96 50 50)"

--- a/react/components/Spinner/index.js
+++ b/react/components/Spinner/index.js
@@ -27,7 +27,7 @@ const Spinner = ({ secondary, size }) => (
         calcMode="linear"
         values="0 50 50;360 50 50"
         keyTimes="0;1"
-        dur="1s"
+        dur="0.75s"
         begin="0s"
         repeatCount="indefinite"
       />


### PR DESCRIPTION
#### What is the purpose of this pull request?
Export Checkbox component as an render app

Change `search-result` to import styleguide components only through Render. 
[PR search-result](https://github.com/vtex-apps/search-result/pull/5)

#### Screenshots or example usage
https://claudivan--storecomponents.myvtexdev.com/smartphones

#### Types of changes
* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
