### PR TITLE
Fix ref prop on InputCurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix `ref` prop in InputCurrency component.
+
+## [8.23.4] - 2019-03-18
+
+### Fixed
+
 - Fix prop types of forwarded `ref`.
 
 ## [8.23.3] - 2019-03-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.24.1] - 2019-03-18
+
 ### Fixed
 
 - Fix `ref` prop in InputCurrency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `ref` prop in InputCurrency.
+
 ## [8.24.0] - 2019-03-18
 
 ### Added
 
 - **PageHeader** added a new subtitle prop.
-
-## [8.24.0] - 2019-03-18
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fix `ref` prop in InputCurrency component.
-
-## [8.23.4] - 2019-03-18
-
-### Fixed
-
 - Fix prop types of forwarded `ref`.
 
 ## [8.23.3] - 2019-03-14

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.24.0",
+  "version": "8.24.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.24.0",
+  "version": "8.24.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/InputCurrency/index.js
+++ b/react/components/InputCurrency/index.js
@@ -102,6 +102,8 @@ class InputCurrency extends Component {
 InputCurrency.propTypes = {
   /** @ignore Forwarded Ref */
   forwardedRef: refShape,
+  /** @ignore ref used by input component */
+  inputRef: PropTypes.any,
   onChange: PropTypes.func,
   onClear: PropTypes.func,
   size: PropTypes.string,

--- a/react/components/InputCurrency/index.js
+++ b/react/components/InputCurrency/index.js
@@ -22,6 +22,7 @@ const BaseInput = props => {
 BaseInput.propTypes = {
   inputPrefix: PropTypes.string,
   inputSuffix: PropTypes.string,
+  inputRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
 }
 
 const baseNumber = 9999999999.9999999999
@@ -39,14 +40,7 @@ class InputCurrency extends Component {
   }
 
   render() {
-    // eslint-disable-next-line no-unused-vars
-    const {
-      locale,
-      currencyCode,
-      onChange,
-      forwardedRef,
-      ...props
-    } = this.props
+    const { locale, currencyCode, forwardedRef, ...props } = this.props
 
     const formatter = new Intl.NumberFormat(locale, {
       style: 'currency',
@@ -102,8 +96,6 @@ class InputCurrency extends Component {
 InputCurrency.propTypes = {
   /** @ignore Forwarded Ref */
   forwardedRef: refShape,
-  /** @ignore ref used by input component */
-  inputRef: PropTypes.any,
   onChange: PropTypes.func,
   onClear: PropTypes.func,
   size: PropTypes.string,

--- a/react/components/InputCurrency/index.js
+++ b/react/components/InputCurrency/index.js
@@ -15,8 +15,8 @@ import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
  *
  */
 const BaseInput = props => {
-  const { inputPrefix: prefix, inputSuffix: suffix } = props
-  return <Input {...props} prefix={prefix} suffix={suffix} />
+  const { inputPrefix: prefix, inputSuffix: suffix, inputRef: ref } = props
+  return <Input {...props} prefix={prefix} suffix={suffix} ref={ref} />
 }
 
 BaseInput.propTypes = {
@@ -40,7 +40,13 @@ class InputCurrency extends Component {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const { locale, currencyCode, onChange, ...props } = this.props
+    const {
+      locale,
+      currencyCode,
+      onChange,
+      forwardedRef,
+      ...props
+    } = this.props
 
     const formatter = new Intl.NumberFormat(locale, {
       style: 'currency',
@@ -78,6 +84,7 @@ class InputCurrency extends Component {
       <div>
         <NumberFormat
           {...props}
+          inputRef={forwardedRef}
           inputPrefix={prefix ? currencySymbol : null}
           inputSuffix={prefix ? null : currencySymbol}
           decimalSeparator={decimalSeparator || false}


### PR DESCRIPTION
InputCurrency uses NumberFormat underneath, and I discovered a problem with `ref` prop in NumberFormat. 
For more info: 
Issue on github: https://github.com/s-yadav/react-number-format/issues/125
NumberFormat doc: https://github.com/s-yadav/react-number-format#getting-reference
