### PR TITLE
Fix collapsible not open on first render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.39.1] - 2019-05-03
+
 ### Fixed
 
 - **Collapsible** not open on first render with `isOpen` set to true.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Collapsible** not open on first render with `isOpen` set to true.
+
 ## [8.39.0] - 2019-05-03
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.39.0",
+  "version": "8.39.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.39.0",
+  "version": "8.39.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Collapsible/index.js
+++ b/react/components/Collapsible/index.js
@@ -22,22 +22,34 @@ class Collapsible extends Component {
     }
   }
 
+  openCard = () => {
+    this.childrenRef.current.style.height = 'auto'
+    const childrenHeight = this.childrenRef.current.offsetHeight
+    this.childrenRef.current.style.height = 0
+    /** after force setting element height like the line above
+     * you have to force layout / reflow so the height value
+     * may actually apply. You can do this by requesting
+     * element offsetHeight again, like the line below
+     */
+    this.childrenRef.current.offsetHeight
+    this.setState({
+      height: childrenHeight,
+    })
+  }
+
+  componentDidMount() {
+    if (this.props.isOpen) {
+      this.openCard()
+    }
+  }
+
   componentDidUpdate(prevProps) {
-    if (!prevProps.isOpen && this.props.isOpen) {
-      this.childrenRef.current.style.height = 'auto'
-      const childrenHeight = this.childrenRef.current.offsetHeight
-      this.childrenRef.current.style.height = 0
-      /** after force setting element height like the line above
-       * you have to force layout / reflow so the height value
-       * may actually apply. You can do this by requesting
-       * element offsetHEigh again, like the line below
-       */
-      this.childrenRef.current.offsetHeight
-      this.setState({
-        height: childrenHeight,
-      })
-    } else if (prevProps.isOpen && !this.props.isOpen) {
-      this.setState({ height: 0 })
+    if (prevProps.isOpen !== this.props.isOpen) {
+      if (this.props.isOpen) {
+        this.openCard()
+      } else {
+        this.setState({ height: 0 })
+      }
     }
   }
 
@@ -63,7 +75,11 @@ class Collapsible extends Component {
       <div>
         <div
           className="flex flex-wrap items-center pointer"
-          onClick={() => handleClick(callback, !isOpen)}>
+          tabIndex={0}
+          role="button"
+          onClick={() => handleClick(callback, !isOpen)}
+          onKeyDown={e => e.key === 'Enter' && handleClick(callback, !isOpen)}
+          aria-expanded={isOpen}>
           {align === 'left' ? (
             <Fragment>
               <div className={`${color} mr3`}>
@@ -80,7 +96,10 @@ class Collapsible extends Component {
             </Fragment>
           )}
         </div>
-        <div ref={this.childrenRef} style={childrenContainerStyle}>
+        <div
+          ref={this.childrenRef}
+          style={childrenContainerStyle}
+          role="region">
           {children}
         </div>
       </div>


### PR DESCRIPTION
when first rendered with `isOpen` set to `true`, the component was still closed.