### PR TITLE
Fix/toggle semantic disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Toggle** Fixes styling when it's `semantic` and `disabled` simultaneously
+
 ## [7.6.3] - 2018-11-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.6.4] - 2018-11-19
+
 ### Fixed
 
 - **Toggle** Fixes styling when it's `semantic` and `disabled` simultaneously

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "7.6.3",
+  "version": "7.6.4",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "7.6.3",
+  "version": "7.6.4",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/components/Toggle/index.js
+++ b/react/components/Toggle/index.js
@@ -19,8 +19,8 @@ class Toggle extends Component {
     let labelClass = disabled ? 'c-disabled ' : 'c-on-base '
     let classes = 'flex items-center relative br4 '
     let circleClasses = 'absolute br-100 '
-    let iconDenyClasses = 'absolute flex justify-center c-danger '
-    let iconCheckClasses = 'absolute flex justify-center c-success '
+    let iconDenyClasses = 'absolute flex justify-center '
+    let iconCheckClasses = 'absolute flex justify-center '
 
     let circleStyle = {
       boxShadow: disabled ? 'none' : '0 0 10px rgba(0,0,0,0.2)',
@@ -33,16 +33,31 @@ class Toggle extends Component {
 
     // Background
     if (semantic) {
-      if (!disabled && !checked) {
-        classes += 'bg-danger '
-        iconDenyClasses += 'o-100 '
-        iconCheckClasses += 'o-0 '
-      }
+      if (!disabled) {
+        iconCheckClasses += 'c-success '
+        iconDenyClasses += 'c-danger '
 
-      if (!disabled && checked) {
-        classes += 'bg-success '
-        iconDenyClasses += 'o-0 '
-        iconCheckClasses += 'o-100 '
+        if (!checked) {
+          classes += 'bg-danger '
+          iconDenyClasses += 'o-100 '
+          iconCheckClasses += 'o-0 '
+        } else {
+          classes += 'bg-success '
+          iconDenyClasses += 'o-0 '
+          iconCheckClasses += 'o-100 '
+        }
+      } else {
+        classes += 'bg-disabled '
+        iconCheckClasses += 'c-on-disabled '
+        iconDenyClasses += 'c-on-disabled '
+
+        if (!checked) {
+          iconDenyClasses += 'o-100 '
+          iconCheckClasses += 'o-0 '
+        } else {
+          iconDenyClasses += 'o-0 '
+          iconCheckClasses += 'o-100 '
+        }
       }
     } else if (disabled) {
       classes += 'bg-disabled '
@@ -129,18 +144,12 @@ class Toggle extends Component {
             <div className={circleClasses} style={circleStyle} />
             {semantic && (
               <div className={iconDenyClasses} style={iconStyle}>
-                <DenyIcon
-                  size={size === 'regular' ? 14 : 12}
-                  color="currentColor"
-                />
+                <DenyIcon size={size === 'regular' ? 14 : 12} />
               </div>
             )}
             {semantic && (
               <div className={iconCheckClasses} style={iconStyle}>
-                <CheckIcon
-                  size={size === 'regular' ? 15 : 13}
-                  color="currentColor"
-                />
+                <CheckIcon size={size === 'regular' ? 15 : 13} />
               </div>
             )}
           </div>


### PR DESCRIPTION
:bezerra:

Fixes case where the toggle styling would break, when it's both `disabled` and `semantic`

Before:
<img width="152" alt="screen shot 2018-11-19 at 14 48 46" src="https://user-images.githubusercontent.com/5691711/48722228-acef6b80-ec0a-11e8-9570-7464f605f334.png">

After:
<img width="136" alt="screen shot 2018-11-19 at 14 47 35" src="https://user-images.githubusercontent.com/5691711/48722238-b4167980-ec0a-11e8-9ac9-76f21778949c.png">
