### PR TITLE
Add caretColor prop to the Collapsible component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- **Collapsible** now receives a props containing a color name for its caret icon.
+
 ## [8.42.0] - 2019-05-09
 ### Added
 - BottomBar and TopBar to ***Modal***

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.43.0] - 2019-05-09
+
 ### Added
 - **Collapsible** now receives a props containing a color name for its caret icon.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.42.0",
+  "version": "8.43.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.42.0",
+  "version": "8.43.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Collapsible/README.md
+++ b/react/components/Collapsible/README.md
@@ -64,6 +64,44 @@ initialState = { isOpen: false }
 </div>
 ```
 
+Custom Caret Color Example
+
+```js
+initialState = { isOpen1: false, isOpen2: false, isOpen3: false }
+;<div>
+  <Collapsible
+    header={<span>Here goes your base header</span>}
+    onClick={e => setState({ isOpen1: e.target.isOpen })}
+    isOpen={state.isOpen1}
+    caretColor="base"
+    >
+      <div className="mt4">
+        Here goes your content
+      </div>
+  </Collapsible>
+  <Collapsible
+    header={<span>Here goes your primary header</span>}
+    onClick={e => setState({ isOpen2: e.target.isOpen })}
+    isOpen={state.isOpen2}
+    caretColor="primary"
+    >
+      <div className="mt4">
+        Here goes your content
+      </div>
+  </Collapsible>
+  <Collapsible
+    header={<span>Here goes your muted header</span>}
+    onClick={e => setState({ isOpen3: e.target.isOpen })}
+    isOpen={state.isOpen3}
+    caretColor="muted"
+    >
+      <div className="mt4">
+        Here goes your content
+      </div>
+  </Collapsible>
+</div>
+```
+
 Navigation bar example
 
 ```js
@@ -92,7 +130,7 @@ initialState = { isOpen1: false, isOpen2: false, isOpen3: false }
           align="right"
           onClick={e => setState({ isOpen1: e.target.isOpen })}
           isOpen={state.isOpen1}
-          muted
+          caretColor="muted"
           >
             <div className="ml6 mt4">
               <a href="#" className="mt3 c-muted-1 link db hover-c-link">Products and SKUs</a>
@@ -124,7 +162,7 @@ initialState = { isOpen1: false, isOpen2: false, isOpen3: false }
           align="right"
           onClick={e => setState({ isOpen2: e.target.isOpen })}
           isOpen={state.isOpen2}
-          muted
+          caretColor="muted"
           >
             <div className="ml6 mt4">
               <a href="#" className="mt3 c-muted-1 link db hover-c-link">Transactions</a>
@@ -155,7 +193,7 @@ initialState = { isOpen1: false, isOpen2: false, isOpen3: false }
           align="right"
           onClick={e => setState({ isOpen3: e.target.isOpen })}
           isOpen={state.isOpen3}
-          muted
+          caretColor="muted"
           >
             <div className="ml6 mt4">
               <a href="#" className="mt3 c-muted-1 link db hover-c-link">Dashboard</a>

--- a/react/components/Collapsible/index.js
+++ b/react/components/Collapsible/index.js
@@ -5,6 +5,12 @@ import CaretDown from '../icon/CaretDown'
 import CaretUp from '../icon/CaretUp'
 import { jsFocusVisible } from './styles.css'
 
+const colorMap = {
+  base: 'c-on-base',
+  primary: 'c-action-primary',
+  muted: 'c-muted-3',
+}
+
 function handleClick(callback, isOpen) {
   callback &&
     callback({
@@ -12,6 +18,10 @@ function handleClick(callback, isOpen) {
         isOpen,
       },
     })
+}
+
+function mapToCSSClass(color) {
+  return colorMap[color]
 }
 
 class Collapsible extends Component {
@@ -63,14 +73,21 @@ class Collapsible extends Component {
       onClick: callback,
       isOpen,
     } = this.props
+    let { caretColor } = this.props
     const { height } = this.state
     const childrenContainerStyle = {
       height,
       overflow: 'hidden',
       transition: 'height 250ms ease-in-out',
     }
+    if (muted) {
+      caretColor = caretColor || 'muted'
+      console.warn(
+        `The "muted" prop on the "Collapsible" component is depreacted and will be removed in a future version. Use "caretColor='muted'" instead.`
+      )
+    }
 
-    const color = muted ? 'c-muted-3' : 'c-action-primary'
+    const color = caretColor ? mapToCSSClass(caretColor) : 'c-action-primary'
 
     return (
       <div className={jsFocusVisible}>
@@ -122,7 +139,7 @@ Collapsible.propTypes = {
   children: PropTypes.node.isRequired,
   /** Component to be used as the header of the collapsible. */
   header: PropTypes.node.isRequired,
-  /** Renders the caret in muted-3 instead of action-primary.
+  /** @deprecated Use the 'muted' option in the caretColor prop instead.
    * To be used only in dense scenarios, or when the affordance is clearly
    * conveyed by the context. */
   muted: PropTypes.bool,
@@ -130,6 +147,8 @@ Collapsible.propTypes = {
   isOpen: PropTypes.bool,
   /** _onClick_ event. */
   onClick: PropTypes.func,
+  /** Color or semantic to be applied to the Caret Icon in the Collapsible header.*/
+  caretColor: PropTypes.oneOf(Object.keys(colorMap)),
 }
 
 export default Collapsible


### PR DESCRIPTION
Add a new prop to the `Collapsible` component named `caretColor`. This props will apply a CSS class to the Caret Icon depending on the value chosen. The possible values are `black`,  `primary` and `muted`.

<img width="267" alt="Screen Shot 2019-05-07 at 5 52 44 PM" src="https://user-images.githubusercontent.com/3064099/57332352-fc5e2100-70f0-11e9-8677-fd20452c3b4b.png">

The `muted` prop now is marked as deprecated, use the muted option of the `caretColor` instead.


