### PR TITLE
Add red danger buttons

### DIFF
--- a/react/components/Button/README.md
+++ b/react/components/Button/README.md
@@ -12,6 +12,9 @@ Types
     <span className="mr4">
       <Button variation="tertiary">Tertiary</Button>
     </span>
+    <span className="mr4">
+      <Button variation="danger">Danger</Button>
+    </span>
   </div>
   <div className="mt4">
     <span className="mr4">
@@ -22,6 +25,9 @@ Types
     </span>
     <span className="mr4">
       <Button variation="tertiary" disabled>Tertiary</Button>
+    </span>
+    <span className="mr4">
+      <Button variation="danger" disabled>Danger</Button>
     </span>
   </div>
 </div>
@@ -78,6 +84,23 @@ Sizes
     </span>
     <span className="mr4">
       <Button variation="tertiary" size="large">
+        Large
+      </Button>
+    </span>
+  </div>
+  <div className="mb4">
+    <span className="mr4">
+      <Button variation="danger" size="small">
+        Small
+      </Button>
+    </span>
+    <span className="mr4">
+      <Button variation="danger" size="regular">
+        Default
+      </Button>
+    </span>
+    <span className="mr4">
+      <Button variation="danger" size="large">
         Large
       </Button>
     </span>

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -69,6 +69,14 @@ class Button extends Component {
         }
         break
       }
+      case 'danger': {
+        if (disabled) {
+          classes += 'bg-light-silver silver b--light-silver '
+        } else {
+          classes += 'bg-red b--red white '
+        }
+        break
+      }
     }
 
     if (!disabled) {
@@ -131,7 +139,7 @@ Button.propTypes = {
   /** Button size  */
   size: PropTypes.oneOf(['small', 'regular', 'large']),
   /** Button prominence variation */
-  variation: PropTypes.oneOf(['primary', 'secondary', 'tertiary']),
+  variation: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'danger']),
   /** Block style */
   block: PropTypes.bool,
   /** Loading state */


### PR DESCRIPTION
Podemos adicionar o danger button ao styleguide?

Detalhe, só tem duas versões de vermelho no vtex-tachyons: `washed-red` e `red`. O `washed-red` é muito claro pra funciona no botão, por isso usei o `red`. Também não adicionei nenhuma cor de _hover_ pois não tinha disponível um vermelho diferente.

![screen shot 2018-06-21 at 11 49 44](https://user-images.githubusercontent.com/1354492/41726898-7cbe5fda-7549-11e8-969b-38d2d1500599.png)
