### PR TITLE
Change FilterOptions to begin with opened collapsibles when it have few options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.47.0] - 2019-05-20
+
 ### Added
 
 - **FilterOptions** now begins with open Collapsibles if it has less than four options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **FilterOptions** now begins with open Collapsibles if it has less than four options.
+
 ## [8.46.2] - 2019-05-16
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.46.2",
+  "version": "8.47.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.46.2",
+  "version": "8.47.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/FilterOptions/FilterColapsible.js
+++ b/react/components/FilterOptions/FilterColapsible.js
@@ -8,7 +8,7 @@ class FilterColapsible extends PureComponent {
   constructor(props) {
     super(props)
     this.state = {
-      isCollapsibleOpen: false,
+      isCollapsibleOpen: props.beginWithOpenCollapsibles,
     }
   }
 
@@ -80,6 +80,7 @@ FilterColapsible.propTypes = {
     })
   ),
   onChangeStatement: PropTypes.func.isRequired,
+  beginWithOpenCollapsibles: PropTypes.bool,
 }
 
 export default FilterColapsible

--- a/react/components/FilterOptions/index.js
+++ b/react/components/FilterOptions/index.js
@@ -45,6 +45,7 @@ class FilterOptions extends PureComponent {
                   options={options}
                   statement={statement}
                   onChangeStatement={this.handleStatementChange}
+                  beginWithOpenCollapsibles={optionsKeys.length <= 3}
                 />
               </div>
             )


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
If there are more than 3 filter options, the `Collapsible`s start opened by default.

#### What problem is this solving?
For modal use, if the `Collapsible`s starting opened helps spread the content over the container.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
