### PR TITLE
Remove bottom margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- **Checkbox** `margin-bottom`
+
 ## [8.17.3] - 2019-02-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.17.4] - 2019-02-07
+
 ### Removed
 
 - **Checkbox** `margin-bottom`

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.17.3",
+  "version": "8.17.4",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.17.3",
+  "version": "8.17.4",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Checkbox/README.md
+++ b/react/components/Checkbox/README.md
@@ -1,30 +1,34 @@
-#### A Checkbox represents a need for the user to do a choice that is binary, required and independent from other choices. 
+#### A Checkbox represents a need for the user to do a choice that is binary, required and independent from other choices.
 
 ### 👍 Dos
+
 - Initialize it with a default value that makes sense to your needs.
-- Use a text label, which should be intuitive and provide sufficient context for the user take that decision. 
+- Use a text label, which should be intuitive and provide sufficient context for the user take that decision.
 
 ### 👎 Don'ts
+
 - Don't use negative labels because they are harder to interpret.
 - Don't implement an "autosave" behavior: checkboxes should always require the use of a button (like "SAVE" or "OK") to commit the choice.
 
 ### Related components
-- Consider using a <a href="#toggle">Toggle</a> if the choice could be read as "turning something on or off".
 
+- Consider using a <a href="#toggle">Toggle</a> if the choice could be read as "turning something on or off".
 
 Default
 
 ```js
-initialState = { check1: true, check2: false };
-<div>
-  <Checkbox
-    checked={state.check1}
-    id="option-0"
-    label="Option 0"
-    name="default-checkbox-group"
-    onChange={e => setState({ check1: !state.check1 })}
-    value="option-0"
-  />
+initialState = { check1: true, check2: false }
+;<div>
+  <div className="mb3">
+    <Checkbox
+      checked={state.check1}
+      id="option-0"
+      label="Option 0"
+      name="default-checkbox-group"
+      onChange={e => setState({ check1: !state.check1 })}
+      value="option-0"
+    />
+  </div>
   <Checkbox
     checked={state.check2}
     id="option-1"
@@ -32,23 +36,25 @@ initialState = { check1: true, check2: false };
     name="default-checkbox-group"
     onChange={e => setState({ check2: !state.check2 })}
     value="option-1"
-    />
+  />
 </div>
 ```
 
 Disabled
 
 ```js
-initialState = { check1: true, check2: false };
-<div>
-  <Checkbox
-    checked={state.check1}
-    disabled
-    label="Option 0"
-    name="disabled-checkbox-group"
-    onChange={() => {}}
-    value="option-0"
-  />
+initialState = { check1: true, check2: false }
+;<div>
+  <div className="mb3">
+    <Checkbox
+      checked={state.check1}
+      disabled
+      label="Option 0"
+      name="disabled-checkbox-group"
+      onChange={() => {}}
+      value="option-0"
+    />
+  </div>
   <Checkbox
     checked={state.check2}
     disabled
@@ -56,7 +62,6 @@ initialState = { check1: true, check2: false };
     name="disabled-checkbox-group"
     onChange={() => {}}
     value="option-1"
-    />
+  />
 </div>
 ```
-

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -11,7 +11,7 @@ class Checkbox extends PureComponent {
 
     return (
       <div
-        className={classNames('flex items-center mb3 relative', {
+        className={classNames('flex items-center relative', {
           pointer: !disabled,
         })}>
         <div


### PR DESCRIPTION
Proposal: remove the bottom margin of the `Checkbox` element. It should be the responsibility of the app importing it. It also allows to use the element "naked" (ex: within the table to select all rows).