### PR TITLE
Add minWidth prop to column schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Table** `minWidth` key for schema
+
 ## [8.16.0] - 2019-01-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.17.0] - 2019-02-01
+
 ### Added
 
 - **Table** `minWidth` key for schema

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.16.0",
+  "version": "8.17.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.16.0",
+  "version": "8.17.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -3,6 +3,7 @@
 Our Table was built to be highly composable and flexible. All parts are optional, and you can compose your table with any other Styleguide components. A Table may be used from a small table with numbers to full CRUD-like functionalities, from a small data display to the main screen of a complex module. All parts are plug'n'play parts that you can turn on and off to match your needs.
 
 ### 👍 Dos
+
 - Try to support as many of the Table features as you can in your system - if we designed there it's because it's highly recommended to have.
 - Provide as many domain-specific actions as you want in the dropdown slot.
 - Line actions: should be mostly for actions that are resolved in the same screen, or if it's was identified to be a very recurrent action.
@@ -14,28 +15,33 @@ Our Table was built to be highly composable and flexible. All parts are optional
 Simple (high density)
 
 ```js
-const sampleData = require('./sampleData').default;
-const itemsCopy = sampleData.items.slice().reverse().splice(15);
+const sampleData = require('./sampleData').default
+const itemsCopy = sampleData.items
+  .slice()
+  .reverse()
+  .splice(15)
 const defaultSchema = {
-    properties: {
-      name: {
-        type: 'string',
-        title: 'Name',
-        width: 300,
-      },
-      email: {
-        type: 'string',
-        title: 'Email',
-        width: 350, // default is 200px
-      },
-      number: {
-        type: 'number',
-        title: 'Number',
-      },
+  properties: {
+    name: {
+      type: 'string',
+      title: 'Name',
+      width: 300,
     },
-  };
+    email: {
+      type: 'string',
+      title: 'Email',
+      minWidth: 350,
+    },
+    number: {
+      type: 'number',
+      title: 'Number',
+      // default is 200px
+      minWidth: 100,
+    },
+  },
+}
 
-<div>
+;<div>
   <div className="mb5">
     <Table
       fullWidth
@@ -59,9 +65,12 @@ const defaultSchema = {
 Custom cell components / sortable columns
 
 ```js
-const sampleData = require('./sampleData').default;
-const itemsCopy = sampleData.items.slice().reverse().splice(20);
-const Tag = require('../Tag').default;
+const sampleData = require('./sampleData').default
+const itemsCopy = sampleData.items
+  .slice()
+  .reverse()
+  .splice(20)
+const Tag = require('../Tag').default
 class CustomTableExample extends React.Component {
   constructor() {
     super()
@@ -70,7 +79,7 @@ class CustomTableExample extends React.Component {
       dataSort: {
         sortedBy: null,
         sortOrder: null,
-      }
+      },
     }
 
     this.sortNameAlphapeticallyASC = this.sortNameAlphapeticallyASC.bind(this)
@@ -78,22 +87,27 @@ class CustomTableExample extends React.Component {
     this.handleSort = this.handleSort.bind(this)
   }
 
-  sortNameAlphapeticallyASC(a, b) { return (a.name < b.name) ? -1 : (a.name > b.name) ? 1 : 0 }
-  sortNameAlphapeticallyDESC(a, b) { return (a.name < b.name) ? 1 : (a.name > b.name) ? -1 : 0 }
+  sortNameAlphapeticallyASC(a, b) {
+    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+  }
+  sortNameAlphapeticallyDESC(a, b) {
+    return a.name < b.name ? 1 : a.name > b.name ? -1 : 0
+  }
 
   handleSort({ sortOrder, sortedBy }) {
-     // I'll just handle sort by 'name', but I could handle multiple properties
+    // I'll just handle sort by 'name', but I could handle multiple properties
     if (sortedBy === 'name') {
-      const orderedItems = sortOrder === 'ASC'
-        ? itemsCopy.slice().sort(this.sortNameAlphapeticallyASC)
-        : itemsCopy.slice().sort(this.sortNameAlphapeticallyDESC)
+      const orderedItems =
+        sortOrder === 'ASC'
+          ? itemsCopy.slice().sort(this.sortNameAlphapeticallyASC)
+          : itemsCopy.slice().sort(this.sortNameAlphapeticallyDESC)
       // the above const could come out of an API call to sort items for example
       this.setState({
         orderedItems,
         dataSort: {
           sortedBy,
           sortOrder,
-        }
+        },
       })
     }
   }
@@ -120,15 +134,20 @@ class CustomTableExample extends React.Component {
           // you can customize cell component render (also header component with headerRenderer)
           cellRenderer: ({ cellData }) => {
             return (
-              <Tag bgColor={cellData.color} color="#fff" onClick={(e) => {
+              <Tag
+                bgColor={cellData.color}
+                color="#fff"
+                onClick={e => {
                   // if you use cellRender click event AND onRowclick event
                   // you should stop the event propagation so the cell click fires and row click don't
                   e.stopPropagation()
-                  alert(`you just clicked a cell to remove ${cellData.label}, HEX: ${cellData.color}`)
+                  alert(
+                    `you just clicked a cell to remove ${
+                      cellData.label
+                    }, HEX: ${cellData.color}`
+                  )
                 }}>
-                <span className="nowrap">
-                  {cellData.label}
-                </span>
+                <span className="nowrap">{cellData.label}</span>
               </Tag>
             )
           },
@@ -136,7 +155,7 @@ class CustomTableExample extends React.Component {
           // headerRenderer: ({ columnIndex, key, rowIndex, style, title })
         },
       },
-    };
+    }
 
     return (
       <div>
@@ -156,9 +175,10 @@ class CustomTableExample extends React.Component {
           />
         </div>
       </div>
-    );
+    )
   }
