### PR TITLE
Fix/toast align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Textarea** Border style error state
 
+### Added
+- **Toast** Added `positioning` prop to `ToastProvider` to position toasts based either on the parent element dimensions, or window dimensions.
+
 ## [7.1.2] - 2018-10-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.1.3] - 2018-10-11
+
 ### Fixed
 
 - **Textarea** Border style error state

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/components/Toast/README.md
+++ b/react/components/Toast/README.md
@@ -6,7 +6,7 @@ Toasts give users instant feedback about the tasks they just did. Its main objec
 - Keep messages in a low to mild priority spectrum. Toasts are intended to be either neutral or positive. 
 
 ### Don'ts
-- Do not present critical or high priority actions on a Toast, if that's the case, you might consider using <a href="#alert">Alerts</a> instead.
+- Do not present critical or high priority actions on a Toast. If that's the case, you might consider using [Alerts](#alert) instead.
 - Due to its low to mild priority usage and dismissability, warning and error semantic styles do not apply to Toasts.
 
 
@@ -16,7 +16,9 @@ const ToastConsumer = require('./index').ToastConsumer
 
 const App = () => (
   // Wrap the entire application on a toast provider
-  <ToastProvider>
+  <ToastProvider
+    positioning="window"
+  >
     <Content/>
   </ToastProvider>
 )

--- a/react/components/Toast/index.js
+++ b/react/components/Toast/index.js
@@ -9,6 +9,12 @@ const ToastContext = React.createContext({
 })
 
 class ToastProvider extends Component {
+  constructor(props) {
+    super(props)
+
+    this.container = React.createRef()
+  }
+
   state = {
     currentToast: null,
     nextToast: null,
@@ -60,6 +66,35 @@ class ToastProvider extends Component {
     })
   }
 
+  getParentBounds = () => {
+    const parentContainer = this.container.current && this.container.current.parentNode
+    return parentContainer &&
+      parentContainer.getBoundingClientRect &&
+      parentContainer.getBoundingClientRect()
+  }
+
+  updateContainerBounds = () => {
+    const defaultBounds = {
+      left: 0,
+      right: window.innerWidth,
+      top: 0,
+      bottom: window.innerHeight,
+    }
+
+    const bounds = (!this.props.breakOutOfParent && this.getParentBounds()) || defaultBounds
+
+    if (this.container.current) {
+      this.container.current.style.left = `${bounds.left}px`
+      this.container.current.style.right = `${window.innerWidth - bounds.right}px`
+      this.container.current.style.top = `${bounds.top}px`
+      this.container.current.style.bottom = `${Math.max(0, window.innerHeight - bounds.bottom)}px`
+    }
+  }
+
+  componentDidUpdate() {
+    this.updateContainerBounds()
+  }
+
   render() {
     const { currentToast } = this.state
     const { children } = this.props
@@ -70,7 +105,8 @@ class ToastProvider extends Component {
       }}>
         {children}
         <div
-          className="fixed bottom-0 left-0 right-0 top-0 z-5 overflow-hidden"
+          className="fixed z-5 overflow-hidden"
+          ref={this.container}
           style={{
             pointerEvents: 'none',
           }}
@@ -91,6 +127,11 @@ class ToastProvider extends Component {
 
 ToastProvider.propTypes = {
   children: PropTypes.node,
+  breakOutOfParent: PropTypes.bool,
+}
+
+ToastProvider.defaultProps = {
+  breakOutOfParent: false,
 }
 
 class ToastConsumer extends Component {

--- a/react/components/Toast/index.js
+++ b/react/components/Toast/index.js
@@ -74,14 +74,14 @@ class ToastProvider extends Component {
   }
 
   updateContainerBounds = () => {
-    const defaultBounds = {
+    const windowBounds = {
       left: 0,
       right: window.innerWidth,
       top: 0,
       bottom: window.innerHeight,
     }
 
-    const bounds = (!this.props.breakOutOfParent && this.getParentBounds()) || defaultBounds
+    const bounds = (this.props.positioning === 'parent' && this.getParentBounds()) || windowBounds
 
     if (this.container.current) {
       this.container.current.style.left = `${bounds.left}px`
@@ -127,11 +127,12 @@ class ToastProvider extends Component {
 
 ToastProvider.propTypes = {
   children: PropTypes.node,
-  breakOutOfParent: PropTypes.bool,
+  /** Sets the position of the toasts based either on the dimensions of the parent element of the ToastProvider, or window dimensions */
+  positioning: PropTypes.oneOf(['parent', 'window']),
 }
 
 ToastProvider.defaultProps = {
-  breakOutOfParent: false,
+  positioning: 'parent',
 }
 
 class ToastConsumer extends Component {


### PR DESCRIPTION
Fixes https://github.com/vtex/styleguide/issues/367

Adds a new prop to position Toasts based either on the parent dimensions of the ToastProvider, or the window dimensions.

The former is necessary in cases where the parent element resizes, e.g. the VTEX Admin when the sidebar opens. The latter is necessary when the ToastProvider is created inside a box which you want the Toast to break out of, e.g. the styleguide documentation.