### PR TITLE
Fix/spinner css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Spinner** Fixed bug where the spinner wasn't animating while the page was loading.
+
 ## [7.5.1] - 2018-11-07
 
 ### Added

--- a/react/components/Spinner/README.md
+++ b/react/components/Spinner/README.md
@@ -29,37 +29,3 @@ A Spinner is a way of showing the user something is being loaded, either because
   <Spinner color="currentColor" size={20} />
 </span>
 ```
-
-#### Transition between spinner status
-
-```js
-initialState = {
-  status: 'working',
-};
-
-<div>
-  <div className="mb5">
-    <Spinner status={state.status} />
-  </div>
-
-  <div className="mb2">
-    Set status:
-  </div>
-  <div className="w-50">
-    <RadioGroup
-      options={[
-        {
-          value: "working",
-          label: "Working",
-        },
-        {
-          value: "idle",
-          label: "Idle",
-        },
-      ]}
-      value={state.status}
-      onChange={e => setState({ status: e.currentTarget.value })}
-    />
-  </div>
-</div>
-```

--- a/react/components/Spinner/README.md
+++ b/react/components/Spinner/README.md
@@ -22,10 +22,44 @@ A Spinner is a way of showing the user something is being loaded, either because
 <Spinner />
 ```
 
-#### Custom color
+#### Custom color and size
 
 ```js
 <span className="dib c-muted-1">
   <Spinner color="currentColor" size={20} />
 </span>
+```
+
+#### Transition between spinner status
+
+```js
+initialState = {
+  status: 'working',
+};
+
+<div>
+  <div className="mb5">
+    <Spinner status={state.status} />
+  </div>
+
+  <div className="mb2">
+    Set status:
+  </div>
+  <div className="w-50">
+    <RadioGroup
+      options={[
+        {
+          value: "working",
+          label: "Working",
+        },
+        {
+          value: "idle",
+          label: "Idle",
+        },
+      ]}
+      value={state.status}
+      onChange={e => setState({ status: e.currentTarget.value })}
+    />
+  </div>
+</div>
 ```

--- a/react/components/Spinner/index.js
+++ b/react/components/Spinner/index.js
@@ -5,58 +5,121 @@ import { baseClassname } from '../icon/utils'
 const radius = 40
 const circ = 2 * radius * Math.PI
 
