### PR TITLE
Add small size to the Numeric Stepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Small size to the `NumericStepper`.
+
 ### Fixed
 - Spinner proptypes
 

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -142,12 +142,14 @@ export default class NumericStepper extends React.Component {
     const isMax = value >= normalizeMax(maxValue)
 
     const buttonSizeClasses = {
+      small: 'pv2 f7',
       regular: 'pv3 f6',
       large: 'pv4 f5',
       'x-large': 'pv5 f4',
     }
 
     const inputSizeClasses = {
+      small: `pv2 f7 ${block ? 'flex-grow-1' : 'w2'}`,
       regular: `pv3 f6 ${block ? 'flex-grow-1' : 'w3'}`,
       large: `pv4 f5 ${block ? 'flex-grow-1' : 'w3'}`,
       'x-large': `pv5 f4 ${block ? 'flex-grow-1' : 'w4'}`,
@@ -161,7 +163,7 @@ export default class NumericStepper extends React.Component {
             type="tel"
             className={`z-1 order-1 tc bw1 ba b--light-gray br0 ${
               inputSizeClasses[size]
-            }`}
+              }`}
             style={{
               ...(block && {
                 width: 0,
@@ -176,7 +178,7 @@ export default class NumericStepper extends React.Component {
             <button
               className={`br2 ph0 tc ba bl-0 bw1 b--light-gray ${
                 buttonSizeClasses[size]
-              } ${isMax ? 'bg-light-silver silver' : 'pointer bg-white blue'}`}
+                } ${isMax ? 'bg-light-silver silver' : 'pointer bg-white blue'}`}
               style={{
                 borderTopLeftRadius: 0,
                 borderBottomLeftRadius: 0,
@@ -197,7 +199,7 @@ export default class NumericStepper extends React.Component {
             <button
               className={`br2 ph0 ba br-0 bw1 b--light-gray ${
                 buttonSizeClasses[size]
-              } ${isMin ? 'bg-light-silver silver' : 'pointer bg-white blue'}`}
+                } ${isMin ? 'bg-light-silver silver' : 'pointer bg-white blue'}`}
               style={{
                 borderTopRightRadius: 0,
                 borderBottomRightRadius: 0,
@@ -237,7 +239,7 @@ NumericStepper.propTypes = {
   /** Default value in case of invalid input (e.g. letters) and there is no minimum value */
   defaultValue: PropTypes.number,
   /** Input size */
-  size: PropTypes.oneOf(['regular', 'large', 'x-large']),
+  size: PropTypes.oneOf(['small', 'regular', 'large', 'x-large']),
   /** Block or default size. */
   block: PropTypes.bool,
   /** Input label */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the small size to the NumericStepper, because there was just reguler, large and x-large one.

#### What problem is this solving?
The MiniCart component needs a Numeric Stepper smaller than the regular one as you can see in the screenshot below. So I propose to create the small size to the Numeric Stepper.  
![captura de tela de 2018-08-22 15-37-29](https://user-images.githubusercontent.com/12852518/44484126-49fa3280-a623-11e8-9c1d-a7a0b0e43111.png)

#### How should this be manually tested?
https://waza--storecomponents.myvtex.com/admin/cms/storefront

#### Screenshots or example usage
![captura de tela de 2018-08-22 15-23-01](https://user-images.githubusercontent.com/12852518/44484248-a65d5200-a623-11e8-9a26-d93afb0f039a.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
