### PR TITLE
Fix/numeric stepper label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.4.4] - 2018-10-01
+
 ### Fixed
 
 - **NumericStepper** Refrains from using the label tag if there is no label, to prevent the keyboard from popping up on iOS unnecessarily

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **NumericStepper** Refrains from using the label tag if there is no label, to prevent the keyboard from popping up on iOS unnecessarily
+- Disable host checking on dev server in order to make it publicly accessible
+
 ## [6.4.3] - 2018-09-28
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "6.4.3",
+  "version": "6.4.4",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "6.4.3",
+  "version": "6.4.4",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -153,8 +153,15 @@ export default class NumericStepper extends React.Component {
       'x-large': `pv5 f4 ${block ? 'flex-grow-1' : 'w4'}`,
     }
 
+    // Refrain from using label tag if not needed, to prevent
+    // iOS from focusing on the text field and popping up the
+    // keyboard when increment/decrement is pressed
+    const Wrapper = ({ children }) => label
+      ? <label>{children}</label>
+      : <div>{children}</div>
+
     return (
-      <label>
+      <Wrapper>
         {label && <span className="db mb3 w-100">{label}</span>}
         <div className="flex self-start">
           <input
@@ -219,7 +226,7 @@ export default class NumericStepper extends React.Component {
             </button>
           </div>
         </div>
-      </label>
+      </Wrapper>
     )
   }
 }

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -153,15 +153,8 @@ export default class NumericStepper extends React.Component {
       'x-large': `pv5 f4 ${block ? 'flex-grow-1' : 'w4'}`,
     }
 
-    // Refrain from using label tag if not needed, to prevent
-    // iOS from focusing on the text field and popping up the
-    // keyboard when increment/decrement is pressed
-    const Wrapper = ({ children }) => label
-      ? <label>{children}</label>
-      : <div>{children}</div>
-
-    return (
-      <Wrapper>
+    const content = (
+      <React.Fragment>
         {label && <span className="db mb3 w-100">{label}</span>}
         <div className="flex self-start">
           <input
@@ -226,8 +219,16 @@ export default class NumericStepper extends React.Component {
             </button>
           </div>
         </div>
-      </Wrapper>
+      </React.Fragment>
     )
+
+    // Refrain from using label tag if not needed, to prevent
+    // iOS from focusing on the text field and popping up the
+    // keyboard when increment/decrement is pressed
+    if (label) {
+      return <label>{content}</label>
+    }
+    return <div>{content}</div>
   }
 }
 

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -46,7 +46,12 @@ module.exports = {
     )
     return `import ${componentName} from '@vtex/styleguide/lib/${dir}'`
   },
-  webpackConfig: require('@vtex/react-scripts/config/webpack.config.dev.js'),
+  webpackConfig: {
+    ...require('@vtex/react-scripts/config/webpack.config.dev.js'),
+    devServer: {
+      disableHostCheck: true,
+    },
+  },
   theme: {
     color: {
       link: config.colors.blue,


### PR DESCRIPTION
Use the label tag on the NumericStepper only when there is a label. 
This prevents focusing on the input when either the increment or the decrement buttons are pressed, and thus popping up the keyboard on mobile devices, as observed on iOS.

Also makes the dev server publicly accessible, for testing on devices running on a proxy.