### PR TITLE
Fix/dropdown size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.7.3] - 2018-12-21
+
 ### Fixed
 
 - **Dropdown** Size was corrected to follow the standards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dropdown** Size was corrected to follow the standards
+
 ## [8.7.2] - 2018-12-20
 
 - Reverting v8.7.1. The implemented solution for the `yarn install` problem was

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "scripts": {
     "test": "react-scripts test --env=jsdom",
     "test:codemod": "jest codemod",

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -104,7 +104,7 @@ ${this.getDropdownIdentification()}`
     let width
     let iconSize
 
-    let classes = 'bg-transparent bn w-100 '
+    let classes = 'bg-transparent bn w-100 h-100 '
     let containerClasses = 'br2 bw1 relative '
     let selectClasses = 'o-0 absolute top-0 left-0 w-100 bottom-0 '
 
@@ -124,15 +124,17 @@ ${this.getDropdownIdentification()}`
 
     switch (size) {
       case 'small':
-        classes += 'h-small t-small pl5 pr3 '
+        classes += 'pl5 pr3 '
         selectClasses += 't-small '
         labelClasses += 't-small '
+        containerClasses += 'h-small t-small '
         iconSize = 18
         break
       case 'large':
-        classes += 'h-large t-body ph5 '
+        classes += 'ph5 '
         selectClasses += 't-body '
         labelClasses += 't-body '
+        containerClasses += 'h-large t-body '
         iconSize = 18
         break
       case 'x-large':
@@ -143,9 +145,10 @@ ${this.getDropdownIdentification()}`
         iconSize = 22
         break
       default:
-        classes += 'h-regular t-body pl5 pr4 '
+        classes += 'pl5 pr4 '
         selectClasses += 't-small '
         labelClasses += 't-small '
+        containerClasses += 'h-regular t-body '
         iconSize = 18
         break
     }


### PR DESCRIPTION
Fixes https://github.com/vtex/styleguide/issues/465

The size classes were being attributed to an inner element of the dropdown component, instead of its parent. This PR corrects this mistake.