### PR TITLE
Hotfix/table toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.11.3] - 2019-01-17
+
 ### Fixed
 
 - **Button** when using block prop and small size, button height was smaller than it was supposed to be.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- **Button** when using block prop and small size, button height was samaller than it was supposed to be.
+- **Button** when using block prop and small size, button height was smaller than it was supposed to be.
 - **Table** Align toolbar buttons and use ButtonWithIcon instead of button.
 
 ## [8.11.2] - 2019-01-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+
+- **Button** when using block prop and small size, button height was samaller than it was supposed to be.
+- **Table** Align toolbar buttons and use ButtonWithIcon instead of button.
+
 ## [8.11.2] - 2019-01-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fix
+### Fixed
 
 - **Button** when using block prop and small size, button height was samaller than it was supposed to be.
 - **Table** Align toolbar buttons and use ButtonWithIcon instead of button.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **Button** when using block prop and small size, button height was smaller than it was supposed to be.
-- **Table** Align toolbar buttons and use ButtonWithIcon instead of button.
+- **Table** Align toolbar buttons and use ButtonWithIcon instead of Button.
 
 ## [8.11.2] - 2019-01-16
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.11.2",
+  "version": "8.11.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.11.2",
+  "version": "8.11.3",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -123,7 +123,7 @@ class Button extends Component {
     }
 
     if (block) {
-      classes += 'w-100 '
+      classes += 'w-100 h-100 '
     }
 
     return (

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -145,7 +145,7 @@ class Toolbar extends PureComponent {
               <ButtonWithIcon
                 icon={
                   <span className="c-on-base" style={ICON_OPTICAL_COMPENSATION}>
-                    <IconDensity size={14} color="currentColor" />
+                    <IconDensity size={14} />
                   </span>
                 }
                 block
@@ -198,7 +198,7 @@ class Toolbar extends PureComponent {
               <ButtonWithIcon
                 icon={
                   <span className="c-on-base" style={ICON_OPTICAL_COMPENSATION}>
-                    <IconColumns size={15} color="currentColor" />
+                    <IconColumns size={15} />
                   </span>
                 }
                 block
@@ -262,7 +262,7 @@ class Toolbar extends PureComponent {
             <ButtonWithIcon
               icon={
                 <span className="c-on-base">
-                  <IconDownload size={15} color="currentColor" />
+                  <IconDownload size={15} />
                 </span>
               }
               disabled={loading}
@@ -276,7 +276,7 @@ class Toolbar extends PureComponent {
             <ButtonWithIcon
               icon={
                 <span className="c-on-base" style={ICON_OPTICAL_COMPENSATION}>
-                  <IconUpload size={14} color="currentColor" />
+                  <IconUpload size={14} />
                 </span>
               }
               disabled={loading}
@@ -335,7 +335,7 @@ class Toolbar extends PureComponent {
           )}
           {isNewLineVisible && (
             <ButtonWithIcon
-              icon={<IconPlus solid size={16} color="currentColor" />}
+              icon={<IconPlus solid size={16} />}
               disabled={loading}
               variation="primary"
               size="small"

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -18,6 +18,9 @@ const EXTRA_ACTIONS_BOX_WIDTH = 199
 const BOX_SHADOW_STYLE = { boxShadow: '0px 1px 18px rgba(0, 0, 0, 0.14)' }
 const DENSITY_OPTIONS = ['low', 'medium', 'high']
 const ICON_OPTICAL_COMPENSATION = { marginTop: '1.5px' }
+const LIGHT_ICON_SIZE = 16
+const MEDIUM_ICON_SIZE = 14
+const HEAVY_ICON_SIZE = 13
 
 class Toolbar extends PureComponent {
   constructor(props) {
@@ -145,7 +148,7 @@ class Toolbar extends PureComponent {
               <ButtonWithIcon
                 icon={
                   <span className="c-on-base" style={ICON_OPTICAL_COMPENSATION}>
-                    <IconDensity size={14} />
+                    <IconDensity size={MEDIUM_ICON_SIZE} />
                   </span>
                 }
                 block
@@ -198,7 +201,7 @@ class Toolbar extends PureComponent {
               <ButtonWithIcon
                 icon={
                   <span className="c-on-base" style={ICON_OPTICAL_COMPENSATION}>
-                    <IconColumns size={15} />
+                    <IconColumns size={MEDIUM_ICON_SIZE} />
                   </span>
                 }
                 block
@@ -262,7 +265,7 @@ class Toolbar extends PureComponent {
             <ButtonWithIcon
               icon={
                 <span className="c-on-base">
-                  <IconDownload size={15} />
+                  <IconDownload size={MEDIUM_ICON_SIZE} />
                 </span>
               }
               disabled={loading}
@@ -276,7 +279,7 @@ class Toolbar extends PureComponent {
             <ButtonWithIcon
               icon={
                 <span className="c-on-base" style={ICON_OPTICAL_COMPENSATION}>
-                  <IconUpload size={14} />
+                  <IconUpload size={HEAVY_ICON_SIZE} />
                 </span>
               }
               disabled={loading}
@@ -294,7 +297,7 @@ class Toolbar extends PureComponent {
               <ButtonWithIcon
                 icon={
                   <span className="c-on-base">
-                    <IconCaretDown height={13} />
+                    <IconCaretDown height={HEAVY_ICON_SIZE} />
                   </span>
                 }
                 iconPosition="right"
@@ -335,7 +338,7 @@ class Toolbar extends PureComponent {
           )}
           {isNewLineVisible && (
             <ButtonWithIcon
-              icon={<IconPlus solid size={16} />}
+              icon={<IconPlus solid size={LIGHT_ICON_SIZE} />}
               disabled={loading}
               variation="primary"
               size="small"

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import InputSearch from '../InputSearch'
 import Button from '../Button'
+import ButtonWithIcon from '../ButtonWithIcon'
 import Toggle from '../Toggle'
 import IconCaretDown from '../icon/CaretDown'
 import IconColumns from '../icon/Columns'
@@ -16,6 +17,7 @@ const FIELDS_BOX_WIDTH = 292
 const EXTRA_ACTIONS_BOX_WIDTH = 199
 const BOX_SHADOW_STYLE = { boxShadow: '0px 1px 18px rgba(0, 0, 0, 0.14)' }
 const DENSITY_OPTIONS = ['low', 'medium', 'high']
+const ICON_OPTICAL_COMPENSATION = { marginTop: '1.5px' }
 
 class Toolbar extends PureComponent {
   constructor(props) {
@@ -140,18 +142,19 @@ class Toolbar extends PureComponent {
               id="toggleDensity"
               ref={this.densityBtnRef}
               className="relative">
-              <Button
+              <ButtonWithIcon
+                icon={
+                  <span className="c-on-base" style={ICON_OPTICAL_COMPENSATION}>
+                    <IconDensity size={14} color="currentColor" />
+                  </span>
+                }
+                block
                 disabled={loading}
                 variation="tertiary"
                 size="small"
                 onClick={() => this.handleToggleBox('isDensityBoxVisible')}>
-                <span className="flex align-baseline items-center c-on-base">
-                  <span className="mr3">
-                    <IconDensity color="currentColor" />
-                  </span>
-                  {density.buttonLabel}
-                </span>
-              </Button>
+                <span className="c-on-base">{density.buttonLabel}</span>
+              </ButtonWithIcon>
               {isDensityBoxVisible && (
                 <div
                   className={`absolute ${
@@ -192,18 +195,19 @@ class Toolbar extends PureComponent {
               id="toggleFieldsBtn"
               ref={this.fieldsBtnRef}
               className="relative">
-              <Button
+              <ButtonWithIcon
+                icon={
+                  <span className="c-on-base" style={ICON_OPTICAL_COMPENSATION}>
+                    <IconColumns size={15} color="currentColor" />
+                  </span>
+                }
+                block
                 disabled={loading}
                 variation="tertiary"
                 size="small"
                 onClick={() => this.handleToggleBox('isFieldsBoxVisible')}>
-                <span className="flex align-baseline c-on-base">
-                  <span className="mr3">
-                    <IconColumns color="currentColor" />
-                  </span>
-                  {fields.label}
-                </span>
-              </Button>
+                <span className="c-on-base">{fields.label}</span>
+              </ButtonWithIcon>
               {isFieldsBoxVisible && (
                 <div
                   className={`absolute ${
@@ -255,50 +259,54 @@ class Toolbar extends PureComponent {
             </div>
           )}
           {isDownloadVisible && (
-            <Button
+            <ButtonWithIcon
+              icon={
+                <span className="c-on-base">
+                  <IconDownload size={15} color="currentColor" />
+                </span>
+              }
               disabled={loading}
               variation="tertiary"
               size="small"
               onClick={download.handleCallback}>
-              <span className="flex align-baseline c-on-base">
-                <span className="mr3">
-                  <IconDownload color="currentColor" />
-                </span>
-                {download.label}
-              </span>
-            </Button>
+              <span className="c-on-base">{download.label}</span>
+            </ButtonWithIcon>
           )}
           {isUploadVisible && (
-            <Button
+            <ButtonWithIcon
+              icon={
+                <span className="c-on-base" style={ICON_OPTICAL_COMPENSATION}>
+                  <IconUpload size={14} color="currentColor" />
+                </span>
+              }
               disabled={loading}
               variation="tertiary"
               size="small"
               onClick={upload.handleCallback}>
-              <span className="flex align-baseline c-on-base">
-                <span className="mr3">
-                  <IconUpload color="currentColor" />
-                </span>
-                {upload.label}
-              </span>
-            </Button>
+              <span className="c-on-base">{upload.label}</span>
+            </ButtonWithIcon>
           )}
           {isExtraActionsVisible && (
             <div
               id="toggleExtraActionsBtn"
               ref={this.extraActionsBtnRef}
               className="relative">
-              <Button
+              <ButtonWithIcon
+                icon={
+                  <span className="c-on-base">
+                    <IconCaretDown height={13} />
+                  </span>
+                }
+                iconPosition="right"
                 disabled={loading}
                 variation="tertiary"
+                block
                 size="small"
                 onClick={() =>
                   this.handleToggleBox('isExtraActionsBoxVisible')
                 }>
-                <span className="flex align-baseline items-center c-on-base">
-                  <span className="mr3">{extraActions.label}</span>
-                  <IconCaretDown height={13} color="currentColor" />
-                </span>
-              </Button>
+                <span className="c-on-base">{extraActions.label}</span>
+              </ButtonWithIcon>
               {isExtraActionsBoxVisible && (
                 <div
                   className={`absolute ${
@@ -326,18 +334,14 @@ class Toolbar extends PureComponent {
             </div>
           )}
           {isNewLineVisible && (
-            <Button
+            <ButtonWithIcon
+              icon={<IconPlus solid size={16} color="currentColor" />}
               disabled={loading}
               variation="primary"
               size="small"
               onClick={newLine.handleCallback}>
-              <span className="flex align-baseline">
-                <span className="mr2">
-                  <IconPlus solid size={16} color="currentColor" />
-                </span>
-                {newLine.label}
-              </span>
-            </Button>
+              {newLine.label}
+            </ButtonWithIcon>
           )}
         </div>
       </div>


### PR DESCRIPTION
# What does this PR do?

 - fix buttonWithIcon height when size is small and block prop is used
 - swap table toolbar buttons for buttonWithIcon
 - align and optically compensate buttons in table's toolbar