### PR TITLE
Fix typo on `breakpoints.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix typo on `/docs/styles/breakpoints.md`
 
 ## [8.4.2] - 2018-12-14
 

--- a/docs/styles/breakpoints.md
+++ b/docs/styles/breakpoints.md
@@ -3,7 +3,7 @@
 | Small | -s  | 320px 20em |
 | Medium | -m  | 640px 40em |
 | Large | -l | 1024px 64em |
-| Not Small | -nl  | Medium and large |
+| Not Small | -ns  | Medium and large |
 
 ```js
 


### PR DESCRIPTION
`Syntax` field for the `Not Small` breakpoint should be `-ns`, not `-nl`