### PR TITLE
Make button label fill view if block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **Button** add w-100 to label class if block mode
 
 ## [9.0.0] - 2019-01-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [9.0.1] - 2019-01-24
 ### Fixed
 - **Button** add w-100 to label class if block mode
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -124,6 +124,7 @@ class Button extends Component {
 
     if (block) {
       classes += 'w-100 h-100 '
+      labelClasses += 'w-100 '
     }
 
     return (


### PR DESCRIPTION
Problem:
<img width="557" alt="screen shot 2019-01-24 at 2 17 22 pm" src="https://user-images.githubusercontent.com/4925068/51692710-a30c2f00-1fe4-11e9-8b1b-e8078d4802ab.png">

With this fix:
<img width="512" alt="screen shot 2019-01-24 at 2 26 16 pm" src="https://user-images.githubusercontent.com/4925068/51692716-a9021000-1fe4-11e9-8011-161763479ccc.png">

If the block prop is true, make the label have the width of parent view. Already has a ph to not touch the border