### PR TITLE
Replaces GA with Google Tag Manager

### DIFF
--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -1,5 +1,0 @@
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-
-gtag('config', 'UA-43760863-25');

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -240,14 +240,19 @@ module.exports = {
   template: {
     favicon: 'https://brand.vtex.com/favicon.ico',
     head: {
-      scripts: [
-        {
-          src: 'https://www.googletagmanager.com/gtag/js?id=UA-43760863-25',
-        },
-        {
-          src: './analytics.js',
-        },
-      ],
+      raw: `<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-M4WMB9F');</script>
+<!-- End Google Tag Manager -->`
+    },
+    body: {
+      raw: `<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M4WMB9F"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->`
     },
   },
   assetsDir: './assets',


### PR DESCRIPTION
Now Google Analytics tracking is done from inside Tag Manager, which enables us to track changes in the URL and forcing Page View events. This is necessary since the Styleguidist routing system uses fragments (those parts after the `#`), which GA doesn't support by default.