### PR TITLE
Add optional countdown to Textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Textarea** character countdown when maxLength is defined
+
 ## [6.1.3] - 2018-08-29
 
-### Fix
+### Fixed
+
 - **Input** fix propType of ref
 - **Dropdown** fix propType of ref
 
 ## [6.1.2] - 2018-08-28
 
 ### Fixed
+
 - **Icons** block prop was sometimes not applied when icons had a `solid` variation
 
 ## [6.1.1] - 2018-08-27
 
 ### Added
+
 - **Table** Enhance schema examples in README documentation
 
 ## [6.1.0] - 2018-08-24
@@ -30,17 +37,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **InputSearch** component
 
 ### Fixed
+
 - **Button** component should be disabled while loading
 
 ## [6.0.1] - 2018-08-23
 
 ### Fixed
+
 - **Dropdown** forward ref to select
 - **Pagination** Next button disabled
 
 ## [6.0.0] - 2018-08-23
 
 ### Added
+
 - **Badge** add prop `type`
 - **Spinner** add prop `color`
 - **Spinner** add default color of `.c-action-primary`
@@ -53,6 +63,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **[BREAKING]** **Spinner** remove prop `secondary`
 
 ### Fixed
+
 - Spinner proptypes
 
 ## [5.6.2] - 2018-8-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `SuffixIcon` to `Input` component.
 
+### Added
+
+- **Textarea** character countdown (optional)
+
 ## [5.4.1] - 2018-07-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,10 +122,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `SuffixIcon` to `Input` component.
 
-### Added
-
-- **Textarea** character countdown (optional)
-
 ## [5.4.1] - 2018-07-20
 
 ### Changed

