### PR TITLE
Toast HOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.6.0] - 2018-11-09
+
 ### Added
 
 - **Toast** Add Toast higher order component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Toast** Add Toast higher order component
+
 ## [7.5.7] - 2018-11-09
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "7.5.7",
+  "version": "7.6.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "7.5.7",
+  "version": "7.6.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/components/Toast/README.md
+++ b/react/components/Toast/README.md
@@ -135,3 +135,56 @@ const Content = () => (
 ;<App/>
 
 ```
+
+### Higher order component
+
+```js
+  const withToast = require('./index').withToast
+  const Input = require('../Input').default
+  const debounce = require('lodash').debounce
+
+  class App extends React.Component {
+    constructor(props){
+      super(props)
+
+      this.state = {
+        value: '',
+      }
+
+      this.handleInputChange = this.handleInputChange.bind(this)
+      this.showToast = debounce(this.showToast.bind(this), 300)
+    }
+
+    handleInputChange(event) {
+      this.setState({ value: event.currentTarget.value })
+    }
+
+    componentDidUpdate(prevState) {
+      if(prevState.value !== this.state.value) {
+        this.showToast(`Value set to ${this.state.value}`)
+      }
+    }
+
+    showToast(message) {
+      this.props.showToast({ message })
+    }
+
+    render() {
+      const {value} = this.state
+      return (
+        <Input
+          value={value}
+          label="Write something below to display a toast"
+          onChange={this.handleInputChange}
+          placeholder="Type here"
+        />
+      )
+    }
+  }
+
+  const AppWithToast = withToast(App)
+
+  ;<ToastProvider positioning="window">
+    <AppWithToast />
+  </ToastProvider>
+```

--- a/react/components/Toast/README.md
+++ b/react/components/Toast/README.md
@@ -136,8 +136,6 @@ const Content = () => (
 
 ```
 
-### Higher order component
-
 ```js
   const withToast = require('./index').withToast
   const Input = require('../Input').default
@@ -160,8 +158,13 @@ const Content = () => (
     }
 
     componentDidUpdate(prevState) {
-      if(prevState.value !== this.state.value) {
-        this.showToast(`Value set to ${this.state.value}`)
+      const { value } = this.state
+      if ( prevState.value !== this.state.value ) {
+        if (value === ''){
+          this.showToast('The text has been erased')
+        } else {
+          this.showToast(`You typed: “${this.state.value}”`)
+        }
       }
     }
 
@@ -172,17 +175,24 @@ const Content = () => (
     render() {
       const {value} = this.state
       return (
-        <Input
-          value={value}
-          label="Write something below to display a toast"
-          onChange={this.handleInputChange}
-          placeholder="Type here"
-        />
+        <React.Fragment>
+          <div className="mb6">
+            <h3>Higher order component</h3>
+            For use on component lifecycle methods (componentDidMount, componentDidUpdate, etc)
+          </div>
+          <Input
+            value={value}
+            label="Write something below to display a toast"
+            onChange={this.handleInputChange}
+            placeholder="Type here"
+          />
+        </React.Fragment>
       )
     }
   }
 
   const AppWithToast = withToast(App)
+
 
   ;<ToastProvider positioning="window">
     <AppWithToast />

--- a/react/components/Toast/ToastManager.js
+++ b/react/components/Toast/ToastManager.js
@@ -1,0 +1,130 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import Toast from './Toast'
+import isString from 'lodash/isString'
+
+export default class ToastManager extends Component {
+  constructor(props) {
+    super(props)
+
+    this.container = React.createRef()
+  }
+
+  state = {
+    currentToast: null,
+    nextToast: null,
+    isToastVisible: true,
+  }
+
+  showToast = args => {
+    if (isString(args)) {
+      args = { message: args }
+    }
+    const { message = '', action, duration } = args
+
+    if (this.state.currentToast) {
+      // If there is a toast present already, queue up the next toast
+      // It will be displayed when the current toast is closed, on handleToastClose
+      this.setState({
+        nextToast: {
+          message,
+          action,
+          duration,
+        },
+      })
+      this.hideToast()
+    } else {
+      this.setState({
+        currentToast: {
+          message,
+          action,
+          duration,
+        },
+        isToastVisible: true,
+      })
+    }
+  }
+
+  hideToast = () => {
+    this.setState({
+      isToastVisible: false,
+    })
+  }
+
+  handleToastClose = () => {
+    this.setState(state => {
+      return {
+        // If there is a toast queued up, shows it.
+        // Otherwise, nextToast will be null, and state.toast will be cleared up
+        currentToast: state.nextToast,
+        isToastVisible: !!state.nextToast,
+        nextToast: null,
+      }
+    })
+  }
+
+  getParentBounds = () => {
+    const parentContainer =
+      this.container.current && this.container.current.parentNode
+    return (
+      parentContainer &&
+      parentContainer.getBoundingClientRect &&
+      parentContainer.getBoundingClientRect()
+    )
+  }
+
+  updateContainerBounds = () => {
+    const windowBounds = {
+      left: 0,
+      right: window.innerWidth,
+      top: 0,
+      bottom: window.innerHeight,
+    }
+
+    const bounds =
+      (this.props.positioning === 'parent' && this.getParentBounds()) ||
+      windowBounds
+
+    if (this.container.current) {
+      this.container.current.style.left = `${bounds.left}px`
+      this.container.current.style.right = `${window.innerWidth -
+        bounds.right}px`
+      this.container.current.style.top = `${bounds.top}px`
+      this.container.current.style.bottom = `${Math.max(
+        0,
+        window.innerHeight - bounds.bottom
+      )}px`
+    }
+  }
+
+  componentDidUpdate() {
+    this.updateContainerBounds()
+  }
+
+  render() {
+    const { currentToast } = this.state
+
+    return (
+      <div
+        className="fixed z-5 overflow-hidden"
+        ref={this.container}
+        style={{
+          pointerEvents: 'none',
+        }}>
+        {currentToast && (
+          <Toast
+            message={currentToast.message}
+            action={currentToast.action}
+            duration={currentToast.duration}
+            visible={this.state.isToastVisible}
+            onClose={this.handleToastClose}
+          />
+        )}
+      </div>
+    )
+  }
+}
+
+ToastManager.propTypes = {
+  positioning: PropTypes.oneOf(['parent', 'window']),
+}

--- a/react/components/Toast/index.js
+++ b/react/components/Toast/index.js
@@ -73,4 +73,17 @@ ToastConsumer.propTypes = {
   children: PropTypes.func.isRequired,
 }
 
-export { ToastProvider, ToastConsumer }
+// eslint-disable-next-line react/display-name
+const withToast = WrappedComponent => props => (
+  <ToastConsumer>
+    {({ showToast, hideToast }) => (
+      <WrappedComponent
+        showToast={showToast}
+        hideToast={hideToast}
+        {...props}
+      />
+    )}
+  </ToastConsumer>
+)
+
+export { ToastProvider, ToastConsumer, withToast }

--- a/react/components/Toast/index.js
+++ b/react/components/Toast/index.js
@@ -14,11 +14,11 @@ class ToastProvider extends Component {
     this.toastManager = React.createRef()
   }
 
-  showToast = message => {
+  showToast = args => {
     this.toastManager &&
       this.toastManager.current &&
       this.toastManager.current.showToast &&
-      this.toastManager.current.showToast(message)
+      this.toastManager.current.showToast(args)
   }
 
   hideToast = () => {

--- a/react/components/Toast/index.js
+++ b/react/components/Toast/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import Toast from './Toast'
-import isString from 'lodash/isString'
+import ToastManager from './ToastManager'
 
 const ToastContext = React.createContext({
   showToast: () => {},
@@ -12,103 +11,25 @@ class ToastProvider extends Component {
   constructor(props) {
     super(props)
 
-    this.container = React.createRef()
+    this.toastManager = React.createRef()
   }
 
-  state = {
-    currentToast: null,
-    nextToast: null,
-    isToastVisible: true,
-  }
-
-  showToast = args => {
-    if (isString(args)) {
-      args = { message: args }
-    }
-    const { message = '', action, duration } = args
-
-    if (this.state.currentToast) {
-      // If there is a toast present already, queue up the next toast
-      // It will be displayed when the current toast is closed, on handleToastClose
-      this.setState({
-        nextToast: {
-          message,
-          action,
-          duration,
-        },
-      })
-      this.hideToast()
-    } else {
-      this.setState({
-        currentToast: {
-          message,
-          action,
-          duration,
-        },
-        isToastVisible: true,
-      })
-    }
+  showToast = message => {
+    this.toastManager &&
+      this.toastManager.current &&
+      this.toastManager.current.showToast &&
+      this.toastManager.current.showToast(message)
   }
 
   hideToast = () => {
-    this.setState({
-      isToastVisible: false,
-    })
-  }
-
-  handleToastClose = () => {
-    this.setState(state => {
-      return {
-        // If there is a toast queued up, shows it.
-        // Otherwise, nextToast will be null, and state.toast will be cleared up
-        currentToast: state.nextToast,
-        isToastVisible: !!state.nextToast,
-        nextToast: null,
-      }
-    })
-  }
-
-  getParentBounds = () => {
-    const parentContainer =
-      this.container.current && this.container.current.parentNode
-    return (
-      parentContainer &&
-      parentContainer.getBoundingClientRect &&
-      parentContainer.getBoundingClientRect()
-    )
-  }
-
-  updateContainerBounds = () => {
-    const windowBounds = {
-      left: 0,
-      right: window.innerWidth,
-      top: 0,
-      bottom: window.innerHeight,
-    }
-
-    const bounds =
-      (this.props.positioning === 'parent' && this.getParentBounds()) ||
-      windowBounds
-
-    if (this.container.current) {
-      this.container.current.style.left = `${bounds.left}px`
-      this.container.current.style.right = `${window.innerWidth -
-        bounds.right}px`
-      this.container.current.style.top = `${bounds.top}px`
-      this.container.current.style.bottom = `${Math.max(
-        0,
-        window.innerHeight - bounds.bottom
-      )}px`
-    }
-  }
-
-  componentDidUpdate() {
-    this.updateContainerBounds()
+    this.toastManager &&
+      this.toastManager.current &&
+      this.toastManager.current.hideToast &&
+      this.toastManager.current.hideToast()
   }
 
   render() {
-    const { currentToast } = this.state
-    const { children } = this.props
+    const { children, positioning } = this.props
     return (
       <ToastContext.Provider
         value={{
@@ -116,22 +37,7 @@ class ToastProvider extends Component {
           hideToast: this.hideToast,
         }}>
         {children}
-        <div
-          className="fixed z-5 overflow-hidden"
-          ref={this.container}
-          style={{
-            pointerEvents: 'none',
-          }}>
-          {currentToast && (
-            <Toast
-              message={currentToast.message}
-              action={currentToast.action}
-              duration={currentToast.duration}
-              visible={this.state.isToastVisible}
-              onClose={this.handleToastClose}
-            />
-          )}
-        </div>
+        <ToastManager positioning={positioning} ref={this.toastManager} />
       </ToastContext.Provider>
     )
   }


### PR DESCRIPTION
Creates a `withToast` higher order component, for use in component lifecycle methods.

Also moves Toast logic to a separate component called `ToastManager`, to avoid rerendering of all `ToastProvider` children