### PR TITLE
Fix/bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [4.3.6] - 2018-6-25
+## [5.0.0] - 2018-6-25
 
 ### Changed
 
-- **Tabs** Group tabs in a single component
+- **[BREAKING] Tabs** Group tabs in a single component
 
 ## [4.3.5] - 2018-6-21
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "4.3.5",
+  "version": "5.0.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "4.3.6",
+  "version": "5.0.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",


### PR DESCRIPTION
Change last release tag to v5.0.0 since it should have been a breaking change to Tabs component