--- a/react/components/Textarea/README.md
+++ b/react/components/Textarea/README.md
@@ -29,6 +29,7 @@ initialState = {
       value={state.value}
       maxLength={100}
       characterCountdown
+      characterCountdownText="characters left"
     />
   </div>
 </div>;

--- a/react/components/Textarea/README.md
+++ b/react/components/Textarea/README.md
@@ -29,7 +29,6 @@ initialState = {
       value={state.value}
       maxLength={100}
       characterCountdown
-      characterCountdownText="characters left"
     />
   </div>
 </div>;

--- a/react/components/Textarea/README.md
+++ b/react/components/Textarea/README.md
@@ -24,9 +24,11 @@ initialState = {
   </div>
   <div className="mb6">
     <Textarea
-      label="Controlling text"
+      label="Controlling text (no spaces) with character countdown"
       onChange={e => setState({ value: e.target.value.trim() })}
       value={state.value}
+      maxLength={100}
+      characterCountdown
     />
   </div>
 </div>;

--- a/react/components/Textarea/README.md
+++ b/react/components/Textarea/README.md
@@ -28,7 +28,6 @@ initialState = {
       onChange={e => setState({ value: e.target.value.trim() })}
       value={state.value}
       maxLength={100}
-      characterCountdown
       helpText="You can have helper text alongside the countdown."
     />
   </div>

--- a/react/components/Textarea/README.md
+++ b/react/components/Textarea/README.md
@@ -29,6 +29,7 @@ initialState = {
       value={state.value}
       maxLength={100}
       characterCountdown
+      helpText="You can have helper text alongside the countdown."
     />
   </div>
 </div>;

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -131,6 +131,7 @@ Textarea.defaultProps = {
   label: '',
   readOnly: false,
   error: false,
+  characterCountdownText: 'characters left',
   rows: 5,
 }
 

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -11,11 +11,11 @@ class Textarea extends Component {
   }
 
   static CharacterCountdown = props => {
-    let classes = 'mid-gray f6 mt3 '
+    let classes = 'mid-gray f6 '
     if (props.value <= 10) {
       classes += 'red'
     }
-    return <div className={classes}>{props.value}</div>
+    return <div className={classes}>{props.value} {props.text}</div>
   }
 
   handleChange = event => {
@@ -115,6 +115,7 @@ class Textarea extends Component {
           {this.props.characterCountdown && (
             <Textarea.CharacterCountdown
               value={this.props.maxLength - this.props.value.length}
+              text={this.props.characterCountdownText}
             />
           )}
         </div>
@@ -184,6 +185,8 @@ Textarea.propTypes = {
   onBlur: PropTypes.func,
   /** Character countdown at the bottom right */
   characterCountdown: PropTypes.bool,
+  /** Helper text for character countdown (X characters left) */
+  characterCountdownText: PropTypes.string,
 }
 
 export default Textarea

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -10,19 +10,27 @@ class Textarea extends Component {
     }
   }
 
+  static CharacterCountdown = props => {
+    let classes = 'mid-gray f6 mt3 '
+    if (props.value <= 10) {
+      classes += 'red'
+    }
+    return <div className={classes}>{props.value}</div>
+  }
+
   handleChange = event => {
     this.props.onChange && this.props.onChange(event)
-  };
+  }
 
   handleFocus = event => {
     this.setState({ active: true })
     this.props.onFocus && this.props.onFocus(event)
-  };
+  }
 
   handleBlur = event => {
     this.setState({ active: false })
     this.props.onBlur && this.props.onBlur(event)
-  };
+  }
 
   render() {
     const {
@@ -68,8 +76,9 @@ class Textarea extends Component {
 
     return (
       <label className="vtex-textarea">
-        {label &&
-          <span className="vtex-textarea__label db mb3 w-100">{label}</span>}
+        {label && (
+          <span className="vtex-textarea__label db mb3 w-100">{label}</span>
+        )}
         <textarea
           {...dataAttrs}
           onBlur={this.handleBlur}
@@ -94,10 +103,21 @@ class Textarea extends Component {
           {children}
         </textarea>
 
-        {errorMessage &&
-          <div className="c-danger f6 mt3 lh-title">{errorMessage}</div>}
-        {helpText &&
-          <div className="c-muted-1 f6 mt3 lh-title">{helpText}</div>}
+        <div className="flex justify-between">
+          <div>
+            {errorMessage && (
+              <div className="red f6 mt3 lh-title">{errorMessage}</div>
+            )}
+            {helpText && (
+              <div className="mid-gray f6 mt3 lh-title">{helpText}</div>
+            )}
+          </div>
+          {this.props.characterCountdown && (
+            <Textarea.CharacterCountdown
+              value={this.props.maxLength - this.props.value.length}
+            />
+          )}
+        </div>
       </label>
     )
   }
@@ -162,6 +182,8 @@ Textarea.propTypes = {
   onFocus: PropTypes.func,
   /** onBlur event */
   onBlur: PropTypes.func,
+  /** Character countdown at the bottom right */
+  characterCountdown: PropTypes.bool,
 }
 
 export default Textarea

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -11,11 +11,17 @@ class Textarea extends Component {
   }
 
   static CharacterCountdown = props => {
-    let classes = 'mid-gray f6 '
+    let classes = 'f6 mt2 lh-title '
     if (props.value <= 10) {
-      classes += 'red'
+      classes += 'c-danger'
+    } else {
+      classes += 'c-muted-1'
     }
-    return <div className={classes}>{props.value} {props.text}</div>
+    return (
+      <div className={classes}>
+        {props.value} {props.text}
+      </div>
+    )
   }
 
   handleChange = event => {
@@ -106,13 +112,13 @@ class Textarea extends Component {
         <div className="flex justify-between">
           <div>
             {errorMessage && (
-              <div className="red f6 mt3 lh-title">{errorMessage}</div>
+              <div className="c-danger f6 mt2 lh-title">{errorMessage}</div>
             )}
             {helpText && (
-              <div className="mid-gray f6 mt3 lh-title">{helpText}</div>
+              <div className="c-muted-1 f6 mt2 lh-title">{helpText}</div>
             )}
           </div>
-          {this.props.characterCountdown && (
+          {this.props.maxLength && (
             <Textarea.CharacterCountdown
               value={this.props.maxLength - this.props.value.length}
               text={this.props.characterCountdownText}
@@ -158,7 +164,7 @@ Textarea.propTypes = {
   disabled: PropTypes.bool,
   /** Spec attribute */
   id: PropTypes.string,
-  /** Spec attribute */
+  /** If defined, the textarea will have a character countdown at the bottom right */
   maxLength: PropTypes.string,
   /** Spec attribute */
   minLength: PropTypes.string,
@@ -184,8 +190,6 @@ Textarea.propTypes = {
   onFocus: PropTypes.func,
   /** onBlur event */
   onBlur: PropTypes.func,
-  /** Character countdown at the bottom right */
-  characterCountdown: PropTypes.bool,
   /** Helper text for character countdown (X characters left) */
   characterCountdownText: PropTypes.string,
 }

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -46,6 +46,7 @@ class Textarea extends Component {
       helpText,
       dataAttributes,
       children,
+      maxLength,
     } = this.props
     const { active } = this.state
 
@@ -118,7 +119,7 @@ class Textarea extends Component {
               <div className="c-muted-1 f6 mt2 lh-title">{helpText}</div>
             )}
           </div>
-          {this.props.maxLength && (
+          {maxLength && (
             <Textarea.CharacterCountdown
               value={this.props.maxLength - this.props.value.length}
               text={this.props.characterCountdownText}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add character countdown to Textarea whenever `maxLength` is defined. Text can be customized using the `characterCountdownText` prop.

#### Screenshots or example usage
Behaviour: becomes red near the limit (last 10 characters)
![character_countdown](https://user-images.githubusercontent.com/39499441/44858666-dff81380-ac48-11e8-8d75-4bf1cf9c8c48.gif)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