-const Spinner = ({ color, size, block }) => (
-  <svg
-    className={`${baseClassname('spinner')} ${
-      !color ? 'c-action-primary' : ''
-    } ${block ? 'db' : ''}`}
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 100 100"
-    preserveAspectRatio="xMidYMid"
-    height={size}
-    width={size}>
-    <circle
-      cx="50"
-      cy="50"
-      fill="none"
-      r={radius}
-      stroke={color || 'currentColor'}
-      strokeWidth="10"
-      strokeDasharray={`0 0 2 ${circ}`}
-      strokeLinecap="round"
-      strokeDashoffset="1"
-      transform="rotate(96 50 50)">
-      <animate
-        attributeName="stroke-dasharray"
-        dur="1.5s"
-        repeatCount="indefinite"
-        values={`0 0 2 ${circ};
+const WORKING = 'working'
+const IDLE = 'idle'
+
+class Spinner extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.strokeAnim = React.createRef()
+
+    this.state = {
+      animating: props.status === WORKING,
+    }
+  }
+
+  onNextLoop = callback => {
+    this.strokeAnim.current.onrepeat = () => {
+      callback()
+      this.strokeAnim.current.onrepeat = null
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { status } = this.props
+    const { status: prevStatus } = prevProps
+
+    if (status !== prevStatus) {
+      if (status === IDLE) {
+        this.onNextLoop(() => {
+          this.setState({
+            animating: false,
+          })
+        })
+      } else if (status === WORKING) {
+        this.onNextLoop(() => {
+          this.setState({
+            animating: true,
+          })
+        })
+      }
+    }
+  }
+
+  render() {
+    const { color, size, block } = this.props
+    const { animating } = this.state
+
+    return (
+      <svg
+        className={
+          `${baseClassname('spinner')} ${!color ? 'c-action-primary' : ''} ${block ? 'db' : ''}`
+        }
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="xMidYMid"
+        height={size}
+        width={size}
+      >
+        <g visibility={animating ? 'inherit' : 'hidden'}>
+          <circle
+            cx="50"
+            cy="50"
+            fill="none"
+            r={radius}
+            stroke={color || 'currentColor'}
+            strokeWidth="10"
+            strokeDasharray={`0 0 2 ${circ}`}
+            strokeLinecap="round"
+            strokeDashoffset="1"
+            transform="rotate(-90 50 50)"
+          >
+            <animate
+              attributeName="stroke-dasharray"
+              dur="1.25s"
+              calcMode="spline"
+              keyTimes="0;0.5;1"
+              keySplines="0.455, 0.030, 0.515, 0.955; 0.455, 0.030, 0.515, 0.955"
+              repeatCount="indefinite"
+              values={
+                `0 0 2 ${circ};
           0 0 ${circ * 0.75} ${circ};
-          0 ${circ - 2} ${circ * 0.75} ${circ}`}
-      />
-      <animateTransform
-        attributeName="transform"
-        type="rotate"
-        calcMode="linear"
-        values="0 50 50;360 50 50"
-        keyTimes="0;1"
-        dur="0.75s"
-        begin="0s"
-        repeatCount="indefinite"
-      />
-    </circle>
-  </svg>
-)
+          0 ${circ - 2} ${circ * 0.75} ${circ}`
+              }
+              ref={this.strokeAnim}
+            />
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              calcMode="linear"
+              values="-90 50 50;275 50 50"
+              keyTimes="0;1"
+              dur="0.625s"
+              repeatCount="indefinite"
+            />
+          </circle>
+        </g>
+      </svg>
+    )
+  }
+}
 
 Spinner.propTypes = {
-  block: PropTypes.bool,
+  /** Color of the spinner */
   color: PropTypes.string,
+  /** Size (diameter) of the spinner */
   size: PropTypes.number,
+  /** Status of the spinner; used for smooth transitioning between different states */
+  status: PropTypes.oneOf(['working', 'idle']),
+  /** Sets the display to block */
+  block: PropTypes.bool,
 }
 
 Spinner.defaultProps = {
   block: false,
   size: 40,
+  status: WORKING,
 }
 
 export default Spinner

