### PR TITLE
Add flex-wrap to PageHeader to fit on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **PageHeader** using `flex-wrap` to fix layout on small screens
 
 ### Added
 

--- a/react/components/PageHeader/index.js
+++ b/react/components/PageHeader/index.js
@@ -33,10 +33,8 @@ class PageHeader extends PureComponent {
           </div>
         )}
 
-        <div
-          className={`vtex-pageHeader__title c-on-base f2 fw6 flex flex-row justify-between ${
-            linkLabel ? 'mt0' : 'mt7'
-          }`}>
+        <div className={`vtex-pageHeader__title c-on-base f2 fw6 flex flex-row 
+          flex-wrap justify-between ${linkLabel ? 'mt0' : 'mt7'}`}>
           <span>{this.props.title}</span>
 
           {children && (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add flex-wrap to PageHeader so it can fit on small screens

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/3926634/48066850-d72a3d80-e1b5-11e8-9105-3b07dde59f78.png)

After:
![image](https://user-images.githubusercontent.com/3926634/48066858-dc878800-e1b5-11e8-9c72-039f7d933a67.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
