### PR TITLE
Vertical tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- **Tabs** `direction` prop to control wether the tabs are displayed vertically or horizontally
-- **Tab** `direction` prop to control wether the border is below or to the right of the active tab
+- **Tabs** `vertical` prop to control the direction of the tabs
+- **Tab** `vertical` prop to control wether the border is below or to the right of the active tab
 
 ## [7.3.3] - 2018-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Tabs** `direction` prop to control wether the tabs are displayed vertically or horizontally
+- **Tab** `direction` prop to control wether the border is below or to the right of the active tab
+
 ## [7.3.3] - 2018-10-11
 
 ### Added

--- a/react/components/Tabs/README.md
+++ b/react/components/Tabs/README.md
@@ -33,7 +33,7 @@ const Bars = require('../../IconBars').default;
 const Check = require('../../IconCheck').default;
 const Tab = require('./Tab').default;
 <div className="w-10">
-  <Tabs direction="column">
+  <Tabs vertical>
     <Tab label={<Bars />} active onClick={() => {}} />
     <Tab label={<Check />} onClick={() => {}} />
   </Tabs>

--- a/react/components/Tabs/README.md
+++ b/react/components/Tabs/README.md
@@ -26,6 +26,21 @@ const Tab = require('./Tab').default;
 </div>
 ```
 
+Vertical
+
+```js
+const Bars = require('../../IconBars').default;
+const Check = require('../../IconCheck').default;
+const Tab = require('./Tab').default;
+<div className="w-10">
+  <Tabs direction="column">
+    <Tab label={<Bars />} active onClick={() => {}} />
+    <Tab label={<Check />} onClick={() => {}} />
+  </Tabs>
+</div>
+```
+
+
 Full width tabs
 
 ```js

