### PR TITLE
Fix/input proptype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `maxLength` propType in `Input` component
+
 ## [5.4.3] - 2018-07-27
 
 ## [5.4.2] - 2018-07-26

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -234,7 +234,7 @@ Input.propTypes = {
   /** Spec attribute */
   max: PropTypes.string,
   /** Spec attribute */
-  maxLength: PropTypes.string,
+  maxLength: PropTypes.number,
   /** Spec attribute */
   min: PropTypes.string,
   /** Spec attribute */


### PR DESCRIPTION
#### What is the purpose of this pull request?
This pull request simply changes the `maxLength` propType inside the `Input` component to be `number` instead of `string`.

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.