### PR TITLE
Hotfix/table toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Table** Toolbar extra options button was using deprecated ActionMenu props.
+
 ## [8.23.0] - 2019-03-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.23.1] - 2019-03-14
+
 ### Fixed
 
 - **Table** Toolbar extra options button was using deprecated ActionMenu props.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.23.0",
+  "version": "8.23.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.23.0",
+  "version": "8.23.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -287,15 +287,14 @@ class Toolbar extends PureComponent {
           {isExtraActionsVisible && (
             <div title={extraActions.label} className="mh2">
               <ActionMenu
-                icon={
-                  <span className="c-on-base mh2">
-                    <IconOptionsDots />
-                  </span>
-                }
                 hideCaretIcon
                 buttonProps={{
                   variation: 'tertiary',
-                  icon: true,
+                  icon: (
+                    <span className="c-on-base">
+                      <IconOptionsDots />
+                    </span>
+                  ),
                   size: 'small',
                 }}
                 options={extraActions.actions.map(action => {


### PR DESCRIPTION
# What does this PR do?
 - icon on table toolbar was using deprecated prop of ActionMenu
![image (7)](https://user-images.githubusercontent.com/8530905/54366164-f0089b00-464e-11e9-8784-06349a03cb3d.png)
