### PR TITLE
Improve suffixIcon documentation and fix color token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **Textarea** Border style error state
+- **Input** Update color token of prefix & suffix to match Figma version
 
 ## [7.1.2] - 2018-10-08
 

--- a/react/components/Input/README.md
+++ b/react/components/Input/README.md
@@ -110,40 +110,8 @@ class InputExamples extends React.Component {
             value={this.state.withSuffixValue}
             onChange={e => this.setState({ withSuffixValue: e.target.value })}
             suffixIcon={
-              <span className="pointer">
-                <IconHelp />
-              </span>
+              <IconHelp />
             }
-          />
-        </div>
-        <div className="mb5">
-          <Input
-            label="Large with suffixIcon"
-            value={this.state.withSuffixLargeValue}
-            onChange={e =>
-              this.setState({ withSuffixLargeValue: e.target.value })
-            }
-            suffixIcon={
-              <span className="pointer">
-                <IconHelp size={18} />
-              </span>
-            }
-            size="large"
-          />
-        </div>
-        <div className="mb5">
-          <Input
-            label="X-large with suffixIcon"
-            value={this.state.withSuffixXLargeValue}
-            onChange={e =>
-              this.setState({ withSuffixXLargeValue: e.target.value })
-            }
-            suffixIcon={
-              <span className="pointer">
-                <IconHelp size={20} />
-              </span>
-            }
-            size="x-large"
           />
         </div>
       </div>

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -72,7 +72,7 @@ class Input extends Component {
     let labelClasses = 'vtex-input__label db mb3 w-100 '
 
     let prefixAndSuffixClasses =
-      'vtex-input__prefix absolute c-muted-1 fw5 flex items-center '
+      'vtex-input__prefix absolute c-muted-2 fw5 flex items-center '
 
     if (token) {
       classes += 'code '


### PR DESCRIPTION
- Closes https://github.com/vtex/styleguide/issues/245
- Updates color token to match Figma's design
- Fixes unnecessary `<span>` in example that were leading the icon to be out of center.

Before
===
![image](https://user-images.githubusercontent.com/467471/46807924-75ef8580-cd41-11e8-9e49-997794819f38.png)


After
===
![image](https://user-images.githubusercontent.com/467471/46807909-70923b00-cd41-11e8-8c8e-7dc97a042117.png)
