### PR TITLE
Add CheckboxGroup component to the Styleguide and fix some page links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.40.0] - 2019-05-03
+
 ### Added
 - **CheckboxGroup** added to the styleguide.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- **CheckboxGroup** added to the styleguide.
+
+### Fixed
+- Fix some component pages references not working properly.
+
 ## [8.39.1] - 2019-05-03
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.39.1",
+  "version": "8.40.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.39.1",
+  "version": "8.40.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/CheckboxGroup.js
+++ b/react/CheckboxGroup.js
@@ -1,0 +1,3 @@
+import CheckboxGroup from './components/CheckboxGroup/index'
+
+export default CheckboxGroup

--- a/react/components/Checkbox/README.md
+++ b/react/components/Checkbox/README.md
@@ -12,7 +12,8 @@
 
 ### Related components
 
-- Consider using a <a href="#toggle">Toggle</a> if the choice could be read as "turning something on or off".
+- Consider using a <a href="#/Components/Forms/Toggle">Toggle</a> if the choice could be read as "turning something on or off".
+- If the checkboxes are related, you can consider the use of a <a href="#/Components/Forms/CheckboxGroup">CheckboxGroup</a>
 
 Default
 

--- a/react/components/CheckboxGroup/README.md
+++ b/react/components/CheckboxGroup/README.md
@@ -1,0 +1,64 @@
+#### A CheckboxGroup represents a group of related binary choices in the format of checkboxes.
+
+### 👍 Dos
+
+- Initialize it with a default value that makes sense to your needs.
+- Use a text label for the checkbox groups, which should clearly inform that this checkbox checks or uncheks all the other checkboxes.
+- Use a text label for each of the inner checkboxes, which should be intuitive and provide sufficient context for the user take that decision.
+
+### 👎 Don'ts
+
+- Don't use negative labels because they are harder to interpret.
+- Don't implement an "autosave" behavior: checkboxes should always require the use of a button (like "SAVE" or "OK") to commit the choice.
+
+### Related components
+
+- If the inner checkboxes have no relation between them consider using single <a href="#/Components/Forms/Checkbox">Checkboxes</a>.
+
+Simple Group
+
+```js
+initialState = { checkedMap: {
+    check1: {label: "Filter 1", checked: true}, 
+    check2: {label: "Filter 2", checked: false}, 
+    check3: {label: "Filter 3", checked: false}
+   }
+}
+;<div>
+<CheckboxGroup name="simpleCheckboxGroup" label="All Filters" checkedMap={state.checkedMap} onGroupChange={newCheckedMap => {
+    setState({checkedMap: newCheckedMap})
+  }}/>
+</div>
+```
+
+Disabled Group
+
+```js
+initialState = { checkedMap: {
+    check1: {label: "Filter 1", checked: true}, 
+    check2: {label: "Filter 2", checked: false}, 
+    check3: {label: "Filter 3", checked: false}
+   }
+}
+;<div>
+<CheckboxGroup name="simpleCheckboxGroup" disabled label="All Filters" checkedMap={state.checkedMap} onGroupChange={newCheckedMap => {
+    setState({checkedMap: newCheckedMap})
+  }}/>
+</div>
+```
+
+Wihtout label group
+
+```js
+initialState = { checkedMap: {
+    check1: {checked: true}, 
+    check2: {checked: false}, 
+    check3: {checked: false}
+   }
+}
+;<div>
+<CheckboxGroup name="simpleCheckboxGroup" checkedMap={state.checkedMap} onGroupChange={newCheckedMap => {
+    setState({checkedMap: newCheckedMap})
+  }}/>
+</div>
+```

