### PR TITLE
Fix npm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ styleguide-visual/*.diff.png
 # production
 /build
 /lib
+/modules
 /styleguide
 
 # misc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- npm build
+
 ## [8.21.2] - 2019-03-01
 
 ## [8.21.1] - 2019-02-28

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "styleguide": "styleguidist server",
     "start": "styleguidist server",
     "styleguide:build": "styleguidist build && echo 'styleguide.vtex.com' >./styleguide/CNAME",
-    "babel": "NODE_ENV=production babel ./react/components --out-dir ./lib --ignore '__tests__,*.spec.js' --ignore '*.md' --copy-files",
-    "compile": "run-s cleanlib babel",
-    "cleanlib": "rm -rf lib",
+    "babel:lib": "NODE_ENV=production babel ./react/components --out-dir ./lib --ignore '__tests__,*.spec.js' --ignore '*.md' --copy-files",
+    "babel:modules": "NODE_ENV=production babel ./react/modules --out-dir ./modules --ignore '__tests__,*.spec.js' --ignore '*.md' --copy-files",
+    "clean:lib": "rm -rf lib",
+    "clean:modules": "rm -rf modules",
+    "compile": "run-s clean:lib clean:modules babel:lib babel:modules",
     "prepublishOnly": "run-s compile deploy",
     "postreleasy": "vtex publish --public --verbose",
     "lint": "eslint react",
@@ -21,6 +23,7 @@
   },
   "files": [
     "lib/",
+    "modules/",
     "codemod/"
   ],
   "homepage": "https://vtex.github.io/styleguide",


### PR DESCRIPTION
Users of this library as a npm module are having issues to use it, since scripts inside the directory `modules` are not being published to npm.

See:
https://unpkg.com/@vtex/styleguide@8.18.3/

You can't find the module `withForwardedRef.js` there.