### PR TITLE
Table's toolbar without the search bar is aligned to the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.36.1] - 2019-04-18
+
 ### Changed
 
 - **Table**: `Toolbar` without the search input now aligns to the right.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **Table**: `Toolbar` without the search input now aligns to the right.
+
 ## [8.36.0] - 2019-04-17
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.36.0",
+  "version": "8.36.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.36.0",
+  "version": "8.36.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -116,6 +116,7 @@ class Toolbar extends PureComponent {
     const isExtraActionsVisible =
       extraActions && extraActions.label && extraActions.actions.length > 0
     const isNewLineVisible = newLine && newLine.label
+    const isSearchBarVisible = !!inputSearch
     const isDensityVisible =
       density &&
       density.buttonLabel &&
@@ -124,7 +125,11 @@ class Toolbar extends PureComponent {
       density.highOptionLabel
 
     return (
-      <div id="toolbar" className="mb5 flex flex-row justify-between w-100">
+      <div
+        id="toolbar"
+        className={`mb5 flex flex-row w-100 ${
+          isSearchBarVisible ? 'justify-between' : 'justify-end'
+        }`}>
         {inputSearch && (
           <form className="w-40" onSubmit={this.handleInputSearchSubmit}>
             <InputSearch disabled={loading} {...inputSearch} />


### PR DESCRIPTION
This PR fixes the case where you want to use the `Toolbar` without the search bar.

Before: 
<img width="858" alt="Screen Shot 2019-04-16 at 17 05 55" src="https://user-images.githubusercontent.com/10400340/56241044-38124780-606b-11e9-89e9-fa73515569b4.png">

After:
<img width="851" alt="Screen Shot 2019-04-16 at 17 05 28" src="https://user-images.githubusercontent.com/10400340/56241049-3ba5ce80-606b-11e9-844e-09648d2d99f0.png">

