### PR TITLE
Add Low prominence variation to tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Tag** `low` new variation prop, now tags may have borders.
+
 ## [8.18.3] - 2019-02-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.19.0] - 2019-02-20
+
 ### Added
 
 - **Tag** `low` new variation prop, now tags may have borders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.19.1] - 2019-02-20
+
 ## [8.19.0] - 2019-02-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.19.2] - 2019-02-20
+
 ## [8.19.1] - 2019-02-20
 
 ## [8.19.0] - 2019-02-20

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.19.0",
+  "version": "8.19.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.19.1",
+  "version": "8.19.2",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.18.3",
+  "version": "8.19.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.19.1",
+  "version": "8.19.2",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.19.0",
+  "version": "8.19.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.18.3",
+  "version": "8.19.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Tag/README.md
+++ b/react/components/Tag/README.md
@@ -3,19 +3,19 @@
 ### 👍 Dos
 
 - Do use semantic colors that have a clear and contextualized meaning in your application, such as _green_ for success and _red_ for errors. However, if your application employs a richer palette with unambiguous usage of colors don't hesitate to use your Tags with them.
-- Do play with contrast to convey the visual prominence more suited to your application. Use high contrast for high proeminence, and low contrast for low proeminence.
+- Do play with contrast to convey the visual prominence more suited to your application. Use high contrast for high prominence, and low contrast for low prominence.
 
 ### 👎 Don'ts
 
 - Don't do make the Tag other than the optional close button, otherwise they should always be read-only.
 - Don't use color contrast combinations that don't pass Accessibility tests.
 
-**@todo: update examples to use VTEX Tachyons colors without hardcoding them**
+** @todo: update examples to use VTEX Tachyons colors without hardcoding them **
 
 Default
 
 ```js
-<Tag>Pending</Tag>
+<Tag>Neutral</Tag>
 ```
 
 Types
@@ -43,22 +43,22 @@ Low prominence
 ```js
 <div>
   <span className="mr4">
-    <Tag bgColor="#FFE6E6" color="#FF4C4C">
+    <Tag type="error" variation="low" >
       Error
     </Tag>
   </span>
   <span className="mr4">
-    <Tag bgColor="#FFF6E0" color="#FFB100">
+    <Tag type="warning" variation="low">
       Warning
     </Tag>
   </span>
   <span className="mr4">
-    <Tag bgColor="#EAFCE3" color="#8BC34A">
+    <Tag type="success" variation="low" >
       Success
     </Tag>
   </span>
   <span className="mr4">
-    <Tag bgColor="#E3E4E6" color="#979899">
+    <Tag variation="low">
       Neutral
     </Tag>
   </span>
@@ -69,17 +69,17 @@ Custom colors
 
 ```js
 <span className="mr4">
-  <Tag bgColor="#F71963" color="#FFFFFF">
+  <Tag bgColor="#F71963">
     Label
   </Tag>
 </span>
 <span className="mr4">
-  <Tag bgColor="#142032" color="#D6D8E0">
+  <Tag bgColor="#134CD8" color="#ffffff">
     Label
   </Tag>
 </span>
 <span className="mr4">
-  <Tag bgColor="#00BBD4" color="#FFFFFF">
+  <Tag bgColor="#FFF6E0" color="#0C389F">
     Label
   </Tag>
 </span>
@@ -92,10 +92,10 @@ With remove
   <Tag onClick={() => console.log('callback')}>Default</Tag>
 </span>
 <span className="mr4">
-  <Tag onClick={() => console.log('callback')} bgColor="#000" color="#ffb100">With color</Tag>
+  <Tag  disabled onClick={() => console.log('callback')}>Disabled</Tag>
 </span>
 <span className="mr4">
-  <Tag  disabled onClick={() => console.log('callback')}>Disabled</Tag>
+  <Tag onClick={() => console.log('callback')} bgColor="#134CD8" color="#fff">With color</Tag>
 </span>
 <span className="mr4">
   <Tag onClick={() => console.log('callback')} type="error">

--- a/react/components/Tag/index.js
+++ b/react/components/Tag/index.js
@@ -22,30 +22,49 @@ class Tag extends PureComponent {
   }
 
   render() {
-    const { children, onClick, disabled, color, bgColor } = this.props
+    const {
+      children,
+      onClick,
+      disabled,
+      color,
+      bgColor,
+      type,
+      variation,
+    } = this.props
 
     const baseClasses = 'br-pill t-small pv2 ph4 dib fw5'
 
     let theme = ''
-    switch (this.props.type) {
+    const variationIsLow = variation === 'low'
+
+    switch (type) {
       case 'success':
-        theme = 'bg-success c-on-success'
+        theme = variationIsLow
+          ? 'bg-transparent ba c-success '
+          : 'bg-success c-on-success '
         break
       case 'error':
-        theme = 'bg-danger c-on-danger'
+        theme = variationIsLow
+          ? 'bg-transparent ba c-danger '
+          : 'bg-danger c-on-danger '
         break
       case 'warning':
-        theme = 'bg-warning c-on-warning'
+        theme = variationIsLow
+          ? 'bg-transparent ba c-warning '
+          : 'bg-warning c-on-warning '
         break
       default:
-        theme = 'bg-muted-4 c-on-base'
+        theme = variationIsLow
+          ? 'bg-transparent ba c-muted-2 '
+          : 'bg-muted-2 c-on-muted-2 '
+        break
     }
 
-    const btnClasses = disabled ? 'c-muted-2' : 'pointer'
+    const btnClasses = disabled ? 'bg-muted-4 c-muted-2 ' : 'pointer '
 
     let hoverClass = ''
     if (!disabled) {
-      hoverClass = this.state.hover && 'o-60'
+      hoverClass = this.state.hover && 'o-80'
     }
 
     return onClick ? (
@@ -90,6 +109,7 @@ Tag.propTypes = {
   bgColor: PropTypes.string,
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
+  variation: PropTypes.oneOf(['default', 'low']),
 }
 
 export default Tag


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a new prop to tags. Now a tag can have a low prominence version, with borders and no background color.

#### What problem is this solving?
Our low prominence tags examples on styleguide weren't actually a prop, and the visual suggested wasn't attending minimum contrast standards.

#### Screenshots or example usage
##### Before
![image](https://user-images.githubusercontent.com/10401309/52878535-fe44c380-3143-11e9-9390-1e5d84c2ced9.png)
##### After
![image](https://user-images.githubusercontent.com/10401309/52878544-07ce2b80-3144-11e9-89ac-1988cba49f22.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