-};<CustomTableExample />
+}
+;<CustomTableExample />
 ```
 
 With Toolbar and Pagination
@@ -196,7 +216,7 @@ class ResourceListExample extends React.Component {
   handleNextClick() {
     const newPage = this.state.currentPage + 1
     const itemFrom = this.state.currentItemTo + 1
-    const itemTo = tableLength * (newPage)
+    const itemTo = tableLength * newPage
     const data = sampleData.items.slice(itemFrom - 1, itemTo)
     this.goToPage(newPage, itemFrom, itemTo, data)
   }
@@ -259,9 +279,7 @@ class ResourceListExample extends React.Component {
       cellRenderer: ({ cellData }) => {
         return (
           <Tag bgColor={cellData.color} color="#fff">
-            <span className="nowrap">
-              {cellData.label}
-            </span>
+            <span className="nowrap">{cellData.label}</span>
           </Tag>
         )
       },
@@ -292,7 +310,7 @@ class ResourceListExample extends React.Component {
         color5: this.customColorTagProperty(5),
         color6: this.customColorTagProperty(6),
       },
-    };
+    }
 
     return (
       <Table
@@ -332,21 +350,21 @@ class ResourceListExample extends React.Component {
             actions: [
               {
                 label: 'alert 1',
-                handleCallback: () => alert('1')
+                handleCallback: () => alert('1'),
               },
               {
                 label: 'alert 2',
-                handleCallback: () => alert('2')
+                handleCallback: () => alert('2'),
               },
               {
                 label: 'alert 3',
-                handleCallback: () => alert('3')
+                handleCallback: () => alert('3'),
               },
             ],
           },
           newLine: {
             label: 'New',
-            handleCallback: () => alert('handle new line callback')
+            handleCallback: () => alert('handle new line callback'),
           },
         }}
         pagination={{

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -54,8 +54,8 @@ class SimpleTable extends Component {
     return col.width
       ? col.width
       : fullWidth
-        ? Math.max(col.minWidth || 100, fullWidthColWidth)
-        : DEFAULT_COLUMN_WIDTH
+      ? Math.max(col.minWidth || 100, fullWidthColWidth)
+      : DEFAULT_COLUMN_WIDTH
   }
 
   render() {

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -43,6 +43,21 @@ class SimpleTable extends Component {
     }
   }
 
+  calculateColWidth = (
+    schema,
+    properties,
+    index,
+    fullWidth,
+    fullWidthColWidth
+  ) => {
+    const col = schema.properties[properties[index]]
+    return col.width
+      ? col.width
+      : fullWidth
+        ? Math.max(col.minWidth || 100, fullWidthColWidth)
+        : DEFAULT_COLUMN_WIDTH
+  }
+
   render() {
     const {
       schema,
@@ -76,8 +91,24 @@ class SimpleTable extends Component {
               {({ width }) => {
                 // updateKey forces grid to rerender when density and window's width change
                 const updateKey = `vtex-table__${rowHeight}--${updateTableKey}--${width}`
+
+                const colsWidth = Object.keys(schema.properties).reduce(
+                  (acc, curr) => {
+                    const col = schema.properties[curr]
+                    return acc + (col.width ? col.width : 0)
+                  },
+                  0
+                )
+
+                const colsWithoutWidth = Object.keys(schema.properties).filter(
+                  curr => {
+                    const col = schema.properties[curr]
+                    return !col.width
+                  }
+                )
+
                 const fullWidthColWidth =
-                  width / Object.keys(schema.properties).length
+                  (width - colsWidth) / colsWithoutWidth.length
 
                 return (
                   <MultiGrid
@@ -101,10 +132,13 @@ class SimpleTable extends Component {
                     fixedColumnCount={fixFirstColumn ? 1 : 0}
                     columnCount={properties.length}
                     columnWidth={({ index }) =>
-                      fullWidth
-                        ? fullWidthColWidth
-                        : schema.properties[properties[index]].width ||
-                          DEFAULT_COLUMN_WIDTH
+                      this.calculateColWidth(
+                        schema,
+                        properties,
+                        index,
+                        fullWidth,
+                        fullWidthColWidth
+                      )
                     }
                     enableFixedColumnScroll
                     overscanColumnCount={0}
@@ -178,8 +212,14 @@ class SimpleTable extends Component {
                           key={key}
                           style={{
                             ...style,
-                            height,
-                            width,
+                            height: rowHeight,
+                            width: this.calculateColWidth(
+                              schema,
+                              properties,
+                              columnIndex,
+                              fullWidth,
+                              fullWidthColWidth
+                            ),
                           }}
                           className={`flex items-center w-100 h-100 truncate ph4 ${
                             disableHeader && rowIndex === 0 ? 'bt' : ''

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -201,12 +201,6 @@ class SimpleTable extends Component {
                         items[disableHeader ? rowIndex : rowIndex - 1]
                       const cellData = rowData[property]
 
-                      const height = rowHeight
-                      const width = fullWidth
-                        ? fullWidthColWidth
-                        : schema.properties[properties[columnIndex]].width ||
-                          DEFAULT_COLUMN_WIDTH
-
                       return (
                         <div
                           key={key}


### PR DESCRIPTION
When using a table with fullWidth on, the schema property **width** is not respected.

This adds a new schema property named **minWidth** that controls the minimum desired width for a column. 

Now, the **width** property will always be respected. If there is no available space remaining (after the **width** subtraction) for the column it will respect its **minWidth** and create a horizontal scrolling.

### Screenshot of the problem

![image](https://user-images.githubusercontent.com/5971264/50974869-5ba97d00-14d3-11e9-90d5-1dd90ae07be7.png)

As you can see in the image above, the columns Name and Email have the **width** property but it's not being respected in the UI (260px).