### PR TITLE
Update badge to receive semantic colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- **Badge** add prop `type`
+
 ### Fixed
 - Spinner proptypes
 

--- a/react/components/Badge/README.md
+++ b/react/components/Badge/README.md
@@ -13,56 +13,42 @@ Default
 <Badge>Pending</Badge>
 ```
 
-High contrast examples
+Type examples
 
 ```js
-<div>
-  <span className="mr4">
-    <Badge bgColor="#FF4C4C" color="#fff">
-      Error
-    </Badge>
-  </span>
-  <span className="mr4">
-    <Badge bgColor="#FFB100" color="#fff">
-      Warning
-    </Badge>
-  </span>
-  <span className="mr4">
-    <Badge bgColor="#8BC34A" color="#fff">
-      Success
-    </Badge>
-  </span>
-  <span className="mr4">
-    <Badge bgColor="#979899" color="#fff">
-      Neutral
-    </Badge>
-  </span>
-</div>
+<span className="mr4">
+  <Badge type="error">
+    Error
+  </Badge>
+</span>
+<span className="mr4">
+  <Badge type="warning">
+    Warning
+  </Badge>
+</span>
+<span className="mr4">
+  <Badge type="success">
+    Success
+  </Badge>
+</span>
 ```
 
-Low contrast examples
+Custom colors examples
 
 ```js
-<div>
-  <span className="mr4">
-    <Badge bgColor="#FFE6E6" color="#FF4C4C">
-      Error
-    </Badge>
-  </span>
-  <span className="mr4">
-    <Badge bgColor="#FFF6E0" color="#FFB100">
-      Warning
-    </Badge>
-  </span>
-  <span className="mr4">
-    <Badge bgColor="#EAFCE3" color="#8BC34A">
-      Success
-    </Badge>
-  </span>
-  <span className="mr4">
-    <Badge bgColor="#E3E4E6" color="#979899">
-      Neutral
-    </Badge>
-  </span>
-</div>
+<span className="mr4">
+  <Badge bgColor="#F71963" color="#FFFFFF">
+    New
+  </Badge>
+</span>
+<span className="mr4">
+  <Badge bgColor="#142032" color="#D6D8E0">
+    New
+  </Badge>
+</span>
+<span className="mr4">
+  <Badge bgColor="#00BBD4" color="#FFFFFF">
+    New
+  </Badge>
+</span>
 ```

--- a/react/components/Badge/index.js
+++ b/react/components/Badge/index.js
@@ -1,12 +1,26 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import config from 'vtex-tachyons/config.json'
 
 class Badge extends PureComponent {
   render() {
+    let theme = ''
+    switch (this.props.type) {
+      case 'success':
+        theme = 'bg-success c-on-success'
+        break
+      case 'error':
+        theme = 'bg-danger c-on-danger'
+        break
+      case 'warning':
+        theme = 'bg-warning c-on-warning'
+        break
+      default:
+        theme = 'bg-muted-4 c-on-base'
+    }
+
     return (
       <div
-        className="br-pill f6 pv2 ph3 dib fw5"
+        className={`br-pill f6 pv2 ph3 dib fw5 ${theme}`}
         style={{
           backgroundColor: this.props.bgColor,
           color: this.props.color,
@@ -18,12 +32,8 @@ class Badge extends PureComponent {
   }
 }
 
-Badge.defaultProps = {
-  color: config.colors['dark-gray'],
-  bgColor: config.colors['light-gray'],
-}
-
 Badge.propTypes = {
+  type: PropTypes.oneOf(['success', 'error', 'warning']),
   children: PropTypes.node.isRequired,
   color: PropTypes.string,
   bgColor: PropTypes.string,


### PR DESCRIPTION
We decided to keep the "custom colors" option for the badges, but we added 3 types: success, warning and error. We also updated the examples:

<img width="970" alt="screen shot 2018-08-22 at 4 48 40 pm" src="https://user-images.githubusercontent.com/21203990/44486920-4b2f5d80-a62b-11e8-8652-d3be34157696.png">
.