### PR TITLE
Fix focus behavior when typing in the search input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **EXPERIMENTAL_Select** fix focus behaviour when typing in the search input.
+
 ## [8.18.2] - 2019-02-15
 
 ### Fixed
@@ -18,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix ref forwarding for the following components:
-  - **Button** 
+  - **Button**
   - **ButtonWithIcon**
   - **Dropdown**
   - **Input**
@@ -29,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [8.18.0] - 2019-02-15
 
 ### Added
+
 - **ColorPicker** component.
 
 ## [8.17.8] - 2019-02-11
@@ -128,6 +133,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **`Toast`** Add `horizontalPosition` to `showToast` options.
 
 ## [8.12.0] - 2019-01-17
+
 ### Added
 
 - **Dropdown** `variation` prop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.18.3] - 2019-02-18
+
 ### Fixed
 
 - **EXPERIMENTAL_Select** fix focus behaviour when typing in the search input.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.18.2",
+  "version": "8.18.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.18.2",
+  "version": "8.18.3",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -22,11 +22,22 @@ class Select extends Component {
   constructor(props) {
     super(props)
 
+    this.state = {
+      searchTerm: undefined,
+    }
+
     this.inputId = `react-select-input-${uuid()}`
   }
 
-  componentDidUpdate() {
-    document.getElementById(this.inputId).focus()
+  componentDidUpdate(prevProps, prevState) {
+    const { searchTerm } = this.state
+    const { searchTerm: prevSearchTerm } = prevState
+    const { loading } = this.props
+    const { loading: prevLoading } = prevProps
+
+    if (searchTerm !== prevSearchTerm || loading !== prevLoading) {
+      document.getElementById(this.inputId).focus()
+    }
   }
 
   render() {
@@ -80,6 +91,9 @@ class Select extends Component {
       noOptionsMessage,
       inputId: this.inputId,
       onInputChange: (value, { action }) => {
+        this.setState({
+          searchTerm: value,
+        })
         if (
           action === 'input-change' &&
           typeof onSearchInputChange === 'function'


### PR DESCRIPTION
Before this PR, we were applying focus to the input component of the **EXPERIMENTAL_Select** in the `componentDidUpdate` lifecycle. This was causing some weird focus behavior when a change in another part of the page triggers an update on the **EXPERIMENTAL_Select** and, therefore, the select was focused, even though the user was not using the component.

Now, we only focus the **EXPERIMENTAL_Select** component when is being used.