### PR TITLE
[TABLE] Add isLoading prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.17.8] - 2019-02-11
+
 ### Added
 
 - **Table** `isLoading` prop for toolbar buttons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Table** `isLoading` prop for toolbar buttons
+
 ## [8.17.7] - 2019-02-08
 
 ## [8.17.6] - 2019-02-08

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.17.7",
+  "version": "8.17.8",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.17.7",
+  "version": "8.17.8",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -268,6 +268,7 @@ class Toolbar extends PureComponent {
               }
               disabled={loading}
               variation="tertiary"
+              isLoading={download.isLoading}
               size="small"
               onClick={download.handleCallback}>
               <span className="c-on-base">{download.label}</span>
@@ -281,6 +282,7 @@ class Toolbar extends PureComponent {
                 </span>
               }
               disabled={loading}
+              isLoading={upload.isLoading}
               variation="tertiary"
               size="small"
               onClick={upload.handleCallback}>
@@ -300,6 +302,7 @@ class Toolbar extends PureComponent {
                 }
                 iconPosition="right"
                 disabled={loading}
+                isLoading={extraActions.isLoading}
                 variation="tertiary"
                 size="small"
                 onClick={() =>
@@ -337,6 +340,7 @@ class Toolbar extends PureComponent {
             <ButtonWithIcon
               icon={<IconPlus solid size={LIGHT_ICON_SIZE} />}
               disabled={loading}
+              isLoading={newLine.isLoading}
               variation="primary"
               size="small"
               onClick={newLine.handleCallback}>

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -382,10 +382,12 @@ Toolbar.propTypes = {
     download: PropTypes.shape({
       label: PropTypes.string,
       handleCallback: PropTypes.func,
+      isLoading: PropTypes.bool,
     }),
     upload: PropTypes.shape({
       label: PropTypes.string,
       handleCallback: PropTypes.func,
+      isLoading: PropTypes.bool,
     }),
     extraActions: PropTypes.shape({
       label: PropTypes.string,
@@ -396,6 +398,7 @@ Toolbar.propTypes = {
         })
       ),
       alignMenu: PropTypes.oneOf(['right', 'left']),
+      isLoading: PropTypes.bool,
     }),
   }),
   schema: PropTypes.object.isRequired,


### PR DESCRIPTION
Allow table's toolbar buttons to use the `isLoading` state:

![screen shot 2019-02-11 at 12 42 29](https://user-images.githubusercontent.com/2573602/52570439-8d777180-2dfa-11e9-8c95-8f1b23f0f2ef.png)
