### PR TITLE
forces table re-render when key changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.3.3] - 2018-09-18
+
 ## [6.3.2] - 2018-09-13
 ### Added
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "5.4.7",
+  "version": "6.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17430,9 +17430,9 @@
       }
     },
     "vtex-tachyons": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/vtex-tachyons/-/vtex-tachyons-2.6.0.tgz",
-      "integrity": "sha512-gsEgF316r1WEwMiZYr04SJpn6fFN/cgrFc/lPgueJ0HwHu4lR3m9yHN5C9yHn8YXcTGxBDPGayeg3BiEMXMDhQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/vtex-tachyons/-/vtex-tachyons-2.7.0.tgz",
+      "integrity": "sha512-qycs+3ewy2vr5UnJSeoi9etjpC3Gy76SvIzJgjFpocjN4Ritlyhz7uMLLodtO1nFDy/AdX6hrnNuKgJ1MU+Lww=="
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -31,6 +31,7 @@ class Table extends PureComponent {
       onRowMouseOut,
       sort: { sortOrder, sortedBy },
       onSort,
+      updateTableKey,
     } = this.props
     const properties = Object.keys(schema.properties)
     // hydrate items with index when 'indexColumn' prop is true
@@ -45,6 +46,7 @@ class Table extends PureComponent {
         <AutoSizer>
           {({ width, height }) => (
             <VirtualTable
+              updateTableKey={updateTableKey}
               width={width}
               height={height}
               headerHeight={36}
@@ -172,6 +174,8 @@ Table.propTypes = {
   }),
   /** Callback to handle sort ({ sortOrder, sortedBy }) : object */
   onSort: PropTypes.func,
+  /** Forces table re-render when changed */
+  updateTableKey: PropTypes.string,
 }
 
 export default Table


### PR DESCRIPTION
There was a client reporting that whenever his locale changed the table wouldn't update unless he forced re-rendering somehow (e.g. changing some row content, adding/deleting row)

That does make sense, because Table is a PureComponent, and since locale is in the context, not in props and not in the state, it really was designed not to update itself automatically in this case.

So we should provide a way the user can tell the table to re-render whenever he wants. Passing through this additional prop will do this, so the client can create a hash based on whatever he wants to tell the table when to update. 

In this case I could instruct him to use the locale as a key and it would re-render as expected when the locale changed.

I tried to explain the problem so maybe we can discuss a different approach to solve the problem different than this.

Thoughts ? 