### PR TITLE
Export ToastContext to allow useContext and ToastManager is now a HOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.25.0] - 2019-03-22
+
 ### Added
 
 - **Toast** Export `ToastContext` to use the `useContext` Hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Toast** Export `ToastContext` to use the `useContext` Hook.
+
+### Changed
+
+- **Toast** Use the `ToastManager` as HOC to provide the toast state as it changes.
+
 ## [8.24.3] - 2019-03-18
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.24.3",
+  "version": "8.25.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.24.3",
+  "version": "8.25.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/ToastContext.js
+++ b/react/ToastContext.js
@@ -1,0 +1,3 @@
+import { ToastContext } from './components/ToastProvider/index'
+
+export default ToastContext

--- a/react/components/ToastProvider/README.md
+++ b/react/components/ToastProvider/README.md
@@ -214,7 +214,7 @@ const Content = () => (
       this.setState({ value: event.currentTarget.value })
     }
 
-    componentDidUpdate(prevState) {
+    componentDidUpdate(_, prevState) {
       const { value } = this.state
       if ( prevState.value !== this.state.value ) {
         if (value === ''){

--- a/react/components/ToastProvider/ToastManager.js
+++ b/react/components/ToastProvider/ToastManager.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import Toast from './Toast'
 import isString from 'lodash/isString'
@@ -13,7 +13,7 @@ export default class ToastManager extends Component {
   state = {
     currentToast: null,
     nextToast: null,
-    isToastVisible: true,
+    isToastVisible: false,
   }
 
   showToast = args => {
@@ -113,31 +113,40 @@ export default class ToastManager extends Component {
   }
 
   render() {
+    const { children } = this.props
     const { currentToast } = this.state
 
     return (
-      <div
-        className="fixed z-max overflow-hidden"
-        ref={this.container}
-        style={{
-          pointerEvents: 'none',
-        }}>
-        {currentToast && (
-          <Toast
-            message={currentToast.message}
-            action={currentToast.action}
-            duration={currentToast.duration}
-            dismissable={currentToast.dismissable}
-            visible={this.state.isToastVisible}
-            onClose={this.handleToastClose}
-            horizontalPosition={currentToast.horizontalPosition}
-          />
-        )}
-      </div>
+      <Fragment>
+        {children({
+          showToast: this.showToast,
+          hideToast: this.hideToast,
+          state: this.state,
+        })}
+        <div
+          className="fixed z-max overflow-hidden"
+          ref={this.container}
+          style={{
+            pointerEvents: 'none',
+          }}>
+          {currentToast && (
+            <Toast
+              message={currentToast.message}
+              action={currentToast.action}
+              duration={currentToast.duration}
+              dismissable={currentToast.dismissable}
+              visible={this.state.isToastVisible}
+              onClose={this.handleToastClose}
+              horizontalPosition={currentToast.horizontalPosition}
+            />
+          )}
+        </div>
+      </Fragment>
     )
   }
 }
 
 ToastManager.propTypes = {
   positioning: PropTypes.oneOf(['parent', 'window']),
+  children: PropTypes.func.isRequired,
 }

--- a/react/components/ToastProvider/index.js
+++ b/react/components/ToastProvider/index.js
@@ -5,6 +5,7 @@ import ToastManager from './ToastManager'
 const ToastContext = React.createContext({
   showToast: () => {},
   hideToast: () => {},
+  toastState: null,
 })
 
 class ToastProvider extends Component {
@@ -14,31 +15,21 @@ class ToastProvider extends Component {
     this.toastManager = React.createRef()
   }
 
-  showToast = args => {
-    this.toastManager &&
-      this.toastManager.current &&
-      this.toastManager.current.showToast &&
-      this.toastManager.current.showToast(args)
-  }
-
-  hideToast = () => {
-    this.toastManager &&
-      this.toastManager.current &&
-      this.toastManager.current.hideToast &&
-      this.toastManager.current.hideToast()
-  }
-
   render() {
     const { children, positioning } = this.props
     return (
-      <ToastContext.Provider
-        value={{
-          showToast: this.showToast,
-          hideToast: this.hideToast,
-        }}>
-        {children}
-        <ToastManager positioning={positioning} ref={this.toastManager} />
-      </ToastContext.Provider>
+      <ToastManager positioning={positioning}>
+        {({ showToast, hideToast, state: toastState }) => (
+          <ToastContext.Provider
+            value={{
+              showToast,
+              hideToast,
+              toastState,
+            }}>
+            {children}
+          </ToastContext.Provider>
+        )}
+      </ToastManager>
     )
   }
 }
@@ -57,14 +48,7 @@ class ToastConsumer extends Component {
   render() {
     const { children } = this.props
     return (
-      <ToastContext.Consumer>
-        {value =>
-          children({
-            showToast: value.showToast,
-            hideToast: value.hideToast,
-          })
-        }
-      </ToastContext.Consumer>
+      <ToastContext.Consumer>{value => children(value)}</ToastContext.Consumer>
     )
   }
 }
@@ -76,14 +60,15 @@ ToastConsumer.propTypes = {
 // eslint-disable-next-line react/display-name
 const withToast = WrappedComponent => props => (
   <ToastConsumer>
-    {({ showToast, hideToast }) => (
+    {({ showToast, hideToast, toastState }) => (
       <WrappedComponent
         showToast={showToast}
         hideToast={hideToast}
+        toastState={toastState}
         {...props}
       />
     )}
   </ToastConsumer>
 )
 
-export { ToastProvider, ToastConsumer, withToast }
+export { ToastContext, ToastProvider, ToastConsumer, withToast }


### PR DESCRIPTION
**There is no breaking changes. ToastProvider API is the same.**

As the title says, with the `ToastContext` exported, we can now use it with Hooks (for those who don't want to use the `withToast` HOC in functional components):

```jsx
import { useContext } from 'react'
import { ToastContext } from 'vtex.styleguide'

function Component() {
  ...
  const { showToast, hideToast, toastState } = useContext(ToastContext)
  ...
}
```

### How to test it

[Access the workspace](http://toast--storecomponents.myvtex.com) and open the dev tools and click the `Network > Offline` option (or turn off your device's network). Then click the buy button to see the offline toast be replaced but when the buy button toast goes away, the offline toast goes up again.