### PR TITLE
Remove isRequired attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **Checkbox** `label` un-require prop
+
 ## [8.17.4] - 2019-02-07
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.17.5] - 2019-02-07
+
 ### Changed
 
 - **Checkbox** `label` un-require prop

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.17.4",
+  "version": "8.17.5",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.17.4",
+  "version": "8.17.5",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import CheckIcon from '../icon/Check'
 
+const OPTICAL_COMPENSATION_WITH_LABEL = -1.5
+const OPTICAL_COMPENSATION_WITHOUT_LABEL = -2
+
 class Checkbox extends PureComponent {
   handleChange = e => !this.props.disabled && this.props.onChange(e)
 
@@ -31,7 +34,12 @@ class Checkbox extends PureComponent {
         />
         <div
           className="absolute w1 h1 flex o-100"
-          style={{ left: 2, top: label ? -1.5 : -2 }}>
+          style={{
+            left: 2,
+            top: label
+              ? OPTICAL_COMPENSATION_WITH_LABEL
+              : OPTICAL_COMPENSATION_WITHOUT_LABEL,
+          }}>
           <div
             className={`absolute top-0 left-0 bottom-0 overflow-hidden ${
               disabled ? 'c-on-disabled' : 'c-on-action-primary'

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -16,12 +16,13 @@ class Checkbox extends PureComponent {
         })}>
         <div
           className={classNames(
-            'h1 w1 relative ba bw1 br1 mr3 flex justify-center items-center',
+            'h1 w1 relative ba bw1 br1 flex justify-center items-center',
             {
               'b--muted-4 pointer': !checked && !disabled,
               'b--disabled bg-muted-5 c-disabled': !checked && disabled,
               'b--action-primary bg-action-primary': checked && !disabled,
               'b--disabled bg-disabled': checked && disabled,
+              mr3: label,
             }
           )}
           style={{
@@ -30,7 +31,7 @@ class Checkbox extends PureComponent {
         />
         <div
           className="absolute w1 h1 flex o-100"
-          style={{ left: 2, top: -1.5 }}>
+          style={{ left: 2, top: label ? -1.5 : -2 }}>
           <div
             className={`absolute top-0 left-0 bottom-0 overflow-hidden ${
               disabled ? 'c-on-disabled' : 'c-on-action-primary'
@@ -56,14 +57,16 @@ class Checkbox extends PureComponent {
           value={value}
           tabIndex={0}
         />
-        <label
-          className={classNames(
-            { 'c-disabled': disabled },
-            { 'c-on-base pointer': !disabled }
-          )}
-          htmlFor={id}>
-          {label}
-        </label>
+        {label && (
+          <label
+            className={classNames(
+              { 'c-disabled': disabled },
+              { 'c-on-base pointer': !disabled }
+            )}
+            htmlFor={id}>
+            {label}
+          </label>
+        )}
       </div>
     )
   }
@@ -83,7 +86,7 @@ Checkbox.propTypes = {
   /** (Input spec attribute) */
   id: PropTypes.string,
   /** Checkbox label */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   /** (Input spec attribute) */
   name: PropTypes.string.isRequired,
   /** onChange event */


### PR DESCRIPTION
Make label not required to use the checkbox on its own. 

Ex: as a column checker in the Table.