### PR TITLE
Hide scroll of the Menu when its content is not overflowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Hide `Menu`'s scroll bar when its content is not overflowing.
 
 ## [9.46.2] - 2019-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Get changes made at version `v8.46.2`.
+
 ## [8.46.2] - 2019-05-16
 
 ### Fixed
 
 - **Table** add offset in table content height so the horizontal scroll bar does not overlap its content.
+
+## [9.46.1] - 2019-05-16
+
+### Changed
+
+- Get changes made at version `v8.46.1`.
 
 ## [8.46.1] - 2019-05-16
 
@@ -49,15 +59,41 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **FilterOptions** component added to the styleguide.
 
+## [9.44.2] - 2019-05-10
+
+### Changed
+
+- Get changes made at version `v8.44.2`.
+
 ## [8.44.2] - 2019-05-10
 
 ### Fixed
 
 - **Table** resize.
 
+## [9.38.1] - 2019-05-09
+
+## [9.38.0] - 2019-05-09
+
+### Changed
+
+- Get changes made at version `v8.44.1`.
+
+## [9.37.0] - 2019-04-18
+
+## [9.36.1] - 2019-04-18
+
 ## [8.44.1] - 2019-05-09
 
+### Fixed
+
+- **ramda** dependency.
+
 ## [8.44.0] - 2019-05-09
+
+### Added
+
+- **Table** buldActions.
 
 ## [8.43.0] - 2019-05-09
 
@@ -122,6 +158,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Tabs** fix partial width content.
 
+### Changed
+
+- Get changes made at version `v8.37.0`.
+- Get changes made at version `v8.36.1`.
+
 ## [8.37.0] - 2019-04-18
 
 ### Added
@@ -140,11 +181,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Table**: `Toolbar` without the search input now aligns to the right.
 
+## [9.36.0] - 2019-04-17
+
+### Changed
+
+- Get changes made at version `v8.36.0`.
+
 ## [8.36.0] - 2019-04-17
 
 ### Added
 
 - **EXPERIMENTAL_ButtonWithAction** new component in _EXPERIMENTAL_ mode.
+
+## [9.35.1] - 2019-04-16
+
+### Changed
+
+- Get changes made at version `v8.35.1`.
 
 ## [8.35.1] - 2019-04-16
 
@@ -161,17 +214,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Experimental_SELECT** add `clearable` prop.
 
+## [9.35.0] - 2019-04-16
+
+### Changed
+
+- Get changes made at version `v8.35.0`.
+
 ## [8.35.0] - 2019-04-16
 
 ### Added
 
 - **Table** added disabled state to `newLine` toolbar prop.
 
+## [9.34.0] - 2019-04-15
+
 ## [8.34.0] - 2019-04-15
 
 ### Added
 
 - **Tabs** added _sticky_ property.
+
+## [9.33.0] - 2019-04-11
+
+### Changed
+
+- Get changes made at version `v.8.33.0`.
 
 ## [8.33.0] - 2019-04-11
 
@@ -184,6 +251,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Table** height behavior.
 
+## [9.32.0] - 2019-04-11
+
+### Changed
+
+- Get changes made at version `v8.32.0`.
+
 ## [8.32.0] - 2019-04-11
 
 ### Added
@@ -195,6 +268,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - **Box** added a new noPadding prop.
+
+## [9.27.4] - 2019-04-10
+
+### Changed
+
+- Get changes made at version `v8.30.2`.
+
+## [9.27.3] - 2019-04-04
+
+### Changed
+
+- Get changes made at version `v8.27.4`.
 
 ## [8.30.2] - 2019-04-10
 
@@ -252,6 +337,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed **Table** pagination when total items was not a multiple of rows length.
 
+## [9.27.2] - 2019-04-03
+
 ## [8.27.3] - 2019-04-03
 
 ### Fixed
@@ -259,6 +346,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed error caused by `instanceof` `null` on `withFowardedRef` module.
 
 ## [8.27.2] - 2019-04-03
+
+## [9.27.1] - 2019-03-28
 
 ## [8.27.1] - 2019-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.46.2] - 2019-05-16
+
 ### Changed
 
 - Get changes made at version `v8.46.2`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "9.46.1",
+  "version": "9.46.2",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.46.2",
+  "version": "9.46.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
-    "react": "2.x"
+    "react": "3.x"
   },
   "scripts": {
     "postreleasy": "vtex publish --verbose"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.46.2",
+  "version": "9.46.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.46.1",
+  "version": "9.46.2",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/FilterBar/Menu.js
+++ b/react/components/FilterBar/Menu.js
@@ -138,7 +138,7 @@ class Menu extends Component {
               style={{ width: width || DEFAULT_WIDTH }}>
               <div
                 style={{ height: menuHeight || 'auto' }}
-                className={menuHeight ? 'overflow-scroll' : ''}>
+                className={menuHeight ? 'overflow-auto' : ''}>
                 {children}
               </div>
             </div>

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -162,7 +162,7 @@ class Menu extends Component {
                 <div className="b2 br2 bg-base">
                   <div
                     style={{ height: menuHeight || 'auto' }}
-                    className={menuHeight ? 'overflow-scroll' : ''}>
+                    className={menuHeight ? 'overflow-auto' : ''}>
                     {options.map((option, index) => (
                       <button
                         key={index}

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -164,7 +164,7 @@ class Toolbar extends PureComponent {
                   <div className="w-100 b2 br2 bg-base">
                     <div
                       style={{ height: 3 * FIELDS_BOX_ITEM_HEIGHT }}
-                      className="overflow-scroll">
+                      className="overflow-auto">
                       {DENSITY_OPTIONS.map((key, index) => {
                         const isKeySelected = selectedDensity === key
                         return (
@@ -240,7 +240,7 @@ class Toolbar extends PureComponent {
                     </div>
                     <div
                       style={{ height: this.calculateFieldsBoxHeight() }}
-                      className="overflow-scroll">
+                      className="overflow-auto">
                       {Object.keys(schema.properties).map((field, index) => (
                         <div
                           key={index}


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Click here to access the workspace.](https://lumineers--storecomponents.myvtex.com/admin/customers)

- Select an ActionMenu of the table's header.

#### Screenshots or example usage

- Before
![image](https://user-images.githubusercontent.com/12852518/57903261-a0f40780-7843-11e9-8746-c361dbd2eb1b.png)

- After
![image](https://user-images.githubusercontent.com/12852518/57903240-86ba2980-7843-11e9-8a4e-cde983a83d27.png)


#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
