### PR TITLE
Add icons

### DIFF
--- a/react/components/icon/Plus/index.js
+++ b/react/components/icon/Plus/index.js
@@ -9,23 +9,39 @@ const iconBase = {
 
 class Plus extends PureComponent {
   render() {
-    const { color, size, block } = this.props
+    const { color, size, solid, block } = this.props
     const newSize = calcIconSize(iconBase, size)
 
+    if (solid) {
+      return (
+        <svg
+          className={`${baseClassname('plus', 'solid')} ${block ? 'db' : ''}`}
+          width={newSize.width}
+          height={newSize.height}
+          viewBox="0 0 20 20"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M13.6569 13.6569C16.7811 10.5326 16.7811 5.46735 13.6569 2.34316C10.5327 -0.781032 5.46739 -0.781075 2.34316 2.34316C-0.781075 5.46739 -0.781032 10.5327 2.34316 13.6569C5.46735 16.7811 10.5326 16.7811 13.6569 13.6569ZM8.00006 6.58567L10.8285 3.75724L12.2427 5.17159L9.41423 8.00001L12.2427 10.8284L10.8285 12.2425L8.00001 9.41423L5.15726 12.257L3.74309 10.8426L6.58576 7.99997L3.74313 5.15734L5.15747 3.74309L8.00006 6.58567Z"
+            transform="translate(10.1006 -1.31372) rotate(45)"
+            fill={color}
+          />
+        </svg>
+      )
+    }
     return (
       <svg
-        className={`${baseClassname('plus')} ${block ? 'db' : ''}`}
         width={newSize.width}
         height={newSize.height}
         viewBox="0 0 20 20"
         fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
+        xmlns="http://www.w3.org/2000/svg">
+        <circle cx="8" cy="8" r="7" stroke="#3F3F40" strokeWidth="2" />
         <path
-          fillRule="evenodd"
-          clipRule="evenodd"
-          d="M13.6569 13.6569C16.7811 10.5326 16.7811 5.46735 13.6569 2.34316C10.5327 -0.781032 5.46739 -0.781075 2.34316 2.34316C-0.781075 5.46739 -0.781032 10.5327 2.34316 13.6569C5.46735 16.7811 10.5326 16.7811 13.6569 13.6569ZM8.00006 6.58567L10.8285 3.75724L12.2427 5.17159L9.41423 8.00001L12.2427 10.8284L10.8285 12.2425L8.00001 9.41423L5.15726 12.257L3.74309 10.8426L6.58576 7.99997L3.74313 5.15734L5.15747 3.74309L8.00006 6.58567Z"
-          transform="translate(10.1006 -1.31372) rotate(45)"
+          d="M4.5 7H7V4.5C7 4.22386 7.22386 4 7.5 4H8.5C8.77614 4 9 4.22386 9 4.5V7H11.5C11.7761 7 12 7.22386 12 7.5V8.5C12 8.77614 11.7761 9 11.5 9H9V11.5C9 11.7761 8.77614 12 8.5 12H7.5C7.22386 12 7 11.7761 7 11.5V9H4.5C4.22386 9 4 8.77614 4 8.5V7.5C4 7.22386 4.22386 7 4.5 7Z"
           fill={color}
         />
       </svg>
@@ -35,13 +51,15 @@ class Plus extends PureComponent {
 
 Plus.defaultProps = {
   color: 'currentColor',
-  size: 16,
+  size: 20,
+  solid: false,
   block: false,
 }
 
 Plus.propTypes = {
   color: PropTypes.string,
   size: PropTypes.number,
+  solid: PropTypes.bool,
   block: PropTypes.bool,
 }
 

--- a/react/components/icon/PlusLines/index.js
+++ b/react/components/icon/PlusLines/index.js
@@ -1,0 +1,45 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { calcIconSize, baseClassname } from '../utils'
+
+const iconBase = {
+  width: 16,
+  height: 16,
+}
+
+class PlusLines extends PureComponent {
+  render() {
+    const { color, size, block } = this.props
+    const newSize = calcIconSize(iconBase, size)
+
+    return (
+      <svg
+        className={`${baseClassname('PlusLines')} ${block ? 'db' : ''}`}
+        width={newSize.width}
+        height={newSize.height}
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M14 7C14 7.55228 13.5523 8 13 8H8V13C8 13.5523 7.55228 14 7 14C6.44772 14 6 13.5523 6 13V8H1C0.447715 8 0 7.55228 0 7C0 6.44772 0.447715 6 1 6H6V1C6 0.447715 6.44772 0 7 0C7.55228 0 8 0.447715 8 1V6H13C13.5523 6 14 6.44772 14 7Z"
+          fill={color}
+        />
+      </svg>
+
+    )
+  }
+}
+
+PlusLines.defaultProps = {
+  color: 'currentColor',
+  size: 16,
+  block: false,
+}
+
+PlusLines.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.number,
+  block: PropTypes.bool,
+}
+
+export default PlusLines

--- a/react/components/icon/README.md
+++ b/react/components/icon/README.md
@@ -154,6 +154,10 @@ const demoLabel = 'pb3 code c-muted-1 f6'
         <Plus size={demoSize} />
       </td>
       <td>
+        <div className={demoLabel}>Plus</div>
+        <Plus solid size={demoSize} />
+      </td>
+      <td>
         <div className={demoLabel}>Save</div>
         <Save size={demoSize} />
       </td>

--- a/react/components/icon/README.md
+++ b/react/components/icon/README.md
@@ -31,6 +31,7 @@ const Upload = require('./Upload').default
 const VisibilityOff = require('./VisibilityOff').default
 const VisibilityOn = require('./VisibilityOn').default
 const Warning = require('./Warning').default
+const PlusLines = require('./PlusLines').default
 
 const demoSize = 20
 const demoLabel = 'pb3 code c-muted-1 f6'
@@ -151,16 +152,22 @@ const demoLabel = 'pb3 code c-muted-1 f6'
       </td>
       <td>
         <div className={demoLabel}>Plus</div>
-        <Plus size={demoSize} />
+        <Plus solid size={demoSize} />
       </td>
       <td>
-        <div className={demoLabel}>Plus</div>
-        <Plus solid size={demoSize} />
+        <div className={demoLabel}>Plus outlines</div>
+        <Plus  size={demoSize} />
+      </td>
+      <td>
+        <div className={demoLabel}>Plus Lines</div>
+        <PlusLines size={demoSize} />
       </td>
       <td>
         <div className={demoLabel}>Save</div>
         <Save size={demoSize} />
       </td>
+    </tr>
+    <tr>
       <td>
         <div className={demoLabel}>Search</div>
         <Search size={demoSize} />
@@ -169,8 +176,6 @@ const demoLabel = 'pb3 code c-muted-1 f6'
         <div className={demoLabel}>Upload</div>
         <Upload size={demoSize} />
       </td>
-    </tr>
-    <tr>
       <td>
         <div className={demoLabel}>Success</div>
         <Success size={demoSize} />
@@ -187,6 +192,9 @@ const demoLabel = 'pb3 code c-muted-1 f6'
         <div className={demoLabel}>Visibility On (solid)</div>
         <VisibilityOn solid size={demoSize} />
       </td>
+      <td />
+    </tr>
+    <tr>
       <td>
         <div className={demoLabel}>Visibility Off</div>
         <VisibilityOff size={demoSize} />
@@ -195,9 +203,6 @@ const demoLabel = 'pb3 code c-muted-1 f6'
         <div className={demoLabel}>Visibility Off (solid)</div>
         <VisibilityOff solid size={demoSize} />
       </td>
-      <td />
-    </tr>
-    <tr>
       <td>
         <div className={demoLabel}>Warning</div>
         <Warning size={demoSize} />


### PR DESCRIPTION
The last PR ([#337](https://github.com/vtex/styleguide/pull/337)) I made had some issues. I worked on a branch that wasn't updated.

Some aditions to our icon set, from figma to the styleguide. I'm adding the icon plus outlines and plus lines.
<img width="191" alt="screen shot 2018-09-20 at 12 36 34" src="https://user-images.githubusercontent.com/13242383/45981735-7216f000-c02c-11e8-92ac-26be400d412c.png">
<img width="101" alt="screen shot 2018-09-20 at 12 36 42" src="https://user-images.githubusercontent.com/13242383/45981731-6dead280-c02c-11e8-933c-6faa2bf25ff8.png">

