### PR TITLE
Fix problems on ColorPicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **ColorPicker** require prop `colorHistory`.
+- **ColorPicker** always show the correct hex value.
+
 ## [8.19.3] - 2019-02-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.19.4] - 2019-02-22
+
 ### Fixed
 
 - **ColorPicker** require prop `colorHistory`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.19.3",
+  "version": "8.19.4",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.19.3",
+  "version": "8.19.4",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/ColorPicker/HexInput.js
+++ b/react/components/ColorPicker/HexInput.js
@@ -32,12 +32,20 @@ class HexInput extends React.Component {
     return validColor
   }
 
+  componentDidMount() {
+    this.updateInputValue()
+  }
+
   componentDidUpdate(prevProps) {
     if (prevProps.rgb !== this.props.rgb) {
-      const { rgb } = this.props
-      const color = colorutil.rgb.to.hex(rgb)
-      this.setState({ inputValue: color })
+      this.updateInputValue()
     }
+  }
+
+  updateInputValue() {
+    const { rgb } = this.props
+    const color = colorutil.rgb.to.hex(rgb)
+    this.setState({ inputValue: color })
   }
 
   render() {

--- a/react/components/ColorPicker/index.js
+++ b/react/components/ColorPicker/index.js
@@ -119,6 +119,8 @@ ColorPicker.propTypes = {
     /** HEX color format */
     hex: PropTypes.string,
   }).isRequired,
+  /** Color history */
+  colorHistory: PropTypes.array.isRequired,
   /** Disable component */
   disabled: PropTypes.bool,
 }


### PR DESCRIPTION
Issues:

1. `colorHistory` prop is not defined but component breaks without it.
    - **How to Reproduce**: Just create a ColorPicker component without defining the `colorHistory` prop and try to edit a color.
    - **Fix**: Add the prop to PropTypes.

2. Hex value only updates after a click.
    - **How to Reproduce**: Go to the [ColorPicker documentation page](https://styleguide.vtex.com/#/Components/Forms/ColorPicker) and scroll to the component without clicking. Values on Hex Input all show `#000000` instead of the correct value.
    - **Fix**: Update state on `componentDidMount` instead of only on `componentDidUpdate`