### PR TITLE
Prevents tab labels from wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- **Tabs** Tab labels won't wrap anymore. 
+
 - Removed extra iOS styiling from inputs
 - **Icons** Fix plus icon svg.
 


### PR DESCRIPTION
Before
===

![image](https://user-images.githubusercontent.com/467471/45648790-e6d3b280-ba9f-11e8-9554-c622578ab932.png)


After
===

![image](https://user-images.githubusercontent.com/467471/45648796-edfac080-ba9f-11e8-9848-9702e256dd87.png)
