### PR TITLE
Input components using HOC withForwardRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.18.1] - 2019-02-15
+
 ### Fixed
 
 - Fix ref forwarding for the following components:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix ref forwarding for the following components:
+  - **Button** 
+  - **ButtonWithIcon**
+  - **Dropdown**
+  - **Input**
+  - **InputCurrency**
+  - **InputPassword**
+  - **InputSearch**
+
 ## [8.18.0] - 2019-02-15
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.18.0",
+  "version": "8.18.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.18.0",
+  "version": "8.18.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 
 import Spinner from '../Spinner'
 
+import withForwardedRef from '../../modules/withForwardedRef'
+
 class Button extends Component {
   handleClick = event => {
     !this.props.disabled &&
@@ -143,7 +145,7 @@ class Button extends Component {
         onMouseOut={this.props.onMouseOut}
         onMouseUp={this.props.onMouseUp}
         onMouseDown={this.props.onMouseDown}
-        ref={this.props.ref}
+        ref={this.props.forwardedRef}
         style={iconOnly ? { fontSize: 0 } : {}}>
         {isLoading ? (
           <Fragment>
@@ -203,6 +205,11 @@ Button.propTypes = {
   autoComplete: PropTypes.string,
   /** (Button spec attribute) */
   disabled: PropTypes.bool,
+  /** @ignore Forwarded Ref */
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
   /** (Button spec attribute) */
   name: PropTypes.string,
   /** (Button spec attribute) */
@@ -225,12 +232,10 @@ Button.propTypes = {
   onMouseUp: PropTypes.func,
   /** onMouseDown event */
   onMouseDown: PropTypes.func,
-  /** ref function */
-  ref: PropTypes.func,
   /** Cancels out left padding */
   collapseLeft: PropTypes.bool,
   /** Cancels out right padding */
   collapseRight: PropTypes.bool,
 }
 
-export default Button
+export default withForwardedRef(Button)

--- a/react/components/ButtonWithIcon/index.js
+++ b/react/components/ButtonWithIcon/index.js
@@ -3,10 +3,17 @@ import PropTypes from 'prop-types'
 
 import Button from '../Button'
 
+import withForwardedRef from '../../modules/withForwardedRef'
+
 class ButtonWithIcon extends Component {
   static propTypes = {
     /** @ignore Button label */
     children: PropTypes.node,
+    /** @ignore Forwarded Ref */
+    forwardedRef: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    ]),
     /** The icon image */
     icon: PropTypes.node.isRequired,
     /** Position of the icon */
@@ -74,4 +81,4 @@ class ButtonWithIcon extends Component {
   }
 }
 
-export default ButtonWithIcon
+export default withForwardedRef(ButtonWithIcon)

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import ArrowDownIcon from './ArrowDownIcon'
 
+import withForwardedRef from '../../modules/withForwardedRef'
+
 class Dropdown extends Component {
   constructor(props) {
     super(props)
@@ -241,23 +243,22 @@ class Dropdown extends Component {
   }
 }
 
-const DropdownWithRef = React.forwardRef((props, ref) => (
-  <Dropdown {...props} forwardedRef={ref} />
-))
-
-DropdownWithRef.displayName = 'Dropdown'
-
-DropdownWithRef.defaultProps = {
+Dropdown.defaultProps = {
   size: 'regular',
   options: [],
   variation: 'default',
 }
 
-DropdownWithRef.propTypes = {
+Dropdown.propTypes = {
   /** Error highlight */
   error: PropTypes.bool,
   /** Error message */
   errorMessage: PropTypes.node,
+  /** @ignore Forwarded Ref */
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
   /** Help text */
   helpText: PropTypes.node,
   /** Dropdown label */
@@ -299,11 +300,6 @@ DropdownWithRef.propTypes = {
   onClose: PropTypes.func,
   /** onOpen event */
   onOpen: PropTypes.func,
-  /** Internal prop used for ref forwarding */
-  forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 }
 
-Dropdown.propTypes = DropdownWithRef.propTypes
-Dropdown.defaultProps = DropdownWithRef.defaultProps
-
-export default DropdownWithRef
+export default withForwardedRef(Dropdown)

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import config from 'vtex-tachyons/config.json'
 
 import { hideDecorators } from './edge.css'
+import withForwardedRef from '../../modules/withForwardedRef'
 
 class Input extends Component {
   constructor(props) {
@@ -233,13 +234,7 @@ class Input extends Component {
   }
 }
 
-const InputWithRef = React.forwardRef((props, ref) => (
-  <Input {...props} forwardedRef={ref} />
-))
-
-InputWithRef.displayName = 'Input'
-
-InputWithRef.defaultProps = {
+Input.defaultProps = {
   autoFocus: false,
   token: false,
   dataAttributes: {},
@@ -253,11 +248,16 @@ InputWithRef.defaultProps = {
   type: 'text',
 }
 
-InputWithRef.propTypes = {
+Input.propTypes = {
   /** Error highlight */
   error: PropTypes.bool,
   /** Error message */
   errorMessage: PropTypes.string,
+  /** @ignore Forwarded Ref */
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
   /** If the input is an API Key, App Key or App Token */
   token: PropTypes.bool,
   /** Help text */
@@ -268,8 +268,6 @@ InputWithRef.propTypes = {
   label: PropTypes.string,
   /** Prefix */
   prefix: PropTypes.node,
-  /** Internal prop used for ref forwarding */
-  forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /** Spec attribute */
   accept: PropTypes.string,
   /** Spec attribute */
@@ -344,7 +342,4 @@ InputWithRef.propTypes = {
   onBlur: PropTypes.func,
 }
 
-Input.propTypes = InputWithRef.propTypes
-Input.defaultProps = InputWithRef.defaultProps
-
-export default InputWithRef
+export default withForwardedRef(Input)

--- a/react/components/InputCurrency/index.js
+++ b/react/components/InputCurrency/index.js
@@ -5,6 +5,8 @@ import NumberFormat from 'react-number-format'
 
 import Input from '../Input'
 
+import withForwardedRef from '../../modules/withForwardedRef'
+
 /** WORKAROUND incoming!
  * BaseInput is a wrapper for the Input component for being able to use the
  * prefix prop with the NumberFormat component.
@@ -90,13 +92,12 @@ class InputCurrency extends Component {
   }
 }
 
-const InputCurrencyWithRef = React.forwardRef((props, ref) => (
-  <InputCurrency {...props} forwardedRef={ref} />
-))
-
-InputCurrencyWithRef.displayName = 'InputCurrency'
-
-InputCurrencyWithRef.propTypes = {
+InputCurrency.propTypes = {
+  /** @ignore Forwarded Ref */
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
   onChange: PropTypes.func,
   onClear: PropTypes.func,
   size: PropTypes.string,
@@ -108,6 +109,4 @@ InputCurrencyWithRef.propTypes = {
   currencyCode: PropTypes.string.isRequired,
 }
 
-InputCurrency.propTypes = InputCurrencyWithRef.propTypes
-
-export default InputCurrencyWithRef
+export default withForwardedRef(InputCurrency)

--- a/react/components/InputPassword/index.js
+++ b/react/components/InputPassword/index.js
@@ -4,6 +4,8 @@ import Input from '../Input'
 import VisibilityOn from '../icon/VisibilityOn'
 import VisibilityOff from '../icon/VisibilityOff'
 
+import withForwardedRef from '../../modules/withForwardedRef'
+
 class InputPassword extends Component {
   static iconSizes = {
     small: 14,
@@ -42,18 +44,15 @@ class InputPassword extends Component {
   }
 }
 
-const InputPasswordWithRef = React.forwardRef((props, ref) => (
-  <InputPassword {...props} forwardedRef={ref} />
-))
-
-InputPasswordWithRef.displayName = 'InputPassword'
-
-InputPasswordWithRef.propTypes = {
+InputPassword.propTypes = {
+  /** @ignore Forwarded Ref */
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
   onChange: PropTypes.func,
   size: PropTypes.string,
   value: PropTypes.string,
 }
 
-InputPassword.propTypes = InputPasswordWithRef.propTypes
-
-export default InputPasswordWithRef
+export default withForwardedRef(InputPassword)

--- a/react/components/InputSearch/index.js
+++ b/react/components/InputSearch/index.js
@@ -4,6 +4,8 @@ import Input from '../Input'
 import SearchIcon from '../icon/Search'
 import DenyIcon from '../icon/Deny'
 
+import withForwardedRef from '../../modules/withForwardedRef'
+
 class InputSearch extends Component {
   static iconSizes = {
     small: 14,
@@ -54,19 +56,16 @@ class InputSearch extends Component {
   }
 }
 
-const InputSearchWithRef = React.forwardRef((props, ref) => (
-  <InputSearch {...props} forwardedRef={ref} />
-))
-
-InputSearchWithRef.displayName = 'InputSearch'
-
-InputSearchWithRef.propTypes = {
+InputSearch.propTypes = {
+  /** @ignore Forwarded Ref */
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
   onChange: PropTypes.func,
   onClear: PropTypes.func,
   size: PropTypes.string,
   value: PropTypes.string,
 }
 
-InputSearch.propTypes = InputSearchWithRef.propTypes
-
-export default InputSearchWithRef
+export default withForwardedRef(InputSearch)

--- a/react/modules/withForwardedRef.js
+++ b/react/modules/withForwardedRef.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+function withForwardedRef(Component) {
+  const ComponentWithRef = React.forwardRef((props, ref) => (
+    <Component {...props} forwardedRef={ref} />
+  ))
+
+  ComponentWithRef.displayName = Component.displayName || Component.name
+
+  return ComponentWithRef
+}
+
+export default withForwardedRef


### PR DESCRIPTION
This PR intends to fix ref forwarding for Button/ButtonWithIcon. We also standardized other input components that needed to forward refs.

As an extra, this fixed (it seems) the documentation for some components:
- Before:
![image](https://user-images.githubusercontent.com/7633179/52714971-6350bb80-2f82-11e9-97c7-37de6aee2656.png)
- After
![image](https://user-images.githubusercontent.com/7633179/52714978-6a77c980-2f82-11e9-90c1-ed218e4cc71f.png)

