### PR TITLE
Fix onChange callback to use the float value and not the formatted value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **InputCurrency** `onChange` callback was using the formatted value instead of
+  the actual float value.
+
 ## [8.15.0] - 2019-01-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.15.1] - 2019-01-29
+
 ### Fixed
 
 - **InputCurrency** `onChange` callback was using the formatted value instead of

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.15.0",
+  "version": "8.15.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.15.0",
+  "version": "8.15.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/InputCurrency/index.js
+++ b/react/components/InputCurrency/index.js
@@ -25,8 +25,21 @@ BaseInput.propTypes = {
 const baseNumber = 9999999999.9999999999
 
 class InputCurrency extends Component {
+  handleChange = ({ floatValue }) => {
+    // console.log(floatValue)
+    this.props.onChange &&
+      this.props.onChange({
+        ...event,
+        target: {
+          ...event.target,
+          value: floatValue,
+        },
+      })
+  }
+
   render() {
-    const { locale, currencyCode } = this.props
+    // eslint-disable-next-line no-unused-vars
+    const { locale, currencyCode, onChange, ...props } = this.props
 
     const formatter = new Intl.NumberFormat(locale, {
       style: 'currency',
@@ -51,13 +64,14 @@ class InputCurrency extends Component {
     return (
       <div>
         <NumberFormat
-          {...this.props}
+          {...props}
           inputPrefix={prefix ? currencySymbol : null}
           inputSuffix={prefix ? null : currencySymbol}
           decimalSeparator={decimalSeparator || false}
           decimalScale={fraction ? fraction.length : 0}
           fixedDecimalScale={!!decimalSeparator}
           thousandSeparator={thousandSeparator}
+          onValueChange={this.handleChange}
           customInput={BaseInput}
         />
       </div>

--- a/react/components/InputCurrency/index.js
+++ b/react/components/InputCurrency/index.js
@@ -26,7 +26,6 @@ const baseNumber = 9999999999.9999999999
 
 class InputCurrency extends Component {
   handleChange = ({ floatValue }) => {
-    // console.log(floatValue)
     this.props.onChange &&
       this.props.onChange({
         ...event,


### PR DESCRIPTION
The **InputCurrency** `onChange`callback was using the formatted value. This PR changes the callback to use the float value.