### PR TITLE
Set checkbox input parent's position to relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.30.1] - 2019-04-10
+
 ### Fixed
 
 - **Toggle** Set checkbox input parent's position to relative.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Toggle** Set checkbox input parent's position to relative.
+
 ## [8.30.0] - 2019-04-10
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.30.0",
+  "version": "8.30.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.30.0",
+  "version": "8.30.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Toggle/index.js
+++ b/react/components/Toggle/index.js
@@ -146,7 +146,9 @@ class Toggle extends Component {
 
     return (
       <label htmlFor={id || undefined}>
-        <div className={`flex flex-row items-center relative ${!disabled && 'pointer'}`}>
+        <div
+          className={`flex flex-row items-center relative ${!disabled &&
+            'pointer'}`}>
           <div className={`vtex-toggle ${classes}`} style={style}>
             <div className={circleClasses} style={circleStyle} />
             {semantic && (

--- a/react/components/Toggle/index.js
+++ b/react/components/Toggle/index.js
@@ -146,7 +146,7 @@ class Toggle extends Component {
 
     return (
       <label htmlFor={id || undefined}>
-        <div className={`flex flex-row items-center ${!disabled && 'pointer'}`}>
+        <div className={`flex flex-row items-center relative ${!disabled && 'pointer'}`}>
           <div className={`vtex-toggle ${classes}`} style={style}>
             <div className={circleClasses} style={circleStyle} />
             {semantic && (


### PR DESCRIPTION
### Problem

Checkbox input "outside" HMTL in terms of positioning.

![image](https://user-images.githubusercontent.com/15948386/55751816-fa833e00-5a1c-11e9-8043-157b696da7ac.png)

![image](https://user-images.githubusercontent.com/15948386/55751834-0111b580-5a1d-11e9-847d-22b248dd5fa3.png)

### Solution
["The absolutely positioned element will position itself relative to the nearest positioned ancestor."](https://medium.freecodecamp.org/how-to-understand-css-position-absolute-once-and-for-all-b71ca10cd3fd)