### PR TITLE
Fix/numeric stepper block width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Dropdown** Decrease default label's font size
 
+### Fixed
+
+- **NumericStepper** Fix width on block mode
+
 ## [5.4.6] - 2018-08-03
 
 ## [5.4.5] - 2018-08-03

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -151,7 +151,12 @@ export default class NumericStepper extends React.Component {
         <div className="flex self-start">
           <input
             type="tel"
-            className={`z-1 order-1 w3 tc bw1 ba b--light-gray br0 ${inputSizeClasses[size]}`}
+            className={`z-1 order-1 tc bw1 ba b--light-gray br0 ${inputSizeClasses[size]}`}
+            style={{
+              ...(block && {
+                width: 0,
+              }),
+            }}
             value={displayValue}
             onChange={this.handleTypeQuantity}
             onFocus={this.handleFocusInput}


### PR DESCRIPTION
Fixes width bug on NumericStepper block mode

![cheap_css_is_awesome_mug-rf064a31396644e03a71994d72eece75d_x7jgr_8byvr_307](https://user-images.githubusercontent.com/5691711/43858587-ce4a49bc-9b24-11e8-994b-b82368adf350.jpg)


Before:
<img width="367" alt="screen shot 2018-08-08 at 16 01 07" src="https://user-images.githubusercontent.com/5691711/43858517-a1d753b6-9b24-11e8-868e-0f4045c78e7a.png">

After:
<img width="225" alt="screen shot 2018-08-08 at 16 00 01" src="https://user-images.githubusercontent.com/5691711/43858527-a973034a-9b24-11e8-8557-6c5de2db8dfc.png">
