### PR TITLE
Currency Input improvements

### DIFF
--- a/react/components/InputCurrency/README.md
+++ b/react/components/InputCurrency/README.md
@@ -1,4 +1,15 @@
-#### InputCurrency is designed to be used when working with monetary values.
+|Prop name    |Type   |Default|Description                                    |
+|---          |---    |---        |---                                            |
+|currencyCode |string |_Required_ |Currency code in ISO 4217 ('USD', 'BRL', etc.) |
+|defaultValue |number |           |Spec attribute                                 |
+|locale       |string |_Required_ |Locale ISO string ('en-US', 'pt-BR', etc.)     |
+|onChange     |func   |           |onChange event                                 |
+|onClear      |func   |           |onClear event                                  |
+|size         |string |           |Input size                                     |
+|value        |number |           |Spec attribute                                 |
+
+#### InputCurrency lets an user easily enter monetary values. The component understands currency codes and locales, so it can automatically format the input with the correct combination of commas, periods, etc.
+
 
 Sizes
 

--- a/react/components/InputCurrency/index.js
+++ b/react/components/InputCurrency/index.js
@@ -18,8 +18,8 @@ const BaseInput = props => {
 }
 
 BaseInput.propTypes = {
-  inputPrefix: PropTypes.string.isRequired,
-  inputSuffix: PropTypes.string.isRequired,
+  inputPrefix: PropTypes.string,
+  inputSuffix: PropTypes.string,
 }
 
 const baseNumber = 9999999999.9999999999
@@ -80,7 +80,7 @@ InputCurrencyWithRef.propTypes = {
   /** Locale ISO string ('en-US', 'pt-BR', etc.)*/
   locale: PropTypes.string.isRequired,
   /** Currency code in ISO 4217 ('USD', 'BRL', etc.) */
-  currencyCode: PropTypes.string,
+  currencyCode: PropTypes.string.isRequired,
 }
 
 InputCurrency.propTypes = InputCurrencyWithRef.propTypes


### PR DESCRIPTION
- Manually added some prop docs while https://github.com/vtex/styleguide/issues/515 isn't fixed.
- Makes `currencyCode` required.
- Remove required statement from `BaseInput` props (they're actually mutually exclusive).

![image](https://user-images.githubusercontent.com/467471/51913526-d15f8500-23bd-11e9-8899-270b1439ba5c.png)
