### PR TITLE
Fix styles for disabled and read-only states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Input** Fix styles for disabled and read-only states.
+
 ## [8.7.3] - 2018-12-21
 
 ### Fixed

--- a/react/components/Input/README.md
+++ b/react/components/Input/README.md
@@ -60,8 +60,15 @@ class InputExamples extends React.Component {
   render() {
     return (
       <div className="w-40">
+      <div className="mb5">
+          <Input
+            value={"This input is read-only."}
+            readOnly={true}
+            label="Read-only"
+          />
+        </div>
         <div className="mb5">
-          <Input disabled value="Hayao Miyazaki" label="Disabled" />
+          <Input disabled value="This input is disabled." label="Disabled" />
         </div>
         <div className="mb5">
           <Input

--- a/react/components/Input/README.md
+++ b/react/components/Input/README.md
@@ -62,7 +62,7 @@ class InputExamples extends React.Component {
       <div className="w-40">
       <div className="mb5">
           <Input
-            value={"This input is read-only."}
+            value="This input is read-only."
             readOnly={true}
             label="Read-only"
           />

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -28,13 +28,17 @@ class Input extends Component {
   }
 
   handleFocus = event => {
-    this.setState({ active: true })
-    this.props.onFocus && this.props.onFocus(event)
+    if (!this.props.readOnly) {
+      this.setState({ active: true })
+      this.props.onFocus && this.props.onFocus(event)
+    }
   }
 
   handleBlur = event => {
-    this.setState({ active: false })
-    this.props.onBlur && this.props.onBlur(event)
+    if (!this.props.readOnly) {
+      this.setState({ active: false })
+      this.props.onBlur && this.props.onBlur(event)
+    }
   }
 
   componentDidMount() {
@@ -89,8 +93,7 @@ class Input extends Component {
     const topBottomHeight = config.borderRadius[1] * 2 // 2 is top AND BOTTOM
     const prefixAndSuffixPosition = `${config.borderRadius[1]}rem`
     const calcPrefixAndSuffixHeight = `calc(100% - ${topBottomHeight}rem)`
-    const typography = 'c-on-base'
-    let classes = `${widthClass} ${box} ${border} ${typography} `
+    let classes = `${widthClass} ${box} ${border} `
 
     let labelClasses = 'vtex-input__label db mb3 w-100 c-on-base '
 
@@ -104,14 +107,17 @@ class Input extends Component {
     if (this.props.disabled) {
       classes += 'bg-disabled b--disabled c-disabled '
     } else {
-      classes += 'bg-base '
+      classes += 'bg-base c-on-base '
 
       if (error || errorMessage) {
         classes += 'b--danger hover-b--danger '
       } else if (active) {
         classes += 'b--muted-2 '
       } else {
-        classes += 'b--muted-4 hover-b--muted-3 '
+        classes += 'b--muted-4 '
+        if (!this.props.readOnly) {
+          classes += 'hover-b--muted-3 '
+        }
       }
     }
 


### PR DESCRIPTION
- Removes hover effects of `read-only` Input, since it's not actually interactive.
- Fixes type color on disabled state.

![image](https://user-images.githubusercontent.com/467471/50483776-6a246e80-09d4-11e9-90a9-90d765da5a98.png)