--- a/react/components/Tabs/Tab.js
+++ b/react/components/Tabs/Tab.js
@@ -7,12 +7,12 @@ class Tab extends Component {
   }
 
   render() {
-    const { active, fullWidth, label } = this.props
+    const { active, direction, fullWidth, label } = this.props
     return (
       <button
         type="button"
         onClick={this.handleClick}
-        className={`vtex-tab__button bt-0 bl-0 br-0 bw1 ${fullWidth ? 'w-100' : ''} ${
+        className={`vtex-tab__button bt-0 bl-0 ${direction === 'row' ? 'br-0' : 'bb-0'} bw1 ${fullWidth ? 'w-100' : ''} ${
           active
             ? 'c-on-muted b--emphasis'
             : 'c-muted-1 b--transparent hover-c-action-primary pointer'}
@@ -25,9 +25,14 @@ class Tab extends Component {
   }
 }
 
+Tab.defaultProps = {
+  direction: 'row',
+}
+
 Tab.propTypes = {
   active: PropTypes.bool,
   fullWidth: PropTypes.bool,
+  direction: PropTypes.oneOf(['row', 'column']),
   children: PropTypes.node,
   label: PropTypes.any.isRequired,
   onClick: PropTypes.func,

--- a/react/components/Tabs/Tab.js
+++ b/react/components/Tabs/Tab.js
@@ -7,12 +7,12 @@ class Tab extends Component {
   }
 
   render() {
-    const { active, direction, fullWidth, label } = this.props
+    const { active, fullWidth, label, vertical } = this.props
     return (
       <button
         type="button"
         onClick={this.handleClick}
-        className={`vtex-tab__button bt-0 bl-0 ${direction === 'row' ? 'br-0' : 'bb-0'} bw1 ${fullWidth ? 'w-100' : ''} ${
+        className={`vtex-tab__button bt-0 bl-0 ${vertical ? 'bb-0' : 'br-0'} bw1 ${fullWidth ? 'w-100' : ''} ${
           active
             ? 'c-on-muted b--emphasis'
             : 'c-muted-1 b--transparent hover-c-action-primary pointer'}
@@ -32,7 +32,7 @@ Tab.defaultProps = {
 Tab.propTypes = {
   active: PropTypes.bool,
   fullWidth: PropTypes.bool,
-  direction: PropTypes.oneOf(['row', 'column']),
+  vertical: PropTypes.bool,
   children: PropTypes.node,
   label: PropTypes.any.isRequired,
   onClick: PropTypes.func,

--- a/react/components/Tabs/index.js
+++ b/react/components/Tabs/index.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types'
 
 class Tabs extends Component {
   render() {
-    const { children, fullWidth } = this.props
+    const { children, fullWidth, direction } = this.props
     const selectedTab = children.find(child => child.props.active)
     const content = selectedTab && selectedTab.props.children
     return (
       <div className="vtex-tabs w-100">
-        <div className="vtex-tabs__nav flex flex-row bb b--muted-4 overflow-y-auto">
+        <div className={`vtex-tabs__nav flex flex-${direction} ${direction === 'row' ? 'bb' : ''} b--muted-4 overflow-y-auto`}>
           {children.map(child =>
-            cloneElement(child, { fullWidth, key: child.props.label.toString() })
+            cloneElement(child, { fullWidth, key: child.props.label.toString(), direction })
           )}
         </div>
         <div className="vtex-tabs__content w-100">
@@ -23,11 +23,13 @@ class Tabs extends Component {
 
 Tabs.defaultProps = {
   fullWidth: false,
+  direction: 'row',
 }
 
 Tabs.propTypes = {
   children: PropTypes.arrayOf(PropTypes.node),
   fullWidth: PropTypes.bool,
+  direction: PropTypes.oneOf(['row', 'column']),
 }
 
 export default Tabs

--- a/react/components/Tabs/index.js
+++ b/react/components/Tabs/index.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types'
 
 class Tabs extends Component {
   render() {
-    const { children, fullWidth, direction } = this.props
+    const { children, fullWidth, vertical } = this.props
     const selectedTab = children.find(child => child.props.active)
     const content = selectedTab && selectedTab.props.children
     return (
       <div className="vtex-tabs w-100">
-        <div className={`vtex-tabs__nav flex flex-${direction} ${direction === 'row' ? 'bb' : ''} b--muted-4 overflow-y-auto`}>
+        <div className={`vtex-tabs__nav flex flex-${vertical ? 'column' : 'row'} ${!vertical && 'bb'} b--muted-4 overflow-y-auto`}>
           {children.map(child =>
-            cloneElement(child, { fullWidth, key: child.props.label.toString(), direction })
+            cloneElement(child, { fullWidth, key: child.props.label.toString(), vertical })
           )}
         </div>
         <div className="vtex-tabs__content w-100">
@@ -23,13 +23,12 @@ class Tabs extends Component {
 
 Tabs.defaultProps = {
   fullWidth: false,
-  direction: 'row',
 }
 
 Tabs.propTypes = {
   children: PropTypes.arrayOf(PropTypes.node),
   fullWidth: PropTypes.bool,
-  direction: PropTypes.oneOf(['row', 'column']),
+  vertical: PropTypes.bool,
 }
 
 export default Tabs


### PR DESCRIPTION
The need arises from `pages-admin` where we want to create a vertical mode switcher, like this:
<img width="205" alt="screen shot 2018-10-31 at 10 49 42" src="https://user-images.githubusercontent.com/3386440/47792393-b6b43c00-dcfa-11e8-9d51-2f6dde5c9d0b.png">
This is from [this figma](https://www.figma.com/file/Fq9myz1oHXLy1Tzygb7jbiUf/Storefront-(Layout-%26-Style)?node-id=365%3A2).

I've figured that the most important thing, for now, is that it is vertical and we can maybe add a prop that allows it to use the secondary color later. There's also some rounded corner on the border created by the figma that looks awesome IMO, but that's maybe a stretch.

It looks like this on the styleguide:
<img width="617" alt="screen shot 2018-10-31 at 10 52 06" src="https://user-images.githubusercontent.com/3386440/47792557-08f55d00-dcfb-11e8-8852-95b5917134f8.png">