--- a/react/components/CheckboxGroup/README.md
+++ b/react/components/CheckboxGroup/README.md
@@ -62,3 +62,18 @@ initialState = { checkedMap: {
   }}/>
 </div>
 ```
+Without Padding
+
+```js
+initialState = { checkedMap: {
+    check1: {label: "Filter 1", checked: true}, 
+    check2: {label: "Filter 2", checked: false}, 
+    check3: {label: "Filter 3", checked: false}
+   }
+}
+;<div>
+<CheckboxGroup padded={false} name="simpleCheckboxGroup" label="All Filters" checkedMap={state.checkedMap} onGroupChange={newCheckedMap => {
+    setState({checkedMap: newCheckedMap})
+  }}/>
+</div>
+```

--- a/react/components/CheckboxGroup/index.js
+++ b/react/components/CheckboxGroup/index.js
@@ -52,22 +52,22 @@ class CheckboxGroup extends Component {
   }
 
   render() {
-    const { checkedMap, disabled, name, id, value, label } = this.props
+    const { checkedMap, disabled, name, id, value, label, padded } = this.props
     return (
       <div>
         <Checkbox
           checked={this.isAllChecked()}
           partial={this.isPartialChecked()}
-          id={`${id}`}
+          id={id}
           name={name}
           onChange={this.handleOnGroupChange}
-          value={`${value}`}
+          value={value}
           disabled={disabled}
           label={label}
         />
-        <div className="ml7 mv5">
+        <div className={`${padded ? 'ml7' : ''} mv5`}>
           {Object.keys(checkedMap).map(key => (
-            <div key={key} className="mv6 ">
+            <div key={key} className="mv6">
               <Checkbox
                 checked={checkedMap[key].checked}
                 id={`${id}-${key}`}
@@ -87,6 +87,7 @@ class CheckboxGroup extends Component {
 
 CheckboxGroup.defaultProps = {
   disabled: false,
+  padded: true,
 }
 
 CheckboxGroup.propTypes = {
@@ -109,6 +110,8 @@ CheckboxGroup.propTypes = {
   onGroupChange: PropTypes.func.isRequired,
   /** (Input spec attribute) */
   value: PropTypes.string.isRequired,
+  /** Setting for the padding, set it for false if want the inner checkboxes with no padding in relation to the main checkbox */
+  padded: PropTypes.bool,
 }
 
 export default CheckboxGroup

--- a/react/components/CheckboxGroup/index.js
+++ b/react/components/CheckboxGroup/index.js
@@ -1,0 +1,114 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+import some from 'lodash/some'
+import every from 'lodash/every'
+
+import Checkbox from '../Checkbox'
+
+class CheckboxGroup extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { groupChecked: false }
+  }
+
+  isPartialChecked = () => {
+    const { checkedMap } = this.props
+    const checkedValues = Object.values(checkedMap).map(value => value.checked)
+    return some(checkedValues) && !every(checkedValues)
+  }
+
+  isAllChecked = () => {
+    const { checkedMap } = this.props
+    const checkedValues = Object.values(checkedMap).map(value => value.checked)
+    return every(checkedValues)
+  }
+
+  handleOnChange = key => {
+    const { checkedMap } = this.props
+    const newCheckedMap = {
+      ...checkedMap,
+      [key]: { ...checkedMap[key], checked: !checkedMap[key].checked },
+    }
+    this.props.onGroupChange(newCheckedMap)
+  }
+
+  handleOnGroupChange = () => {
+    if (this.isPartialChecked() || this.isAllChecked()) {
+      const { checkedMap } = this.props
+      const newCheckedMap = { ...checkedMap }
+      Object.keys(checkedMap).forEach(
+        key => (newCheckedMap[key].checked = false)
+      )
+      this.props.onGroupChange(newCheckedMap)
+    } else {
+      const { checkedMap } = this.props
+      const newCheckedMap = { ...checkedMap }
+      Object.keys(checkedMap).forEach(
+        key => (newCheckedMap[key].checked = true)
+      )
+      this.props.onGroupChange(newCheckedMap)
+    }
+  }
+
+  render() {
+    const { checkedMap, disabled, name, id, value, label } = this.props
+    return (
+      <div>
+        <Checkbox
+          checked={this.isAllChecked()}
+          partial={this.isPartialChecked()}
+          id={`${id}`}
+          name={name}
+          onChange={this.handleOnGroupChange}
+          value={`${value}`}
+          disabled={disabled}
+          label={label}
+        />
+        <div className="ml7 mv5">
+          {Object.keys(checkedMap).map(key => (
+            <div key={key} className="mv6 ">
+              <Checkbox
+                checked={checkedMap[key].checked}
+                id={`${id}-${key}`}
+                name={name}
+                onChange={() => this.handleOnChange(key)}
+                value={`${value}-${key}`}
+                disabled={disabled}
+                label={checkedMap[key].label}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+}
+
+CheckboxGroup.defaultProps = {
+  disabled: false,
+}
+
+CheckboxGroup.propTypes = {
+  /** Map of objects containing the label and the checked value of each checkbox of this group */
+  checkedMap: PropTypes.objectOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      checked: PropTypes.bool.isRequired,
+    })
+  ),
+  /** (Input spec attribute) */
+  disabled: PropTypes.bool,
+  /** (Input spec attribute) */
+  id: PropTypes.string.isRequired,
+  /** Checkbox Group label (i.e. main checkbox label)*/
+  label: PropTypes.string,
+  /** (Input spec attribute) */
+  name: PropTypes.string.isRequired,
+  /** onChange event for the checkedMap object */
+  onGroupChange: PropTypes.func.isRequired,
+  /** (Input spec attribute) */
+  value: PropTypes.string.isRequired,
+}
+
+export default CheckboxGroup

--- a/react/components/CheckboxGroup/index.js
+++ b/react/components/CheckboxGroup/index.js
@@ -12,13 +12,13 @@ class CheckboxGroup extends Component {
     this.state = { groupChecked: false }
   }
 
-  isPartialChecked = () => {
+  isPartiallyChecked = () => {
     const { checkedMap } = this.props
     const checkedValues = Object.values(checkedMap).map(value => value.checked)
     return some(checkedValues) && !every(checkedValues)
   }
 
-  isAllChecked = () => {
+  isFullyChecked = () => {
     const { checkedMap } = this.props
     const checkedValues = Object.values(checkedMap).map(value => value.checked)
     return every(checkedValues)
@@ -33,21 +33,20 @@ class CheckboxGroup extends Component {
     this.props.onGroupChange(newCheckedMap)
   }
 
+  setGroupChecked = value => {
+    const { checkedMap } = this.props
+    const newCheckedMap = { ...checkedMap }
+    Object.keys(checkedMap).forEach(key => {
+      newCheckedMap[key].checked = value
+    })
+    return newCheckedMap
+  }
+
   handleOnGroupChange = () => {
-    if (this.isPartialChecked() || this.isAllChecked()) {
-      const { checkedMap } = this.props
-      const newCheckedMap = { ...checkedMap }
-      Object.keys(checkedMap).forEach(
-        key => (newCheckedMap[key].checked = false)
-      )
-      this.props.onGroupChange(newCheckedMap)
+    if (this.isPartiallyChecked() || this.isFullyChecked()) {
+      this.props.onGroupChange(this.setGroupChecked(false))
     } else {
-      const { checkedMap } = this.props
-      const newCheckedMap = { ...checkedMap }
-      Object.keys(checkedMap).forEach(
-        key => (newCheckedMap[key].checked = true)
-      )
-      this.props.onGroupChange(newCheckedMap)
+      this.props.onGroupChange(this.setGroupChecked(true))
     }
   }
 
@@ -56,8 +55,8 @@ class CheckboxGroup extends Component {
     return (
       <div>
         <Checkbox
-          checked={this.isAllChecked()}
-          partial={this.isPartialChecked()}
+          checked={this.isFullyChecked()}
+          partial={this.isPartiallyChecked()}
           id={id}
           name={name}
           onChange={this.handleOnGroupChange}

--- a/react/components/Toggle/README.md
+++ b/react/components/Toggle/README.md
@@ -6,7 +6,7 @@
 - It's usually a good practice to be optimistic about its effect. Even if you're not sure if the resulting network request will be successful, pretend it does and let it change its state.
 
 ### Related components
-- Consider using a <a href="#checkbox">Checkbox</a> if it's inside a form, or if the property doesn't have a clear "ON/OFF".
+- Consider using a <a href="#/Components/Forms/Checkbox">Checkbox</a> if it's inside a form, or if the property doesn't have a clear "ON/OFF".
 
 
 Default

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -113,6 +113,7 @@ module.exports = {
             'react/components/Button/index.js',
             'react/components/ButtonWithIcon/index.js',
             'react/components/Checkbox/index.js',
+            'react/components/CheckboxGroup/index.js',
             'react/components/ColorPicker/index.js',
             'react/components/DatePicker/index.js',
             'react/components/Dropdown/index.js',


### PR DESCRIPTION
Add the `CheckboxGroup` component which creates a group of `Checkbox` components based on its props. 

The group of checkbox should be somehow related, the main checkbox is also created allowing the checking or unchecking of all inner checkboxes.

![checkboxGroup](https://user-images.githubusercontent.com/3064099/57151412-48366080-6da7-11e9-9bcf-09912cacfd46.gif)

The spacing between the checkbox is optimized for mobile applications. This can be later modified by props in a future PR.

Also, some references to other components were modified as they seemed to not be working properly.