### PR TITLE
Fix/toast z index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.3.0] - 2018-12-13
+
 ### Fixed
 - **Toast** Increase z-index to the max.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- **Toast** Increase z-index to the max.
+
 ### Added
 - **PageBlock** new component for organizing the blocks that make up our Admin pages.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/components/Toast/ToastManager.js
+++ b/react/components/Toast/ToastManager.js
@@ -106,7 +106,7 @@ export default class ToastManager extends Component {
 
     return (
       <div
-        className="fixed z-5 overflow-hidden"
+        className="fixed z-max overflow-hidden"
         ref={this.container}
         style={{
           pointerEvents: 'none',


### PR DESCRIPTION
Increase the z-index of the toast component to be on top of everything. This is for the toast to be displayed over eventual modal or drawer windows