### PR TITLE
ActionMenu improvements

### DIFF
--- a/react/components/ActionMenu/Menu.js
+++ b/react/components/ActionMenu/Menu.js
@@ -21,7 +21,7 @@ class Menu extends Component {
   }
 
   render() {
-    const { options, boxWidth, align, isOpen, onMenuClose } = this.props
+    const { options, menuWidth, align, isOpen, onMenuClose } = this.props
 
     return (
       <Fragment>
@@ -34,7 +34,7 @@ class Menu extends Component {
               }`}>
               <div
                 className="b2 br2 bg-base"
-                style={{ width: boxWidth || BOX_WIDTH }}>
+                style={{ width: menuWidth || BOX_WIDTH }}>
                 <div
                   style={{ height: this.calculateBoxHeight() }}
                   className={
@@ -88,7 +88,7 @@ Menu.propTypes = {
   /** Menu visibility (default is false) */
   isOpen: PropTypes.bool,
   /** Menu Box width (default is 292px) */
-  boxWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  menuWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Menu options */
   options: PropTypes.arrayOf(
     PropTypes.shape({

--- a/react/components/ActionMenu/README.md
+++ b/react/components/ActionMenu/README.md
@@ -1,305 +1,244 @@
-#### An Action Menu lets a user choose an action to perform from a list of options (menu).
+#### Action Menus are contextual menus that let the user chose and execute actions from a list.
+
+### 👍 Dos
+- Use _isDangerous_ for destructive actions that delete data or lead to a state that is hard to recover. Danger buttons should always have a confirmation dialog.
 
 ### 👎 Don'ts
-
-- Don't use an ActionMenu if you want to provide a list of options that doesn't represent actions.
-- Avoid hiding the caret, it signifies to the user that this button behaves different than normal buttons.
-
-### Related components
-
-- This component uses the Menu component (the list of actions) that should never be used alone.
+- It's OK to hide the caret when using the OptionsDots icon, but avoid otherwise. It's important to signify that this button behaves differently than normal ones.
 
 
-Alignment
+Using button variations
 
 ```js
-<div className="flex flex-row w-100 justify-between">
-  <div className="ma3">
-    <ActionMenu
-      label="box aligned left"
-      align="left"
-      boxWidth="100%"
-      buttonProps={{
-        size: 'small',
-        variation: 'primary',
-      }}
-      options={[
-        {
-          label: 'Open pod doors, HAL',
-          handleCallback: () => alert('I’m sorry, Dave. I’m afraid I can’t do that.')
-        },
-        {
-          label: 'Have you heard about the word?',
-          handleCallback: () => alert('sure, everybody knows that the bird is the word...')
-        },
-        {
-          label: 'Hey look',
-          handleCallback: () => alert('Listen!')
-        },
-        {
-          label: 'Quit now and cake will be served',
-          handleCallback: () => alert('The cake is a lie')
-        },
-      ]}
-    />
+const options = [
+  {
+    label: 'Open pod doors, HAL',
+    handleCallback: () => alert('I’m sorry, Dave. I’m afraid I can’t do that.')
+  },
+  {
+    label: 'Have you heard about the word?',
+    handleCallback: () => alert('sure, everybody knows that the bird is the word...')
+  },
+  {
+    label: 'Hey look',
+    handleCallback: () => alert('Listen!')
+  },
+  {
+    label: 'Quit now and cake will be served',
+    isDangerous: 'true',
+    handleCallback: () => alert('The cake is a lie')
+  },
+];
+
+<div className="flex">
+  <div className="flex flex-column">
+    <div className="ma3">
+      <ActionMenu
+        label="Actions"
+        buttonProps={{
+          variation: 'primary',
+        }}
+        options={options}
+      />
+    </div>
+    <div className="ma3">
+      <ActionMenu
+        label="Actions"
+        buttonProps={{
+          variation: 'secondary',
+        }}
+        options={options}
+      />
+    </div>
+    <div className="ma3">
+      <ActionMenu
+        label="Actions"
+        buttonProps={{
+          variation: 'tertiary',
+        }}
+        options={options}
+      />
+    </div>
   </div>
-  <div className="ma3">
-    <ActionMenu
-      label="box aligned right"
-      boxWidth="100%"
-      buttonProps={{
-        size: 'small',
-        variation: 'primary',
-      }}
-      options={[
-        {
-          label: 'Start front engines motors',
-          handleCallback: () => alert('beep!')
-        },
-        {
-          label: 'Engage side thrusters heating',
-          handleCallback: () => alert('boop!')
-        },
-        {
-          label: 'Commence take off immediatelly',
-          handleCallback: () => alert('meerp!')
-        },
-        {
-          label: 'Prepare for Adama maneuver',
-          handleCallback: () => alert('Do a barrel roll!')
-        },
-      ]}
-    />
+  <div className="flex flex-column">
+    <div className="ma3">
+      <ActionMenu
+        label="Actions"
+        buttonProps={{
+          variation: 'primary',
+          disabled: 'true'
+        }}
+        options={options}
+      />
+    </div>
+    <div className="ma3">
+      <ActionMenu
+        label="Actions"
+        buttonProps={{
+          variation: 'secondary',
+          disabled: 'true'
+        }}
+        options={options}
+      />
+    </div>
+    <div className="ma3">
+      <ActionMenu
+        label="Actions"
+        buttonProps={{
+          variation: 'tertiary',
+          disabled: 'true'
+        }}
+        options={options}
+      />
+    </div>
   </div>
 </div>
 ```
 
-With toggles
+With icons
 
-```js
-class MenusExample extends React.Component {
-  constructor() {
-    super()
-    this.state = {
-      songOption0: true,
-      songOption1: true,
-      songOption2: false,
-      songOption3: false,
-      songOption4: true,
-      songOption5: true,
-      songOption6: false,
-      songOption7: true,
-      songOption8: true,
-      songOption9: false,
-      songOption10: true,
-    }
-  }
-
-  render() {
-    return (
-      <div>
-        <ActionMenu
-          label="big list example"
-          align="left"
-          buttonProps={{
-            size: 'small',
-            variation: 'primary',
-          }}
-          options={[
-            {
-              label: 'Syncopation',
-              handleCallback: () => this.setState({ songOption0: !this.state.songOption0 }),
-              toggle: {
-                checked: this.state.songOption0,
-                handleChange: () => {},
-              }
-            },
-            {
-              label: 'Beat',
-              handleCallback: () => this.setState({ songOption1: !this.state.songOption1 }),
-              toggle: {
-                checked: this.state.songOption1,
-                handleChange: () => {},
-              }
-            },
-            {
-              label: 'Meter',
-              handleCallback: () => this.setState({ songOption2: !this.state.songOption2 }),
-              toggle: {
-                checked: this.state.songOption2,
-                handleChange: () => {},
-              }
-            },
-            {
-              label: 'Tempo',
-              handleCallback: () => this.setState({ songOption3: !this.state.songOption3 }),
-              toggle: {
-                checked: this.state.songOption3,
-                handleChange: () => {},
-              }
-            },
-            {
-              label: 'Melody',
-              handleCallback: () => this.setState({ songOption4: !this.state.songOption4 }),
-              toggle: {
-                checked: this.state.songOption4,
-                handleChange: () => {},
-              }
-            },
-            {
-              label: 'Harmony',
-              handleCallback: () => this.setState({ songOption5: !this.state.songOption5 }),
-              toggle: {
-                checked: this.state.songOption5,
-                handleChange: () => {},
-              }
-            },
-            {
-              label: 'Chord',
-              handleCallback: () => this.setState({ songOption6: !this.state.songOption6 }),
-              toggle: {
-                checked: this.state.songOption6,
-                handleChange: () => {},
-              }
-            },
-            {
-              label: 'Progression',
-              handleCallback: () => this.setState({ songOption7: !this.state.songOption7 }),
-              toggle: {
-                checked: this.state.songOption7,
-                handleChange: () => {},
-              }
-            },
-            {
-              label: 'Tone',
-              handleCallback: () => this.setState({ songOption8: !this.state.songOption8 }),
-              toggle: {
-                checked: this.state.songOption8,
-                handleChange: () => {},
-              }
-            },
-            {
-              label: 'Texture',
-              handleCallback: () => this.setState({ songOption9: !this.state.songOption9 }),
-              toggle: {
-                checked: this.state.songOption9,
-                handleChange: () => {},
-              }
-            },
-            {
-              label: 'Form',
-              handleCallback: () => this.setState({ songOption10: !this.state.songOption10 }),
-              toggle: {
-                checked: this.state.songOption10,
-                handleChange: () => {},
-              }
-            },
-          ]}
-        />
-      </div>
-    );
-  }
-};<MenusExample />
-```
-
-Examples with no caret
-```js
-const Cog = require('../icon/Cog').default;
-<div className="flex flex-row justify-between">
-  <div className="ma3">
-    <ActionMenu
-      icon={<Cog color="currentColor" size={13} />}
-      buttonProps={{
-        size: 'small',
-        variation: 'secondary',
-      }}
-      label="Settings"
-      showCaretIcon={false}
-      align="left"
-      boxWidth="100%"
-      options={[
-        {
-          label: 'Open pod doors, HAL',
-          handleCallback: () => alert('I’m sorry, Dave. I’m afraid I can’t do that.')
-        },
-        {
-          label: 'Have you heard about the word?',
-          handleCallback: () => alert('sure, everybody knows that the bird is the word...')
-        },
-        {
-          label: 'Hey look',
-          handleCallback: () => alert('Listen!')
-        },
-        {
-          label: 'Quit now and cake will be served',
-          handleCallback: () => alert('The cake is a lie')
-        },
-      ]}
-    />
-  </div>
-  <div className="ma3">
-    <ActionMenu
-      icon={<Cog color="currentColor" size={13} />}
-      buttonProps={{
-        size: 'small',
-        variation: 'secondary',
-        icon: true,
-      }}
-      showCaretIcon={false}
-      boxWidth="100%"
-      options={[
-        {
-          label: 'Open pod doors, HAL',
-          handleCallback: () => alert('I’m sorry, Dave. I’m afraid I can’t do that.')
-        },
-        {
-          label: 'Have you heard about the word?',
-          handleCallback: () => alert('sure, everybody knows that the bird is the word...')
-        },
-        {
-          label: 'Hey look',
-          handleCallback: () => alert('Listen!')
-        },
-        {
-          label: 'Quit now and cake will be served',
-          handleCallback: () => alert('The cake is a lie')
-        },
-      ]}
-    />
-  </div>
-</div>
-```
-
-Simple icon right aligned
 ```js
 const OptionsDots = require('../icon/OptionsDots').default;
-<div className="ma3">
-  <ActionMenu
-    isSimpleIcon
-    shouldCloseOnClick
-    icon={<OptionsDots />}
-    showCaretIcon={false}
-    buttonProps={{
-      size: 'small',
-      variation: 'tertiary',
-      icon: true,
-    }}
-    boxWidth="100%"
-    options={[
-      {
-        label: 'Remove something',
-        isDangerous: true, // for options that perform dangerous actions like deleting.
-        handleCallback: () => alert('you are removing something important')
-      },
-      {
-        label: 'Make some action',
-        handleCallback: () => alert('act!')
-      },
-      {
-        label: 'Configurations',
-        handleCallback: () => alert('config!')
-      },
-    ]}
-  />
+const Cog = require('../icon/Cog').default;
+
+const options = [
+  {
+    label: 'Open pod doors, HAL',
+    handleCallback: () => alert('I’m sorry, Dave. I’m afraid I can’t do that.')
+  },
+  {
+    label: 'Have you heard about the word?',
+    handleCallback: () => alert('sure, everybody knows that the bird is the word...')
+  },
+  {
+    label: 'Hey look',
+    handleCallback: () => alert('Listen!')
+  },
+  {
+    label: 'Quit now and cake will be served',
+    isDangerous: 'true',
+    handleCallback: () => alert('The cake is a lie')
+  },
+];
+
+<div className="flex">
+  <div className="flex flex-column">
+    <div className="ma3">
+      <ActionMenu
+        icon={<Cog color="currentColor"/>}
+        buttonProps={{
+          variation: 'primary',
+        }}
+        label="Settings"
+        options={options}
+      />
+    </div>
+    <div className="ma3">
+      <ActionMenu
+        icon={<Cog color="currentColor"/>}
+        buttonProps={{
+          variation: 'secondary',
+        }}
+        label="Settings"
+        options={options}
+      />
+    </div>
+    <div className="ma3">
+      <ActionMenu
+        icon={<Cog color="currentColor"/>}
+        buttonProps={{
+          variation: 'tertiary',
+        }}
+        label="Settings"
+        options={options}
+      />
+    </div>
+  </div>
+  <div className="flex flex-column">
+    <div className="ma3">
+      <ActionMenu
+        label="Actions"
+        icon={<OptionsDots color="currentColor"/>}
+        hideCaretIcon
+        buttonProps={{
+          variation: 'primary',
+          icon: true
+        }}
+        options={options}
+      />
+    </div>
+    <div className="ma3">
+      <ActionMenu
+        label="Actions"
+        icon={<OptionsDots />}
+        hideCaretIcon
+        buttonProps={{
+          variation: 'secondary',
+          icon: true
+        }}
+        options={options}
+      />
+    </div>
+    <div className="ma3">
+      <ActionMenu
+        label="Actions"
+        icon={<OptionsDots />}
+        hideCaretIcon
+        buttonProps={{
+          variation: 'tertiary',
+          icon: true
+        }}
+        options={options}
+      />
+    </div>
+  </div>
+</div>
+
+```
+
+Menu Alignment
+
+```js
+const options = [
+  {
+    label: 'Open pod doors, HAL',
+    handleCallback: () => alert('I’m sorry, Dave. I’m afraid I can’t do that.')
+  },
+  {
+    label: 'Have you heard about the word?',
+    handleCallback: () => alert('sure, everybody knows that the bird is the word...')
+  },
+  {
+    label: 'Hey look',
+    handleCallback: () => alert('Listen!')
+  },
+  {
+    label: 'Quit now and cake will be served',
+    isDangerous: 'true',
+    handleCallback: () => alert('The cake is a lie')
+  },
+];
+
+<div className="flex flex-column items-center">
+  <div className="ma3">
+    <ActionMenu
+      label="left-aligned"
+      align="left"
+      buttonProps={{
+        variation: 'primary',
+      }}
+      options={options}
+    />
+  </div>
+  <div className="ma3">
+    <ActionMenu
+      label="right-aligned"
+      align="right"
+      buttonProps={{
+        variation: 'primary',
+      }}
+      options={options}
+    />
+  </div>
 </div>
 ```

--- a/react/components/ActionMenu/index.js
+++ b/react/components/ActionMenu/index.js
@@ -1,9 +1,8 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 import Button from '../Button'
 import IconCaretDown from '../icon/CaretDown'
-import IconCaretUp from '../icon/CaretUp'
 import Menu from './Menu'
 
 class ActionMenu extends Component {
@@ -41,59 +40,46 @@ class ActionMenu extends Component {
       icon,
       label,
       options,
-      boxWidth,
+      menuWidth,
       align,
       buttonProps,
-      showCaretIcon,
+      hideCaretIcon,
       shouldCloseOnClick,
     } = this.props
 
     const { isBoxOpen } = this.state
 
-    const iconMenu = icon && <div onClick={this.handleClick}>{icon}</div>
-
-    const iconCaret = isBoxOpen ? (
-      <IconCaretUp size={13} color="currentColor" />
-    ) : (
-      <IconCaretDown size={13} color="currentColor" />
-    )
+    const iconCaret = <IconCaretDown size={12} color="currentColor" />
 
     const buttonMenu = (
       <Button {...buttonProps} onClick={this.handleClick}>
         <span className="flex align-baseline items-center">
           {icon && (
-            <div className={`pt2 self-center ${showCaretIcon ? 'mr2' : ''}`}>
+            <div className={`pt2 self-center ${hideCaretIcon ? '' : 'mr2'}`}>
               {icon}
             </div>
           )}
 
           {label && (
-            <span className={`${showCaretIcon ? 'mr3' : ''}`}>{label}</span>
+            <span className={`${hideCaretIcon ? '' : 'mr3'}`}>{label}</span>
           )}
 
-          {showCaretIcon && iconCaret}
+          {!hideCaretIcon && <span>{iconCaret}</span>}
         </span>
       </Button>
     )
 
     return (
-      <Fragment>
-        <div ref={this.menuBtnRef} className="relative pointer">
-          <div
-            className={`flex ${
-              align === 'left' ? 'justify-start' : 'justify-end'
-            }`}>
-            {!buttonProps ? iconMenu : buttonMenu}
-          </div>
-          <Menu
-            isOpen={isBoxOpen}
-            align={align}
-            boxWidth={boxWidth}
-            options={options}
-            onMenuClose={shouldCloseOnClick ? this.handleClick : null}
-          />
-        </div>
-      </Fragment>
+      <div ref={this.menuBtnRef}>
+        {buttonMenu}
+        <Menu
+          isOpen={isBoxOpen}
+          align={align}
+          menuWidth={menuWidth}
+          options={options}
+          onMenuClose={shouldCloseOnClick ? this.handleClick : null}
+        />
+      </div>
     )
   }
 }
@@ -101,25 +87,26 @@ class ActionMenu extends Component {
 ActionMenu.defaultProps = {
   options: [],
   align: 'right',
-  showCaretIcon: true,
+  hideCaretIcon: false,
+  menuWidth: '100%',
+  shouldCloseOnClick: true,
 }
 
 ActionMenu.propTypes = {
-  /** ActionMenu alignment (default is right) */
+  /** Menu alignment in relation to the button*/
   align: PropTypes.oneOf(['right', 'left']),
-  /** if should close the menu after clicking an option */
+  /** If should close the menu after clicking an option */
   shouldCloseOnClick: PropTypes.bool,
-  /** respecting button props contract.
-   * If empty, will be treated as a simple icon, no button. */
+  /** Respecting button props contract. */
   buttonProps: PropTypes.shape({ ...Button.propTypes }),
-  /** ActionMenu Button icon */
+  /** Button icon */
   icon: PropTypes.element,
-  /** ActionMenu Button label */
-  label: PropTypes.string.isRequired,
-  /** If should show Caret icon */
-  showCaretIcon: PropTypes.bool,
-  /** Menu width (default is 292px) */
-  boxWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Button text label */
+  label: PropTypes.string,
+  /** Hide the automatic caret icon */
+  hideCaretIcon: PropTypes.bool,
+  /** Menu width*/
+  menuWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Menu options */
   options: PropTypes.arrayOf(
     PropTypes.shape({


### PR DESCRIPTION
I was checking the current state of the ActionMenu development and implemented some suggested changes.

- Removes the "container" from the Menu, which was trying to be opinionated about the button alignment in the layout. I think it doesn't make sense, the button alignment should be handled by its parent.
- The caret icon is now opt-out instead of opt-in. Renamed prop to `hideCaretIcon`, with default value equal to `false`.
- Remove `shouldCloseOnClick` prop, making it the default behavior.
- Rename prop `boxWidth` to `menuWidth`, to avoid confusing with our Box component. Also made it default to `100%`.
- Fix vertical alignment of caret icon.
- Improves documentation & examples to present more possible options and avoid undesiderable usage.

![image](https://user-images.githubusercontent.com/467471/50600806-78bdca80-0e99-11e9-8074-13393c60b7ce.png)
