### PR TITLE
Add controlled value to Textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Textarea** Add `value` and `defaultValue` props to enable control
+
 ## [5.0.1] - 2018-6-25
 
 ### Changed

--- a/react/components/Textarea/README.md
+++ b/react/components/Textarea/README.md
@@ -1,6 +1,9 @@
 Default
 
 ```js
+initialState = {
+  value: ""
+};
 <div>
   <div className="mb6">
     <Textarea label="With a label">I haz content</Textarea>
@@ -14,12 +17,17 @@ Default
     <Textarea
       label="With helper"
       helpText={<span>Your help text goes here!</span>}
-    >
-      I content, shall be readable.
-    </Textarea>
+    />
   </div>
-  <div>
+  <div className="mb6">
     <Textarea label="With error" error errorMessage="Somehow wrong" />
   </div>
-</div>
+  <div className="mb6">
+    <Textarea
+      label="Controlling text"
+      onChange={e => setState({ value: e.target.value.trim() })}
+      value={state.value}
+    />
+  </div>
+</div>;
 ```

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -89,8 +89,11 @@ class Textarea extends Component {
           spellCheck={this.props.spellCheck}
           id={this.props.id}
           rows={this.props.rows}
-          defaultValue={children}
-        />
+          defaultValue={this.props.defaultValue}
+          value={this.props.value}
+        >
+          {children}
+        </textarea>
 
         {errorMessage && (
           <div className="red f6 mt3 lh-title">{errorMessage}</div>
@@ -102,7 +105,6 @@ class Textarea extends Component {
 }
 
 Textarea.defaultProps = {
-  children: '',
   autoFocus: false,
   dataAttributes: {},
   disabled: false,
@@ -115,6 +117,10 @@ Textarea.defaultProps = {
 Textarea.propTypes = {
   /** Content of the textarea */
   children: PropTypes.string,
+  /** Controlled content of the textarea */
+  value: PropTypes.string,
+  /** Default content of the textarea */
+  defaultValue: PropTypes.string,
   /** Error highlight */
   error: PropTypes.bool,
   /** Error message */


### PR DESCRIPTION
Fix issue where only the default value would change with input from Textarea. This also allows the use of controlled value in React.