### PR TITLE
Update babel script to copy files ignoring *.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ styleguide-visual/*.diff.png
 .env.test.local
 .env.production.local
 .vscode
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- **CSS** file support
+
 - **Icon** add OptionsDots icon
 
 ## [7.5.0] - 2018-11-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.5.2] - 2018-11-07
+
 ## [7.5.1] - 2018-11-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.5.1] - 2018-11-07
+
+### Added
+
+- **Icon** add OptionsDots icon
+
 ## [7.5.0] - 2018-11-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.5.3] - 2018-11-07
+
 ## [7.5.2] - 2018-11-07
 
 ## [7.5.1] - 2018-11-07

--- a/README.md
+++ b/README.md
@@ -99,16 +99,12 @@ import Button from '@vtex/styleguide/lib/Button'
 
 ### Publishing
 
-We use [releasy](https://www.npmjs.com/package/releasy) to publish our styleguide. To publish on both npm and render(VTEX IO), execute the command below: 
+To post the changelog on Github Release Notes, is required to configure a Personal Token. [See more here](https://www.npmjs.com/package/releasy#settings)
+
+We use [releasy](https://www.npmjs.com/package/releasy) to publish our styleguide. To publish on both npm and render(VTEX IO) with Github Release Notes, execute the command below:
 
 ```sh
-releasy --stable --npm 
-```
-
-Also, if you want to post the changelog on Github Release Notes, is required to configure a Personal Token. [See more here](https://www.npmjs.com/package/releasy#settings). When you have the environment set, add a `--notes` flag, For example: 
-
-```sh
-releasy --stable --npm --notes
+releasy --stable
 ```
 
 ### Docs

--- a/_releasy.json
+++ b/_releasy.json
@@ -1,0 +1,4 @@
+{
+"notes": true,
+"npm": true,
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "7.5.2",
+  "version": "7.5.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "7.5.1",
+  "version": "7.5.2",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "7.5.2",
+  "version": "7.5.3",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "styleguide": "styleguidist server",
     "start": "styleguidist server",
     "styleguide:build": "styleguidist build",
-    "babel": "NODE_ENV=production babel ./react/components --out-dir ./lib --ignore '__tests__,*.spec.js' --ignore '*.md' --copy-files",
+    "babel": "NODE_ENV=production babel ./react/components --out-dir ./lib --ignore '__tests__,*.spec.js,*.md' --copy-files",
     "compile": "run-s cleanlib babel",
     "cleanlib": "rm -rf lib",
     "prepublishOnly": "run-s compile deploy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "7.5.1",
+  "version": "7.5.2",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "styleguide": "styleguidist server",
     "start": "styleguidist server",
     "styleguide:build": "styleguidist build",
-    "babel": "NODE_ENV=production babel ./react/components --out-dir ./lib --ignore '__tests__,*.spec.js'",
+    "babel": "NODE_ENV=production babel ./react/components --out-dir ./lib --ignore '__tests__,*.spec.js' --ignore '*.md' --copy-files",
     "compile": "run-s cleanlib babel",
     "cleanlib": "rm -rf lib",
     "prepublishOnly": "run-s compile deploy",

--- a/react/IconOptionsDots.js
+++ b/react/IconOptionsDots.js
@@ -1,0 +1,3 @@
+import OptionsDots from './components/icon/OptionsDots/index'
+
+export default OptionsDots

--- a/react/IconVisibilityOff.js
+++ b/react/IconVisibilityOff.js
@@ -1,3 +1,3 @@
-import VisibilityOff from './components/icon/VisibilityOff'
+import VisibilityOff from './components/icon/VisibilityOff/index'
 
 export default VisibilityOff

--- a/react/IconVisibilityOn.js
+++ b/react/IconVisibilityOn.js
@@ -1,3 +1,3 @@
-import VisibilityOn from './components/icon/VisibilityOn'
+import VisibilityOn from './components/icon/VisibilityOn/index'
 
 export default VisibilityOn

--- a/react/PasswordInput.js
+++ b/react/PasswordInput.js
@@ -1,3 +1,3 @@
-import PasswordInput from './components/PasswordInput'
+import PasswordInput from './components/PasswordInput/index'
 
 export default PasswordInput

--- a/react/Slider.js
+++ b/react/Slider.js
@@ -1,1 +1,3 @@
-export { default } from './components/Slider/index'
+import Slider from './components/Slider/index'
+
+export default Slider

--- a/react/components/icon/OptionsDots/index.js
+++ b/react/components/icon/OptionsDots/index.js
@@ -1,0 +1,168 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { calcIconSize } from '../utils'
+
+const iconBase = {
+  width: 16,
+  height: 16,
+}
+
+class OptionsDots extends PureComponent {
+  render() {
+    const { color, size, block, radius } = this.props
+    const newSize = calcIconSize(iconBase, size)
+
+    return (
+      <svg
+        viewBox="0 0 32 32"
+        className={`${block ? 'db' : ''}`}
+        width={newSize.width}
+        height={newSize.height}>
+        <g className="nc-icon-wrapper" fill={color}>
+          <g
+            className="nc-interact_dots-close-o-32"
+            transform="rotate(90 16 16)">
+            {' '}
+            <g className="nc-dot_left" transform="translate(0)">
+              {' '}
+              <circle
+                cx="6"
+                cy="16"
+                r={radius}
+                fill={color}
+                data-cap="butt"
+                data-stroke="none"
+                strokeLinecap="butt"
+                strokeLinejoin="miter"
+              />{' '}
+              <circle
+                cx="6"
+                cy="16"
+                r={radius}
+                fill="none"
+                stroke={color}
+                strokeLinecap="square"
+                strokeLinejoin="miter"
+                strokeWidth="2"
+              />{' '}
+            </g>{' '}
+            <g className="nc-dot_right" transform="translate(-0)">
+              {' '}
+              <circle
+                cx="26"
+                cy="16"
+                r={radius}
+                fill={color}
+                data-cap="butt"
+                data-stroke="none"
+                strokeLinecap="butt"
+                strokeLinejoin="miter"
+              />{' '}
+              <circle
+                cx="26"
+                cy="16"
+                r={radius}
+                fill="none"
+                stroke={color}
+                strokeLinecap="square"
+                strokeLinejoin="miter"
+                strokeWidth="2"
+              />{' '}
+            </g>{' '}
+            <g className="nc-dot_center">
+              {' '}
+              <circle
+                cx="16"
+                cy="16"
+                r={radius}
+                fill={color}
+                data-cap="butt"
+                data-stroke="none"
+                strokeLinecap="butt"
+                strokeLinejoin="miter"
+              />{' '}
+              <circle
+                cx="16"
+                cy="16"
+                r={radius}
+                fill="none"
+                stroke={color}
+                strokeLinecap="square"
+                strokeLinejoin="miter"
+                strokeWidth="2"
+              />{' '}
+            </g>{' '}
+            <path
+              className="nc-line_top-right"
+              data-cap="none"
+              fill="none"
+              stroke={color}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M16 16L27 5"
+              strokeDasharray="15.56 15.56"
+              strokeDashoffset="15.56"
+              opacity="0"
+            />{' '}
+            <path
+              className="nc-line_bottom-left"
+              data-cap="none"
+              fill="none"
+              stroke={color}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M5 27l11-11"
+              strokeDasharray="15.56 15.56"
+              strokeDashoffset="-15.56"
+              opacity="0"
+            />{' '}
+            <path
+              className="nc-line_bottom-right"
+              data-cap="none"
+              fill="none"
+              stroke={color}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M16 16l11 11"
+              strokeDasharray="15.56 15.56"
+              strokeDashoffset="15.56"
+              opacity="0"
+            />{' '}
+            <path
+              className="nc-line_top-left"
+              data-cap="none"
+              fill="none"
+              stroke={color}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M5 5l11 11"
+              strokeDasharray="15.56 15.56"
+              strokeDashoffset="-15.56"
+              opacity="0"
+            />{' '}
+          </g>
+        </g>
+      </svg>
+    )
+  }
+}
+
+OptionsDots.defaultProps = {
+  color: '#444444',
+  size: 16,
+  radius: 2,
+  block: false,
+}
+
+OptionsDots.propTypes = {
+  color: PropTypes.string,
+  radius: PropTypes.number,
+  size: PropTypes.number,
+  block: PropTypes.bool,
+}
+
+export default OptionsDots

--- a/react/components/icon/README.md
+++ b/react/components/icon/README.md
@@ -27,6 +27,7 @@ const ICONS = {
   Filter: require('./Filter').default,
   Help: require('./Help').default,
   Link: require('./Link').default,
+  OptionsDots: require('./OptionsDots').default,
   Plus: require('./Plus').default,
   PlusLines: require('./PlusLines').default,
   Save: require('./Save').default,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow CSS files in styleguide

#### What problem is this solving?
Style files are not allowed, they are ignored during transpilation

#### How should this be manually tested?
Create a style for a component, use compile script and then use npm link to use styleguide locally and test if the style is being applied.

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change which improves security, performance or maintainability)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
