### PR TITLE
Add name prop to toggle component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Toggle** added `name` and pass it down to `input`.
+
 ## [8.38.0] - 2019-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.39.0] - 2019-05-03
+
 ### Added
 
 - **Toggle** added `name` and pass it down to `input`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.38.0",
+  "version": "8.39.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.38.0",
+  "version": "8.39.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Toggle/index.js
+++ b/react/components/Toggle/index.js
@@ -145,7 +145,7 @@ class Toggle extends Component {
     iconStyle = { ...iconStyle, ...checkedStyle }
 
     return (
-      <label htmlFor={id || undefined}>
+      <label htmlFor={id}>
         <div
           className={`flex flex-row items-center relative ${!disabled &&
             'pointer'}`}>
@@ -163,11 +163,12 @@ class Toggle extends Component {
             )}
           </div>
           <input
-            id={id || undefined}
+            id={id}
             type="checkbox"
             className="h1 w1 absolute o-0"
             disabled={disabled}
             checked={checked}
+            name={this.props.name}
             onClick={this.props.onClick}
             onChange={this.props.onChange}
             tabIndex={0}
@@ -196,6 +197,7 @@ Toggle.propTypes = {
   disabled: PropTypes.bool,
   id: PropTypes.string,
   label: PropTypes.string,
+  name: PropTypes.string,
   onChange: PropTypes.func,
   onClick: PropTypes.func,
   size: PropTypes.oneOf(['regular', 'large']),


### PR DESCRIPTION
#### Add prop name to `Toggle` component + remove unnecessary or conditions.

I needed this prop because I'm using `formik` and the way it changes of current state is getting the name of the target (or the id) to change the values of the form. I could use id too (and I will until this PR is merged), but since the rest of the code is using name and usually when you use formik you pass the `name` prop to the element, doesn't make sense to let only the `Toggle` component passing the id.
Another point is that `Input` passed the prop name to it's `input` element, so I thought that `Toggle` should be passing too.