### PR TITLE
Change alert width to 100%

### DIFF
--- a/react/components/Alert/index.js
+++ b/react/components/Alert/index.js
@@ -53,8 +53,8 @@ class Alert extends Component {
     }
 
     return (
-      <div className={`vtex-alert flex justify-between f5 near-black ${classes}`}>
-        <div className="flex items-center">
+      <div className={`vtex-alert flex justify-between f5 near-black w-100 ${classes}`}>
+        <div className="flex items-center w-100">
           {showIcon && <div><Icon color={color} size={18} /></div>}
 
           <div className={`${showIcon ? 'ph5 flex' : 'pr5'}`}>


### PR DESCRIPTION
**What is the purpose of this pull request?**
- The alert must fill 100% of the width it is contained. I had to do this to make it possible to add an action button on the alert: 

![image](https://user-images.githubusercontent.com/5035494/43975950-9f4f14a2-9cb5-11e8-8567-a9f39b990aeb.png)
