### PR TITLE
Fix behavior of subtitle prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PageHeader** fixed behavior of subtitle misplacement when without children.
+
 ## [8.24.1] - 2019-03-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.24.2] - 2019-03-18
+
 ### Fixed
 
 - **PageHeader** fixed behavior of subtitle misplacement when without children.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.24.1",
+  "version": "8.24.2",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.24.1",
+  "version": "8.24.2",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/PageHeader/index.js
+++ b/react/components/PageHeader/index.js
@@ -10,7 +10,7 @@ class PageHeader extends PureComponent {
   }
 
   render() {
-    const { linkLabel, children } = this.props
+    const { linkLabel, children, subtitle } = this.props
 
     return (
       <div className="vtex-pageHeader__container pa5 pa7-ns">
@@ -40,12 +40,16 @@ class PageHeader extends PureComponent {
             {this.props.title}
           </div>
           {children && (
-            <div className="vtex-pageHeader__children order-2 order-0-ns mt5 mt0-ns">
+            <div
+              className={`vtex-pageHeader__children order-2 order-0-ns ${
+                subtitle ? 'mt5' : ''
+              } mt0-ns`}>
               {children}
             </div>
           )}
+          <div className="w-100" style={{ height: 0 }} />
           <div className="vtex-pageHeader__subtitle t-body lh-copy c-muted-1 mv5 order-1 order-0-ns">
-            {this.props.subtitle}
+            {subtitle}
           </div>
         </div>
       </div>


### PR DESCRIPTION
When without 'children', 'subtitle' was being misplaced on the component. And when without 'subtitle', 'children' was getting too far away from the 'title'.