### PR TITLE
Fix withForwardedRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix prop types of forwarded `ref`.
+
 ## [8.23.3] - 2019-03-14
 
 ### Fixed

--- a/react/modules/withForwardedRef.js
+++ b/react/modules/withForwardedRef.js
@@ -2,15 +2,18 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 // For more info see: https://stackoverflow.com/a/51127130/10725088
-const Element = typeof Element === 'undefined' ? function() {} : Element
+const Element =
+  typeof window === 'undefined' || typeof window.Element === 'undefined'
+    ? function() {}
+    : window.Element
 
 export const refShape = PropTypes.oneOfType([
   PropTypes.func,
   PropTypes.shape({
-    current: PropTypes.oneOfType(
+    current: PropTypes.oneOfType([
       PropTypes.instanceOf(null),
-      PropTypes.instanceOf(Element)
-    ),
+      PropTypes.instanceOf(Element),
+    ]),
   }),
 ])
 


### PR DESCRIPTION
1. oneOf requires an array
2. `Element` is not available in the global namespace while running jest, so we get it from `window` instead