### PR TITLE
Fixed error caused by intanceof null on withFowardedRef module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed error caused by `intanceof` null on `withFowardedRef` module.
+- Fixed error caused by `instanceof` `null` on `withFowardedRef` module.
 
 ## [8.27.2] - 2019-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.27.3] - 2019-04-03
+
 ### Fixed
 
 - Fixed error caused by `instanceof` `null` on `withFowardedRef` module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed error caused by `intanceof` null on `withFowardedRef` module.
+
 ## [8.27.2] - 2019-04-03
 
 ## [8.27.1] - 2019-03-28

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.27.2",
+  "version": "8.27.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.27.2",
+  "version": "8.27.3",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/modules/withForwardedRef.js
+++ b/react/modules/withForwardedRef.js
@@ -10,10 +10,7 @@ const Element =
 export const refShape = PropTypes.oneOfType([
   PropTypes.func,
   PropTypes.shape({
-    current: PropTypes.oneOfType([
-      PropTypes.instanceOf(null),
-      PropTypes.instanceOf(Element),
-    ]),
+    current: PropTypes.oneOfType([null, PropTypes.instanceOf(Element)]),
   }),
 ])
 


### PR DESCRIPTION
The `Proptypes.instaceof(null)` was causing the error:

![image](https://user-images.githubusercontent.com/6964311/55505853-6aaf4f80-562a-11e9-8abd-ae5b98f0b561.png)
 
[Workspace with these changes](https://searchproptypes--storecomponents.myvtex.com/)