### PR TITLE
Add LocaleSwitcher to styleguide

### DIFF
--- a/react/IconGlobe.js
+++ b/react/IconGlobe.js
@@ -1,0 +1,3 @@
+import Globe from './components/icon/Globe/index'
+
+export default Globe

--- a/react/LocaleSwitcher.js
+++ b/react/LocaleSwitcher.js
@@ -1,0 +1,3 @@
+import LocaleSwitcher from './components/LocaleSwitcher/index'
+
+export default LocaleSwitcher

--- a/react/LocaleSwitcherContainer.js
+++ b/react/LocaleSwitcherContainer.js
@@ -1,0 +1,3 @@
+import LocaleSwitcherContainer from './components/LocaleSwitcherContainer/index'
+
+export default LocaleSwitcherContainer

--- a/react/components/LocaleSwitcher/README.md
+++ b/react/components/LocaleSwitcher/README.md
@@ -1,0 +1,18 @@
+Dropdown selector for locale selection. There's also a Container for it, the `LocaleSwitcherContainer`, which feeds the current selected locale and the callback function for locale selection from `context`, which is the standart application for this component.
+
+Simple use
+
+```js
+initialState = { value1: '', value2: '', value3: '' }
+;<div>
+  <LocaleSwitcher
+    availableLocales={[
+      {text: 'EN', id: 'en-US'},
+      {text: 'ES', id: 'es-AR'},
+      {text: 'PT', id: 'pt-BR'},
+    ]}
+    currentLocale="pt-BR"
+    switchLocale={() => {}}
+  />
+</div>
+````

--- a/react/components/LocaleSwitcher/index.js
+++ b/react/components/LocaleSwitcher/index.js
@@ -1,0 +1,92 @@
+import classnames from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import IconGlobe from '../icon/Globe'
+import IconCaretDown from '../icon/CaretDown'
+
+const findLocale = (currentLocale, availableLocales) => {
+  const localeObj = availableLocales.find(
+    ({ id }) => id.split('-')[0] === currentLocale.split('-')[0]
+  )
+  return localeObj || availableLocales[0]
+}
+
+class LocaleSwitcher extends Component {
+  static propTypes = {
+    availableLocales: PropTypes.arrayOf(PropTypes.shape({
+      text: PropTypes.string,
+      id: PropTypes.string,
+    })),
+    currentLocale: PropTypes.string,
+    switchLocale: PropTypes.func,
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      opened: false,
+      selectedLocale: findLocale(props.currentLocale, props.availableLocales),
+    }
+  }
+
+  handleButtonClick = () => {
+    this.setState(({ opened }) => ({ opened: !opened }))
+  }
+
+  handleLocaleClick = ({ target: { id } }) => {
+    const [, locale] = id.split('@')
+
+    this.props.switchLocale(locale)
+    this.setState({
+      opened: false,
+      selectedLocale: findLocale(locale, this.props.availableLocales),
+    })
+  }
+
+  handleBlur = () => {
+    this.setState({ opened: false })
+  }
+
+  handleMouseDown = e => {
+    e.preventDefault()
+  }
+
+  render() {
+    const { opened, selectedLocale } = this.state
+    const listClasses = classnames(
+      'absolute z-5 list top-2 w3 ph0 pv2 mh0 mv4 bg-white br2 shadow-02',
+      { dn: !opened }
+    )
+    return (
+      <div className="relative h-3em w3 flex items-center ml2 mr3">
+        <button
+          className="link pa0 mv2 bg-transparent bn flex items-center pointer mr3 near-black"
+          onBlur={this.handleBlur}
+          onClick={this.handleButtonClick}>
+          <IconGlobe size={24} />
+          <span className="f5 fw5 pl2 near-black">{selectedLocale.text}</span>
+          <div className={opened ? 'rotate-180 pb2 pr2' : 'pb2 pl2'}>
+            <IconCaretDown className={opened ? 'rotate-180' : null} size={8} />
+          </div>
+        </button>
+        <ul className={listClasses}>
+          {this.props.availableLocales.map(
+            ({ id, text }) =>
+              id !== selectedLocale.id ? (
+                <li
+                  key={id}
+                  id={`appframe-locale@${id}`}
+                  className="pointer f5 pa3 hover-bg-light-silver tc"
+                  onClick={this.handleLocaleClick}
+                  onMouseDown={this.handleMouseDown}>
+                  {text}
+                </li>
+              ) : null
+          )}
+        </ul>
+      </div>
+    )
+  }
+}
+
+export default LocaleSwitcher

--- a/react/components/LocaleSwitcherContainer/index.js
+++ b/react/components/LocaleSwitcherContainer/index.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import LocaleSwitcher from '../LocaleSwitcher'
+
+const locales = [
+  {
+    text: 'EN',
+    id: 'en-US',
+  },
+  {
+    text: 'PT',
+    id: 'pt-BR',
+  },
+  {
+    text: 'ES',
+    id: 'es-AR',
+  },
+]
+
+class LocaleSwitcherContainer extends Component {
+  static contextTypes = {
+    culture: PropTypes.object,
+    emitter: PropTypes.object,
+  }
+
+  switchLocale = (locale) => {
+    this.context.emitter.emit('localesChanged', locale)
+  }
+
+  render() {
+    return (
+      <LocaleSwitcher
+        availableLocales={locales}
+        currentLocale={this.context.culture.locale}
+        switchLocale={this.switchLocale}
+      />
+    )
+  }
+}
+
+export default LocaleSwitcherContainer

--- a/react/components/icon/Globe/index.js
+++ b/react/components/icon/Globe/index.js
@@ -1,0 +1,44 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { calcIconSize, baseClassname } from '../utils'
+
+const iconBase = {
+  width: 24,
+  height: 24,
+}
+
+class Globe extends PureComponent {
+  render() {
+    const { color, size, block } = this.props
+    const newSize = calcIconSize(iconBase, size)
+
+    return (
+      <svg
+        className={`${baseClassname('filter', 'solid')} ${block ? 'db' : ''}`}
+        width={newSize.width}
+        height={newSize.height}
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm6.93 6h-2.95c-.32-1.25-.78-2.45-1.38-3.56 1.84.63 3.37 1.91 4.33 3.56zM12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96zM4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2H4.26zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56-1.84-.63-3.37-1.9-4.33-3.56zm2.95-8H5.08c.96-1.66 2.49-2.93 4.33-3.56C8.81 5.55 8.35 6.75 8.03 8zM12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96zM14.34 14H9.66c-.09-.66-.16-1.32-.16-2 0-.68.07-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2zm.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95c-.96 1.65-2.49 2.93-4.33 3.56zM16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2h-3.38z"
+          fill={color}
+        />
+        <path d="M0 0h24v24H0V0z" fill="none" />
+      </svg>
+    )
+  }
+}
+
+Globe.defaultProps = {
+  color: 'currentColor',
+  size: 16,
+  block: false,
+}
+
+Globe.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.number,
+  block: PropTypes.bool,
+}
+
+export default Globe

--- a/react/components/icon/README.md
+++ b/react/components/icon/README.md
@@ -23,6 +23,7 @@ const ExternalLink = require('./ExternalLink').default
 const ExternalLinkMini = require('./ExternalLinkMini').default
 const Failure = require('./Failure').default
 const Filter = require('./Filter').default
+const Globe = require('./Globe').default
 const Help = require('./Help').default
 const Link = require('./Link').default
 const Plus = require('./Plus').default
@@ -147,6 +148,10 @@ const demoLabel = 'pb3 code c-muted-1 f6'
     </tr>
     <tr>
       <td>
+        <div className={demoLabel}>Globe</div>
+        <Globe size={demoSize} />
+      </td>
+      <td>
         <div className={demoLabel}>Help</div>
         <Help size={demoSize} />
       </td>
@@ -166,6 +171,8 @@ const demoLabel = 'pb3 code c-muted-1 f6'
         <div className={demoLabel}>Plus outlines</div>
         <Plus  size={demoSize} />
       </td>
+    </tr>
+    <tr>
       <td>
         <div className={demoLabel}>Plus Lines</div>
         <PlusLines size={demoSize} />
@@ -174,14 +181,10 @@ const demoLabel = 'pb3 code c-muted-1 f6'
         <div className={demoLabel}>Save</div>
         <Save size={demoSize} />
       </td>
-    </tr>
-    <tr>
       <td>
         <div className={demoLabel}>Search</div>
         <Search size={demoSize} />
       </td>
-    </tr>
-    <tr>
       <td>
         <div className={demoLabel}>Upload</div>
         <Upload size={demoSize} />
@@ -194,6 +197,8 @@ const demoLabel = 'pb3 code c-muted-1 f6'
         <div className={demoLabel}>Success (solid)</div>
         <Success solid size={demoSize} />
       </td>
+    </tr>
+    <tr>
       <td>
         <div className={demoLabel}>Visibility On</div>
         <VisibilityOn size={demoSize} />
@@ -203,8 +208,6 @@ const demoLabel = 'pb3 code c-muted-1 f6'
         <VisibilityOn solid size={demoSize} />
       </td>
       <td />
-    </tr>
-    <tr>
       <td>
         <div className={demoLabel}>Visibility Off</div>
         <VisibilityOff size={demoSize} />


### PR DESCRIPTION
This is based on the [`LocaleSwitcher` used on `admin`](https://github.com/vtex/admin/blob/master/react/appframe/components/Topbar/components/LocaleSwitcher.js). Applied on that context, it looks like this:
<img width="147" alt="screen shot 2018-10-04 at 16 52 48" src="https://user-images.githubusercontent.com/3386440/46499264-f2401100-c7f5-11e8-8654-a808582d8ac7.png">

On the styleguide:
<img width="240" alt="screen shot 2018-10-04 at 16 56 28" src="https://user-images.githubusercontent.com/3386440/46499437-772b2a80-c7f6-11e8-8209-420e1af05f79.png">
Opened:
<img width="234" alt="screen shot 2018-10-04 at 16 56 49" src="https://user-images.githubusercontent.com/3386440/46499462-890ccd80-c7f6-11e8-848d-2d72982a2559.png">

It comes with a `LocaleSwitcherContainer` which implements the actual locale switching functionality. The `LocaleSwitcher` itself receives props for the accepted locales, the current locale and a callback function that is fired when a different locale is selected, receiving the selection as an argument.