### PR TITLE
Make PageLayout occupy all available horizontal space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **EXPERIMENTAL_Select** fixed lost of focus behaviour when props were updated.
+- **PageLayout** now occupies all available width (even without using fullWidth)
 
 ## [8.17.2] - 2019-02-01
 

--- a/react/components/Layout/README.md
+++ b/react/components/Layout/README.md
@@ -11,7 +11,7 @@ The centered version has a max width. This layout version will keep the page con
 ```js
 <Layout pageHeader={<PageHeader title="Page title centered" />}>
   <PageBlock>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada ut neque id pharetra. Suspendisse tortor eros, sagittis at molestie at, semper mollis urna. Sed porta ipsum ac vulputate ultrices. Mauris sed libero quis risus rutrum efficitur in nec justo.
+    <Button>click me</Button>
   </PageBlock>
 </Layout>
 ```

--- a/react/components/Layout/index.js
+++ b/react/components/Layout/index.js
@@ -7,7 +7,7 @@ class Layout extends Component {
 
     return (
       <div className="styleguide__layout flex justify-center pb7 bg-muted-5 min-h-100">
-        <div className={fullWidth ? 'w-100' : 'mw8'}>
+        <div className={`w-100 ${fullWidth && 'mw8'}`}>
           {pageHeader}
           <div className="layout__container ph7-ns">{children}</div>
         </div>

--- a/react/components/Layout/index.js
+++ b/react/components/Layout/index.js
@@ -7,7 +7,7 @@ class Layout extends Component {
 
     return (
       <div className="styleguide__layout flex justify-center pb7 bg-muted-5 min-h-100">
-        <div className={`w-100 ${fullWidth && 'mw8'}`}>
+        <div className={fullWidth ? 'w-100' : 'w-100 mw8'}>
           {pageHeader}
           <div className="layout__container ph7-ns">{children}</div>
         </div>


### PR DESCRIPTION
As discussed in the Styleguide meeting the 17th January.

# Before
![image](https://user-images.githubusercontent.com/467471/52415904-79b4ce00-2acf-11e9-8a82-cdf37056b2ef.png)

# After
![image](https://user-images.githubusercontent.com/467471/52415888-6b66b200-2acf-11e9-80c3-f577e11c4b65.png)