--- a/react/components/Spinner/index.js
+++ b/react/components/Spinner/index.js
@@ -21,7 +21,7 @@ class Spinner extends React.Component {
         width={size}>
         <style>
           {`
-            @keyframes rot {
+            @keyframes vtex-spinner-rotate {
               from {
                 transform-origin: 50% 50%;
                 transform: rotate(0deg);
@@ -32,7 +32,7 @@ class Spinner extends React.Component {
               }
             }
 
-            @keyframes fill {
+            @keyframes vtex-spinner-fill {
               0% {
                 stroke-dasharray: 0 0 2 ${circ};
               }
@@ -44,14 +44,14 @@ class Spinner extends React.Component {
               }
             }
 
-            .loader {
-              animation: fill 1.25s infinite cubic-bezier(0.455, 0.030, 0.515, 0.955), rot 0.625s infinite linear;
+            .vtex-spinner_circle {
+              animation: vtex-spinner-fill 1.25s infinite cubic-bezier(0.455, 0.030, 0.515, 0.955), vtex-spinner-rotate 0.625s infinite linear;
             }
           `}
         </style>
 
         <circle
-          className="loader"
+          className="vtex-spinner_circle"
           cx="50"
           cy="50"
           fill="none"

--- a/react/components/Spinner/index.js
+++ b/react/components/Spinner/index.js
@@ -5,101 +5,63 @@ import { baseClassname } from '../icon/utils'
 const radius = 40
 const circ = 2 * radius * Math.PI
 
-const WORKING = 'working'
-const IDLE = 'idle'
-
 class Spinner extends React.Component {
-  constructor(props) {
-    super(props)
-
-    this.strokeAnim = React.createRef()
-
-    this.state = {
-      animating: props.status === WORKING,
-    }
-  }
-
-  onNextLoop = callback => {
-    this.strokeAnim.current.onrepeat = () => {
-      callback()
-      this.strokeAnim.current.onrepeat = null
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    const { status } = this.props
-    const { status: prevStatus } = prevProps
-
-    if (status !== prevStatus) {
-      if (status === IDLE) {
-        this.onNextLoop(() => {
-          this.setState({
-            animating: false,
-          })
-        })
-      } else if (status === WORKING) {
-        this.onNextLoop(() => {
-          this.setState({
-            animating: true,
-          })
-        })
-      }
-    }
-  }
-
   render() {
     const { color, size, block } = this.props
-    const { animating } = this.state
 
     return (
       <svg
-        className={
-          `${baseClassname('spinner')} ${!color ? 'c-action-primary' : ''} ${block ? 'db' : ''}`
-        }
+        className={`${baseClassname('spinner')} ${
+          !color ? 'c-action-primary' : ''
+        } ${block ? 'db' : ''}`}
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 100 100"
         preserveAspectRatio="xMidYMid"
         height={size}
-        width={size}
-      >
-        <g visibility={animating ? 'inherit' : 'hidden'}>
-          <circle
-            cx="50"
-            cy="50"
-            fill="none"
-            r={radius}
-            stroke={color || 'currentColor'}
-            strokeWidth="10"
-            strokeDasharray={`0 0 2 ${circ}`}
-            strokeLinecap="round"
-            strokeDashoffset="1"
-            transform="rotate(-90 50 50)"
-          >
-            <animate
-              attributeName="stroke-dasharray"
-              dur="1.25s"
-              calcMode="spline"
-              keyTimes="0;0.5;1"
-              keySplines="0.455, 0.030, 0.515, 0.955; 0.455, 0.030, 0.515, 0.955"
-              repeatCount="indefinite"
-              values={
-                `0 0 2 ${circ};
-          0 0 ${circ * 0.75} ${circ};
-          0 ${circ - 2} ${circ * 0.75} ${circ}`
+        width={size}>
+        <style>
+          {`
+            @keyframes rot {
+              from {
+                transform-origin: 50% 50%;
+                transform: rotate(0deg);
               }
-              ref={this.strokeAnim}
-            />
-            <animateTransform
-              attributeName="transform"
-              type="rotate"
-              calcMode="linear"
-              values="-90 50 50;275 50 50"
-              keyTimes="0;1"
-              dur="0.625s"
-              repeatCount="indefinite"
-            />
-          </circle>
-        </g>
+              to {
+                transform-origin: 50% 50%;
+                transform: rotate(360deg);
+              }
+            }
+
+            @keyframes fill {
+              0% {
+                stroke-dasharray: 0 0 2 ${circ};
+              }
+              50% {
+                stroke-dasharray: 0 0 ${circ * 0.75} ${circ};
+              }
+              100% {
+                stroke-dasharray: 0 ${circ - 2} ${circ * 0.75} ${circ};
+              }
+            }
+
+            .loader {
+              animation: fill 1.25s infinite cubic-bezier(0.455, 0.030, 0.515, 0.955), rot 0.625s infinite linear;
+            }
+          `}
+        </style>
+
+        <circle
+          className="loader"
+          cx="50"
+          cy="50"
+          fill="none"
+          r={radius}
+          stroke={color || 'currentColor'}
+          strokeWidth="10"
+          strokeDasharray={`0 0 ${circ * 0.75} ${circ}`}
+          strokeLinecap="round"
+          strokeDashoffset="1"
+        />
       </svg>
     )
   }
@@ -110,8 +72,6 @@ Spinner.propTypes = {
   color: PropTypes.string,
   /** Size (diameter) of the spinner */
   size: PropTypes.number,
-  /** Status of the spinner; used for smooth transitioning between different states */
-  status: PropTypes.oneOf(['working', 'idle']),
   /** Sets the display to block */
   block: PropTypes.bool,
 }
@@ -119,7 +79,6 @@ Spinner.propTypes = {
 Spinner.defaultProps = {
   block: false,
   size: 40,
-  status: WORKING,
 }
 
 export default Spinner


### PR DESCRIPTION
Changes the animation of the spinner from SVG based to CSS based. This fixes a problem where the spinner wasn't playing during certain stages of the page load—namely, the beginning of it—due to how SVG animations work.