### PR TITLE
Fix/ios input shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **PasswordInput** New component
 - **Toast** New component
 
+### Fixed
+
+- Removed extra iOS styiling from inputs
+
 ## [6.3.3] - 2018-09-18
 
 ## [6.3.2] - 2018-09-13

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -171,6 +171,9 @@ class Input extends Component {
             type={this.props.type}
             value={this.props.value}
             id={this.props.id}
+            style={{
+              WebkitAppearance: 'none',
+            }}
           />
           {suffixIcon && (
             <span

--- a/react/components/MultiSelect/index.js
+++ b/react/components/MultiSelect/index.js
@@ -178,6 +178,9 @@ export default class MultiSelect extends Component {
               placeholder={placeholder}
               ref={this.searchInput}
               value={this.state.searchTerm}
+              style={{
+                WebkitAppearance: 'none',
+              }}
             />
             {tags}
           </div>

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -166,6 +166,7 @@ export default class NumericStepper extends React.Component {
               ...(block && {
                 width: 0,
               }),
+              WebkitAppearance: 'none',
             }}
             value={displayValue}
             onChange={this.handleTypeQuantity}

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -106,6 +106,9 @@ class Textarea extends Component {
           rows={this.props.rows}
           defaultValue={this.props.defaultValue}
           value={this.props.value}
+          style={{
+            WebkitAppearance: 'none',
+          }}
         >
           {children}
         </textarea>


### PR DESCRIPTION
Removes default iOS styling from input elements—this weird-ass shadow, mostly, but iOS also adds some padding and a round corner. It also messes up the search input.

![file](https://user-images.githubusercontent.com/5691711/46155362-7ff78b80-c24d-11e8-8675-03237000ab0a.jpg)
![img_0852](https://user-images.githubusercontent.com/5691711/46155242-3b6bf000-c24d-11e8-83c4-f89de397a7c3.PNG)
![img_0851](https://user-images.githubusercontent.com/5691711/46155243-3c048680-c24d-11e8-8027-72d11c615fcc.PNG)



