### PR TITLE
Fix table pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.27.4] - 2019-04-04
+
 ### Fixed
 
 - Fixed **Table** pagination when total items was not a multiple of rows length.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed **Table** pagination when total items was not a multiple of rows length.
+
 ## [8.27.3] - 2019-04-03
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.27.3",
+  "version": "8.27.4",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.27.3",
+  "version": "8.27.4",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Pagination/index.js
+++ b/react/components/Pagination/index.js
@@ -38,12 +38,22 @@ class Pagination extends PureComponent {
   }
 
   render() {
-    const { rowsOptions } = this.props
+    const {
+      rowsOptions,
+      totalItems,
+      currentItemFrom,
+      currentItemTo,
+      textOf,
+      textShowRows,
+    } = this.props
     const { selectedRowsOptionIndex } = this.state
+
     const dropdownOptions = this.createRowOptions(rowsOptions)
 
-    const isPrevDisabled = this.props.currentItemFrom === 1
-    const isNextDisabled = this.props.currentItemTo >= this.props.totalItems
+    const isPrevDisabled = currentItemFrom === 1
+    const isNextDisabled = currentItemTo >= totalItems
+
+    const itemTo = currentItemTo > totalItems ? totalItems : currentItemTo
 
     return (
       <div
@@ -53,7 +63,7 @@ class Pagination extends PureComponent {
         {dropdownOptions && (
           <div className="flex flex-row pt5 items-baseline">
             <span className="mr4 c-muted-2 t-small self-center">
-              {this.props.textShowRows}
+              {textShowRows}
             </span>
             <Dropdown
               size="small"
@@ -66,10 +76,9 @@ class Pagination extends PureComponent {
 
         <div className="flex flex-row pt5 items-center">
           <div className="c-muted-2 t-small">
-            {this.props.currentItemFrom}
+            {currentItemFrom}
             {' - '}
-            {this.props.currentItemTo} {this.props.textOf}{' '}
-            {this.props.totalItems}
+            {itemTo} {textOf} {totalItems}
           </div>
           <div className="ml4">
             <Button

--- a/react/components/Table/sampleData.js
+++ b/react/components/Table/sampleData.js
@@ -327,17 +327,5 @@ export default {
       color5: generateRandomColorObject(),
       color6: generateRandomColorObject(),
     },
-    {
-      email: 'Alicia.Ullrich@yahoo.com',
-      name: 'Oren Beatty V',
-      number: 25.6073,
-      color: generateRandomColorObject(),
-      color1: generateRandomColorObject(),
-      color2: generateRandomColorObject(),
-      color3: generateRandomColorObject(),
-      color4: generateRandomColorObject(),
-      color5: generateRandomColorObject(),
-      color6: generateRandomColorObject(),
-    },
   ],
 }


### PR DESCRIPTION
Fixes pagination when the total amount of items in not a multiple of the rows length.
Closes https://github.com/vtex/styleguide/issues/554

Before:

<img width="166" alt="Screen Shot 2019-04-04 at 10 45 32" src="https://user-images.githubusercontent.com/2573602/55560586-e8289d80-56c6-11e9-82f2-473655ddba37.png">

After:

<img width="169" alt="Screen Shot 2019-04-04 at 10 40 01" src="https://user-images.githubusercontent.com/2573602/55560596-ed85e800-56c6-11e9-8061-5e7c6e440585.png">
