### PR TITLE
Adjust InputPassword styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **InputPassword** Use monospaced font to prevent the width from shifting.
+
 ### Fixed
 
-- **Input** Fixed `token` prop which was not working
+- **Input** Fixed `token` prop which was not working.
 
 ## [8.9.1] - 2019-01-02
 

--- a/react/components/InputPassword/index.js
+++ b/react/components/InputPassword/index.js
@@ -26,6 +26,8 @@ class InputPassword extends Component {
       <Input
         {...this.props}
         type={this.state.showPassword ? 'text' : 'password'}
+        token
+        spellCheck="false"
         suffix={
           <span className="pointer pt2" onClick={() => this.toggle()}>
             {this.state.showPassword ? (


### PR DESCRIPTION
:bezerra:

Sets its font to monospaced to prevent the text width from shifting. Also removes spellcheck from it

After:
![password-drake-yes](https://user-images.githubusercontent.com/5691711/50526809-abe41080-0acb-11e9-801a-d105748ccc2c.gif)

Before:
![password-drake-no](https://user-images.githubusercontent.com/5691711/50526811-b0a8c480-0acb-11e9-8305-2773048a2ecc.gif)

