### PR TITLE
Add ProgressBar component to the Styleguide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **ProgressBar** added to the styleguide.
+
 ## [8.37.1] - 2019-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.38.0] - 2019-04-30
+
 ### Added
 
 - **ProgressBar** added to the styleguide.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.37.1",
+  "version": "8.38.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.37.1",
+  "version": "8.38.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/ProgressBar.js
+++ b/react/ProgressBar.js
@@ -1,0 +1,3 @@
+import ProgressBar from './components/ProgressBar/index'
+
+export default ProgressBar

--- a/react/components/ProgressBar/README.md
+++ b/react/components/ProgressBar/README.md
@@ -1,0 +1,61 @@
+#### A ProgressBar should be used to represent the linear progression of some workflow by representing which steps are completed, in progress or yet to do.
+
+### 👍 Dos
+- The steps should be used in this order: "Completed", "In Progress" and "To Do". You are free to choose the quantity of steps.
+- Steps should be grouped together by their type.
+
+### 👎 Don'ts
+- Don't put more than one "in progress" step.
+- Don't put steps of a different type in between steps of the same type (e.g. ["Completed", "In Progress", "Completed"]). Remember that the component represents a linear progression.
+
+Simple ProgressBar example
+```jsx
+<div style={{width: "300px", height: "40px"}}>
+  <ProgressBar steps={["completed", "inProgress", "toDo"]}/>
+  <span className="vtex-input__label mb3 w-100"> Second Action in Progress</span>
+</div>
+```
+
+ProgressBar with all steps to do
+
+```jsx
+<div style={{width: "300px", height: "40px"}}>
+  <ProgressBar steps={["toDo", "toDo", "toDo", "toDo"]}/>
+  <span className="vtex-input__label mb3 w-100"> First Action Ready to Begin</span>
+</div>
+```
+
+Completed ProgressBar example
+
+```jsx
+<div style={{width: "300px", height: "40px"}}>
+  <ProgressBar steps={["completed", "completed"]}/>
+  <span className="vtex-input__label mb3 w-100"> All completed</span>
+</div>
+```
+
+Slim ProgressBar example
+
+```jsx
+<div style={{width: "300px", height: "40px"}}>
+  <ProgressBar slim steps={["completed", "inProgress", "toDo"]}/>
+  <span className="vtex-input__label mb3 w-100"> Second Action in Progress</span>
+</div>
+```
+
+ProgressBar with a single step in progress example
+
+```jsx
+<div style={{width: "300px", height: "40px"}}>
+  <ProgressBar steps={["inProgress"]}/>
+  <span className="vtex-input__label mb3 w-100"> In Progress</span>
+</div>
+```
+Simple danger ProgressBar example
+
+```jsx
+<div style={{width: "300px", height: "40px"}}>
+  <ProgressBar danger steps={["completed", "inProgress", "toDo"]}/>
+  <span className="vtex-input__label mb3 w-100"> Late Second Action in Progress</span>
+</div>
+```

