### PR TITLE
Fix/modal responsivefullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [8.45.2] - 2019-05-13
 ### Fixed
 - ResponsiveFullScreen padding
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- ResponsiveFullScreen padding
 
 ## [8.45.1] - 2019-05-10
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.45.1",
+  "version": "8.45.2",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.45.1",
+  "version": "8.45.2",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Modal/modal.global.css
+++ b/react/components/Modal/modal.global.css
@@ -1,9 +1,9 @@
-.Modal-overlay-1-1-1.pa0 {
+.vtex-modal__overlay.pa0 {
   padding: 0;
 }
 
 @media screen and (min-width: 40rem) {
-  .Modal-overlay-1-1-1.pa5-ns {
+  .vtex-modal__overlay.pa5-ns {
     padding: 1.25rem;
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove padding when prop responsive fullscreen is true and it's in mobile mode

#### What problem is this solving?
Padding in the responsiveFullScreen mode that depended on a class from another library which changed the className from 'Modal-overlay-1-1-1 ', running locally, to 'c111', at [https://styleguide.vtex.com/#/Components/Overlays/Modal](https://styleguide.vtex.com/#/Components/Overlays/Modal)

#### How should this be manually tested?
Local styleguide build

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/13491046/57553523-26a81c80-7345-11e9-887f-1b54be901837.png)
![image](https://user-images.githubusercontent.com/13491046/57553642-830b3c00-7345-11e9-9780-54f95f163ed3.png)



#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
