### PR TITLE
dont pass null to oneOfType function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix withFowardedRef prop type.
 
 ## [9.28.0] - 2019-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.28.0] - 2019-04-04
+
 ## [8.28.0] - 2019-04-04
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "9.27.5",
+  "version": "9.28.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
@@ -12,6 +12,8 @@
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
-  "registries": ["smartcheckout"],
+  "registries": [
+    "smartcheckout"
+  ],
   "settingsSchema": {}
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,17 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.28.0",
+  "version": "9.27.5",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
-    "react": "2.x"
+    "react": "3.x"
   },
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "settingsSchema": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.27.5",
+  "version": "9.28.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.28.0",
+  "version": "9.27.5",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/modules/withForwardedRef.js
+++ b/react/modules/withForwardedRef.js
@@ -10,7 +10,7 @@ const Element =
 export const refShape = PropTypes.oneOfType([
   PropTypes.func,
   PropTypes.shape({
-    current: PropTypes.oneOfType([null, PropTypes.instanceOf(Element)]),
+    current: PropTypes.instanceOf(Element),
   }),
 ])
 


### PR DESCRIPTION
FIx error:
<img width="417" alt="Screen Shot 2019-04-05 at 12 11 27 PM" src="https://user-images.githubusercontent.com/4925068/55638085-c7327c00-579c-11e9-9d29-41f97324d208.png">


wks: https://teste--storecomponents.myvtex.com/

There is no need to pass oneOfType([null, mytype]), this is already implicit if you don't insert a `.isRequired` after your type.