### PR TITLE
Hotfix - add title as param in headerRenderer callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - **PageBlock** new component for organizing the blocks that make up our Admin pages.
 
+### Added
+- **Table** Add `title` as param to headerRenderer callback declared in schema to customize header cell
+
 ## [8.2.0] - 2018-12-06
 
 ### Added

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -131,6 +131,8 @@ class CustomTableExample extends React.Component {
               </Tag>
             )
           },
+          // you can also customize non sortable headers with the following prop
+          // headerRenderer: ({ columnIndex, key, rowIndex, style, title })
         },
       },
     };

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -121,7 +121,13 @@ class SimpleTable extends Component {
                           <span>{title}</span>
                         </div>
                       ) : headerRenderer ? (
-                        headerRenderer({ columnIndex, key, rowIndex, style })
+                        headerRenderer({
+                          columnIndex,
+                          key,
+                          rowIndex,
+                          style,
+                          title,
+                        })
                       ) : (
                         title
                       )}


### PR DESCRIPTION
## What does this PR do?
 - adds title in headerRenderer params.
 - Fixes vtex/styleguide/issues/442