### PR TITLE
Fix forwardedRef Proptype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.1.3] - 2018-08-29
+
 ### Fix
 - **Input** fix propType of ref
 - **Dropdown** fix propType of ref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+- **Input** fix propType of ref
+- **Dropdown** fix propType of ref
+
 ## [6.1.2] - 2018-08-28
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -266,7 +266,7 @@ DropdownWithRef.propTypes = {
   /** onOpen event */
   onOpen: PropTypes.func,
   /** Internal prop used for ref forwarding */
-  forwardedRef: PropTypes.func,
+  forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 }
 
 Dropdown.propTypes = DropdownWithRef.propTypes

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -232,7 +232,7 @@ InputWithRef.propTypes = {
   /** Prefix */
   prefix: PropTypes.string,
   /** Internal prop used for ref forwarding */
-  forwardedRef: PropTypes.func,
+  forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /** Spec attribute */
   accept: PropTypes.string,
   /** Spec attribute */


### PR DESCRIPTION
Refs created with the new `React.createRef()`, introduced in React 16.3 are of type `object`, instead of `function`. This PR adds support for both commonly used types, as explained [here](https://reactjs.org/docs/refs-and-the-dom.html).