### PR TITLE
Prevent importing of the entire lodash lib

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
     "vtex",
     "vtex-react",
     "plugin:import/recommended",
-    "plugin:prettier/recommended",
+    "plugin:prettier/recommended"
   ],
   "plugins": ["import", "lodash"],
   "rules": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,9 +3,9 @@
     "vtex",
     "vtex-react",
     "plugin:import/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
   ],
-  "plugins": ["import"],
+  "plugins": ["import", "lodash"],
   "rules": {
     "import/no-unresolved": [
       "error",
@@ -15,6 +15,7 @@
         "ignore": ["^([a-zA-Z@]+[-\\.]?)+"]
       }
     ],
+    "lodash/import-scope": [2, "method"],
     // Rules that conflict with Prettier.
     // To verify conflicting rules, run:
     // $ npm run prettier-conflict-check

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-flowtype": "2",
     "eslint-plugin-import": "2.10.0",
     "eslint-plugin-jsx-a11y": "6.0.3",
+    "eslint-plugin-lodash": "^4.0.0",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.7.0",
     "eslint-utils": "^1.3.1",

--- a/react/components/MultiSelect/index.js
+++ b/react/components/MultiSelect/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { debounce } from 'lodash'
+import debounce from 'lodash/debounce'
 
 import Tag from './Tag'
 import DropdownList from './DropdownList'

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import { cloneDeep, isEqual } from 'lodash'
+import cloneDeep from 'lodash/cloneDeep'
+import isEqual from 'lodash/isEqual'
 
 import Toolbar from './Toolbar'
 import Pagination from '../Pagination'

--- a/react/components/Toast/README.md
+++ b/react/components/Toast/README.md
@@ -139,7 +139,7 @@ const Content = () => (
 ```js
   const withToast = require('./index').withToast
   const Input = require('../Input').default
-  const debounce = require('lodash').debounce
+  const debounce = require('lodash/debounce')
 
   class App extends React.Component {
     constructor(props){

--- a/yarn.lock
+++ b/yarn.lock
@@ -3823,6 +3823,13 @@ eslint-plugin-jsx-a11y@6.0.3:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^2.0.0"
 
+eslint-plugin-lodash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-4.0.0.tgz#de61ebd1a59e18a0b1d4eaf114972e5a97f3cfc2"
+  integrity sha512-LB81qXVWM3PzGRBtThDAxM89gn2D3VU33+iGpKd5J981/hstzCGzz1KhztuXjzDm1ib8Fx96HLiBJUe/y9l6Ow==
+  dependencies:
+    lodash "4.17.10"
+
 eslint-plugin-prettier@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz#f6b823e065f8c36529918cdb766d7a0e975ec30c"
@@ -6916,15 +6923,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash@4.17.10, "lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.3, lodash@^4.17.4:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
+
 lodash@4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
   integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
-
-"lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.3, lodash@^4.17.4:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
 lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.11"


### PR DESCRIPTION
Changes the importing method of lodash functions, to avoid including the entire lodash lib, reducing the file size

Before
<img width="882" alt="screen shot 2018-11-21 at 17 08 42" src="https://user-images.githubusercontent.com/5691711/48863718-71db6c80-edb1-11e8-9b91-2ec987929bb9.png">

After
<img width="872" alt="screen shot 2018-11-21 at 17 09 31" src="https://user-images.githubusercontent.com/5691711/48863738-87e92d00-edb1-11e8-8ad8-dcbedfb4686d.png">

(both are the unminified, ungzipped, dev build of the styleguide from vtex io)
