### PR TITLE
fixes toast line breaking for big buttons on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - **InputPassword** Use monospaced font to prevent the width from shifting.
+- **Toast** Allow single line toast on small screens if the message is short.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.10.1] - 2019-01-07
+
 ### Changed
 - **Toast** Allow single line toast on small screens if the message is short enough.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- **Toast** Allow single line toast on small screens if the message is short enough.
+
 ## [8.10.0] - 2019-01-07
 
 ### Added
@@ -16,7 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - **InputPassword** Use monospaced font to prevent the width from shifting.
-- **Toast** Allow single line toast on small screens if the message is short.
 
 ### Fixed
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.10.0",
+  "version": "8.10.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.10.0",
+  "version": "8.10.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/components/Toast/Toast.js
+++ b/react/components/Toast/Toast.js
@@ -44,10 +44,7 @@ export default class Toast extends Component {
       return
     }
 
-    this.autoCloseTimeout = setTimeout(
-      this.close,
-      this.props.duration || this.getDefaultDuration()
-    )
+    this.autoCloseTimeout = setTimeout(this.close, this.props.duration || this.getDefaultDuration())
   }
 
   stopAutoClose = () => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix the `Toast` line breaking for small messages with a long action text.

#### How should this be manually tested?
Just run styleguide on the branch `fix/toast-linebreak`. You should create an VTEX IO app that is mobile friendly and invoke the toast with different text lengths and actions.

#### Screenshots or example usage

##### Before
![screen shot 2018-10-16 at 10 58 06](https://user-images.githubusercontent.com/8474847/47022209-5e464180-d133-11e8-9609-3356b33b92fe.png)

##### After
![screen shot 2018-10-16 at 10 58 43](https://user-images.githubusercontent.com/8474847/47022356-ad8c7200-d133-11e8-90bd-76b91d907e6f.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
