### PR TITLE
Add disabled state to tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.20.1-beta] - 2019-02-28
+
 ### Added
 
 - **Tabs** `disabled` prop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Tabs** `disabled` prop
+
 ## [8.20.0] - 2019-02-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.20.1] - 2019-02-28
+
 ## [8.20.1-beta] - 2019-02-28
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.20.0",
+  "version": "8.20.1-beta",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.20.1-beta",
+  "version": "8.20.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.20.1-beta",
+  "version": "8.20.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.20.0",
+  "version": "8.20.1-beta",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Tabs/README.md
+++ b/react/components/Tabs/README.md
@@ -38,6 +38,18 @@ const Tab = require('./Tab').default;
 </div>
 ```
 
+Disabled tabs
+
+```js
+const Tab = require('./Tab').default;
+<div>
+  <Tabs>
+    <Tab label="Active and disabled tab" active disabled onClick={() => {}}/>
+    <Tab label="Disabled tab" disabled onClick={() => {}}/>
+  </Tabs>
+</div>
+```
+
 Working example
 
 ```js

--- a/react/components/Tabs/Tab.js
+++ b/react/components/Tabs/Tab.js
@@ -3,27 +3,40 @@ import PropTypes from 'prop-types'
 
 class Tab extends Component {
   handleClick = e => {
-    this.props.onClick && this.props.onClick(e)
+    !this.props.disabled && this.props.onClick && this.props.onClick(e)
   }
 
   render() {
-    const { active, fullWidth, label } = this.props
+    const { active, fullWidth, label, disabled } = this.props
+
+    let tabStyle =
+      'c-muted-1 b--transparent hover-c-action-primary pointer vtex-tab__button--inactive'
+
+    if (active && disabled) {
+      tabStyle = 'fw5 b--muted-1 c-muted-2'
+    } else if (active) {
+      tabStyle = 'c-on-muted b--emphasis fw5 vtex-tab__button--active'
+    } else if (disabled) {
+      tabStyle = 'b--muted-4 c-muted-3'
+    }
+
     return (
       <button
         type="button"
         onClick={this.handleClick}
         className={`vtex-tab__button bt-0 bl-0 br-0 bw1 ${
           fullWidth ? 'w-100' : ''
-        } ${
-          active
-            ? 'c-on-muted b--emphasis vtex-tab__button--active'
-            : 'c-muted-1 b--transparent hover-c-action-primary pointer vtex-tab__button--inactive'
-        } v-mid relative h-regular ph4 t-body bg-transparent outline-0
+        } ${tabStyle}
+        v-mid relative h-regular ph4 t-body bg-transparent outline-0
         `}>
         {label}
       </button>
     )
   }
+}
+
+Tab.defaultProps = {
+  disabled: false,
 }
 
 Tab.propTypes = {
@@ -32,6 +45,7 @@ Tab.propTypes = {
   children: PropTypes.node,
   label: PropTypes.any.isRequired,
   onClick: PropTypes.func,
+  disabled: PropTypes.bool,
 }
 
 export default Tab


### PR DESCRIPTION
Add disable state to tabs, styling them in grayscale and preventing the click event to be triggered.