--- a/react/components/ProgressBar/Step.js
+++ b/react/components/ProgressBar/Step.js
@@ -1,0 +1,64 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { scrollStep, roundedRight, roundedLeft } from './styles.css'
+
+const COMPLETED = 'completed'
+const IN_PROGRESS = 'inProgress'
+const TO_DO = 'toDo'
+
+class Step extends PureComponent {
+  render() {
+    const { type, roundLeft, roundRight, danger, slim } = this.props
+
+    const halfOpacity = 'rgba(255, 255, 255, 0.5)'
+    const fullOpacity = 'rgba(255, 255, 255, 0)'
+    const gradientBackgroundStyle = {
+      background: `repeating-linear-gradient(-45deg,  ${fullOpacity}, ${fullOpacity} 10px, ${halfOpacity} 10px, ${halfOpacity} 20px)`,
+    }
+
+    const backgroundColorClass = danger ? 'bg-danger' : 'bg-action-primary'
+
+    const roundLeftCSS = roundLeft ? roundedLeft : ''
+    const roundRightCSS = roundRight ? roundedRight : ''
+    const roundingStyle =
+      roundLeft && roundRight ? 'br2' : roundRightCSS || roundLeftCSS
+
+    const paddingClass = slim ? 'pa1' : 'pa2'
+
+    switch (type) {
+      case IN_PROGRESS:
+        return (
+          <div
+            className={`relative ${paddingClass} ${backgroundColorClass} overflow-hidden ${roundingStyle}`}>
+            <div
+              style={gradientBackgroundStyle}
+              className={`${scrollStep} absolute top-0 bottom-0 right-0 left--2 pr2`}
+            />
+          </div>
+        )
+      case COMPLETED:
+        return (
+          <div
+            className={`${roundingStyle} ${paddingClass} ${backgroundColorClass} flex flex-row`}
+          />
+        )
+      case TO_DO:
+      default:
+        return (
+          <div
+            className={`${roundingStyle} ${paddingClass} bg-muted-3 flex flex-row `}
+          />
+        )
+    }
+  }
+}
+
+Step.propTypes = {
+  type: PropTypes.oneOf([COMPLETED, IN_PROGRESS, TO_DO]).isRequired,
+  roundLeft: PropTypes.bool,
+  roundRight: PropTypes.bool,
+  danger: PropTypes.bool,
+  slim: PropTypes.bool,
+}
+
+export default Step

--- a/react/components/ProgressBar/index.js
+++ b/react/components/ProgressBar/index.js
@@ -1,0 +1,48 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import Step from './Step'
+
+class ProgressBar extends PureComponent {
+  isFirstElement(index) {
+    return index === 0
+  }
+
+  isLastElement(index, array) {
+    return index === array.length - 1
+  }
+
+  render() {
+    const { steps, danger, slim } = this.props
+
+    const stepsElements = steps.map((type, index) => {
+      const isFirstElement = this.isFirstElement(index)
+      const isLastElement = this.isLastElement(index, steps)
+
+      const marginRightCSS = isLastElement ? '' : 'mr2'
+      return (
+        <div className={`w-100 ${marginRightCSS}`} key={index}>
+          <Step
+            type={type}
+            roundLeft={isFirstElement}
+            roundRight={isLastElement}
+            danger={danger}
+            slim={slim}
+          />
+        </div>
+      )
+    })
+    return <div className="w-100 mb3 inline-flex flex-row">{stepsElements}</div>
+  }
+}
+
+ProgressBar.propTypes = {
+  /** Array of steps, it should be composed of instances of the following strings:'completed', 'inProgress' and 'toDo' */
+  steps: PropTypes.arrayOf(PropTypes.oneOf(['completed', 'inProgress', 'toDo']))
+    .isRequired,
+  /** Boolean representing a dangerous state of the progress (e.g. a late or critical progress), if true this changes the color of the steps */
+  danger: PropTypes.bool,
+  /** Boolean representing if the progress bar should be slim or not, if true this decreases the height of the bar */
+  slim: PropTypes.bool,
+}
+
+export default ProgressBar

--- a/react/components/ProgressBar/styles.css
+++ b/react/components/ProgressBar/styles.css
@@ -1,0 +1,20 @@
+@keyframes scroll{
+  0% {
+    transform: translate3d(0,0,0);
+  }
+  100% {
+    transform: translate3d(26px,0,0);
+  }
+}
+
+.scrollStep {
+  animation: scroll 300ms infinite linear;
+}
+
+.roundedLeft {
+  border-radius: 4px 0 0 4px
+}
+
+.roundedRight {
+  border-radius: 0 4px 4px 0
+}

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -103,6 +103,7 @@ module.exports = {
             'react/components/Spinner/index.js',
             'react/components/Table/index.js',
             'react/components/Tag/index.js',
+            'react/components/ProgressBar/index.js',
           ],
         },
         {


### PR DESCRIPTION
Add a `ProgressBar` component to the Styleguide. This component should be used to represent the progression of some workflow by representing which steps are completed, in progress or yet to do.

Example with the 3 types of steps, in order: _completed, in progress, to do_:
![stepBar](https://user-images.githubusercontent.com/3064099/56965387-8f1c2000-6b33-11e9-9690-4f957e3f4b6f.gif)


The inStore team needs this component for displaying in which step the picking activity is for the vendor in charge of the picking.

