### PR TITLE
Fix/caret names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [5.4.5] - 2018-08-03
+
 ## [5.4.4] - 2018-08-02
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/components/icon/CaretDown/index.js
+++ b/react/components/icon/CaretDown/index.js
@@ -8,7 +8,7 @@ const iconBase = {
   height: 10,
 }
 
-class CarretDown extends PureComponent {
+class CaretDown extends PureComponent {
   render() {
     const { color, size } = this.props
     const newSize = calcIconSize(iconBase, size)
@@ -30,14 +30,14 @@ class CarretDown extends PureComponent {
   }
 }
 
-CarretDown.defaultProps = {
+CaretDown.defaultProps = {
   color: config.colors['serious-black'],
   size: 16,
 }
 
-CarretDown.propTypes = {
+CaretDown.propTypes = {
   color: PropTypes.string,
   size: PropTypes.number,
 }
 
-export default CarretDown
+export default CaretDown

--- a/react/components/icon/CaretLeft/index.js
+++ b/react/components/icon/CaretLeft/index.js
@@ -8,7 +8,7 @@ const iconBase = {
   height: 14,
 }
 
-class CarretLeft extends PureComponent {
+class CaretLeft extends PureComponent {
   render() {
     const { color, size } = this.props
     const newSize = calcIconSize(iconBase, size)
@@ -31,14 +31,14 @@ class CarretLeft extends PureComponent {
   }
 }
 
-CarretLeft.defaultProps = {
+CaretLeft.defaultProps = {
   color: config.colors['serious-black'],
   size: 16,
 }
 
-CarretLeft.propTypes = {
+CaretLeft.propTypes = {
   color: PropTypes.string,
   size: PropTypes.number,
 }
 
-export default CarretLeft
+export default CaretLeft

--- a/react/components/icon/CaretRight/index.js
+++ b/react/components/icon/CaretRight/index.js
@@ -8,7 +8,7 @@ const iconBase = {
   height: 14,
 }
 
-class CarretRight extends PureComponent {
+class CaretRight extends PureComponent {
   render() {
     const { color, size } = this.props
     const newSize = calcIconSize(iconBase, size)
@@ -31,14 +31,14 @@ class CarretRight extends PureComponent {
   }
 }
 
-CarretRight.defaultProps = {
+CaretRight.defaultProps = {
   color: config.colors['serious-black'],
   size: 16,
 }
 
-CarretRight.propTypes = {
+CaretRight.propTypes = {
   color: PropTypes.string,
   size: PropTypes.number,
 }
 
-export default CarretRight
+export default CaretRight

--- a/react/components/icon/CaretUp/index.js
+++ b/react/components/icon/CaretUp/index.js
@@ -8,7 +8,7 @@ const iconBase = {
   height: 10,
 }
 
-class CarretUp extends PureComponent {
+class CaretUp extends PureComponent {
   render() {
     const { color, size } = this.props
     const newSize = calcIconSize(iconBase, size)
@@ -31,14 +31,14 @@ class CarretUp extends PureComponent {
   }
 }
 
-CarretUp.defaultProps = {
+CaretUp.defaultProps = {
   color: config.colors['serious-black'],
   size: 16,
 }
 
-CarretUp.propTypes = {
+CaretUp.propTypes = {
   color: PropTypes.string,
   size: PropTypes.number,
 }
 
-export default CarretUp
+export default CaretUp


### PR DESCRIPTION
Fixes `Caret` classes being written as `Carret` (does not affect external use)