### PR TITLE
Add headerRight property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.48.1] - 2019-05-24
+
 ### Added
 
 - **Table** schema property `headerRight`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Table** schema property `headerRight`.
+
 ## [8.48.0] - 2019-05-23
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.48.0",
+  "version": "8.48.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.48.0",
+  "version": "8.48.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -57,56 +57,68 @@ const defaultSchema = {
 
 The Schema property is a JSON used to define the table columns and how they should behave visually. The Schema has properties and each one of them defines a column in the table.
 Example with simple structure:
+
 ```md
 {
-  properties: {
-    column1: {
-      title: "First Column"
-    },
-    column2: {
-      title: "Second Column",
-      width: 350
-    }
-  }
+properties: {
+column1: {
+title: "First Column"
+},
+column2: {
+title: "Second Column",
+width: 350
+}
+}
 }
 ```
 
 ##### title
-  - Control the title which appears on table Header.
-  - It receives only strings.
-  - If you want to customize it with a component, you can use the `headerRenderer` prop.
+
+- Control the title which appears on table Header.
+- It receives only strings.
+- If you want to customize it with a component, you can use the `headerRenderer` prop.
 
 ##### width
-  - Control the column width.
-  - It receives only numbers, which are values in pixels.
-  - Default value is 200px
+
+- Control the column width.
+- It receives only numbers, which are values in pixels.
+- Default value is 200px
 
 ##### minWidth
-  - Fix a minimum width to the column.
-  - It receives only numbers, which are values in pixels.
-  - Default value is 200px
+
+- Fix a minimum width to the column.
+- It receives only numbers, which are values in pixels.
+- Default value is 200px
 
 ##### cellRenderer
-  - Customize the render method of a single column cell.
-  - It receives a function that returns a node (react component).
-  - The function has the following params: ({ cellData, rowData })
-  - Default is render the value as a string.
-  - If you have a custom cell component that has a click interaction and at the same time you use the onRowClick Table prop, you might stumble uppon the problem of both click actions being fired. We can work around that by doing a wrapper around cellRenderer to stop click event propagation, like so:
 
- ```jsx noeditor static
- {
-   properties: {
-     column1: {
-       cellRenderer: ({ cellData, rowData }) => {
-         return (
-          <div onClick={e => {
-            e.stopPropagation()
-            // the click event propagation start on the checkbox click below, and propagates up the DOM tree.
-            // this wrapper is going to catch the event right after it fires and stop it's propagation.
-            // stoping the click event from propagating until the row component node,
-            // so the onRowClick will not be fired.
-            // you can learm more about DOM event propagation here: http://tiny.cc/c1625y
-          }}>
+- Customize the render method of a single column cell.
+- It receives a function that returns a node (react component).
+- The function has the following params: ({ cellData, rowData })
+- Default is render the value as a string.
+- If you have a custom cell component that has a click interaction and at the same time you use the onRowClick Table prop, you might stumble uppon the problem of both click actions being fired. We can work around that by doing a wrapper around cellRenderer to stop click event propagation, like so:
+
+##### headerRight
+
+- Use this boolean property to align right the text of a header. Useful for monetary values.
+- Usage: `headerRight: true`.
+- You will have to use the `cellRenderer` proerty to also align right the content of the column.
+
+```jsx noeditor static
+{
+  properties: {
+    column1: {
+      cellRenderer: ({ cellData, rowData }) => {
+        return (
+          <div
+            onClick={e => {
+              e.stopPropagation()
+              // the click event propagation start on the checkbox click below, and propagates up the DOM tree.
+              // this wrapper is going to catch the event right after it fires and stop it's propagation.
+              // stoping the click event from propagating until the row component node,
+              // so the onRowClick will not be fired.
+              // you can learm more about DOM event propagation here: http://tiny.cc/c1625y
+            }}>
             <Checkbox
               checked={this.state.check}
               id="select-option"
@@ -114,12 +126,12 @@ Example with simple structure:
               onChange={() => this.setState({ check: !this.state.check })}
             />
           </div>
-         )
-       }
-     }
-   }
- }
- ```
+        )
+      }
+    }
+  }
+}
+```
 
 Example customizing color column cell, with clickable badges
 
@@ -195,10 +207,10 @@ class CustomTableExample extends React.Component {
 ```
 
 ##### sortable
-  - Sinalize that a column is sortable, so the header will be clickable.
-  - This prop receives a boolean.
-  - On sortable header's click the Table `onSort` callback will be fired.
 
+- Sinalize that a column is sortable, so the header will be clickable.
+- This prop receives a boolean.
+- On sortable header's click the Table `onSort` callback will be fired.
 
 Example sortable by Name
 
@@ -262,10 +274,14 @@ class CustomTableExample extends React.Component {
         },
         email: {
           title: 'Email',
-          width: 350,
+          width: 300,
         },
         number: {
-          title: 'Number',
+          title: 'Value',
+          headerRight: true,
+          cellRenderer: data => (
+            <div className="w-100 tr">$ {data.cellData}</div>
+          ),
         },
       },
     }
@@ -291,12 +307,14 @@ class CustomTableExample extends React.Component {
 ```
 
 ##### headerRenderer
-  - Customized the render method of a single header cell.
-  - It receives a function that returns a node (react component).
-  - The function has the following params: ({ columnIndex, key, title })
-  - This prop will not work if the `sortable` prop for the same header is active.
+
+- Customized the render method of a single header cell.
+- It receives a function that returns a node (react component).
+- The function has the following params: ({ columnIndex, key, title })
+- This prop will not work if the `sortable` prop for the same header is active.
 
 example customizing number column header to use intl FormattedMessage
+
 ```js
 const sampleData = require('./sampleData').default
 const itemsCopy = sampleData.items
@@ -307,7 +325,7 @@ const Tag = require('../Tag').default
 class FormattedMessage extends React.Component {
   render() {
     const renderTextByIntlId = id => {
-      switch(id) {
+      switch (id) {
         case 'some.intl.message.id':
           return 'Number'
           break
@@ -316,9 +334,7 @@ class FormattedMessage extends React.Component {
           break
       }
     }
-    return (
-      <span>{renderTextByIntlId(this.props.id)}</span>
-    )
+    return <span>{renderTextByIntlId(this.props.id)}</span>
   }
 }
 
@@ -344,9 +360,7 @@ class CustomTableExample extends React.Component {
         number: {
           title: 'some.intl.message.id',
           headerRenderer: ({ title }) => {
-            return (
-              <FormattedMessage id={title} />
-            )
+            return <FormattedMessage id={title} />
           },
         },
       },
@@ -355,10 +369,7 @@ class CustomTableExample extends React.Component {
     return (
       <div>
         <div className="mb5">
-          <Table
-            schema={customSchema}
-            items={this.state.orderedItems}
-          />
+          <Table schema={customSchema} items={this.state.orderedItems} />
         </div>
       </div>
     )
@@ -376,7 +387,7 @@ class CustomTableExample extends React.Component {
 ##### Custom empty state
 
 Empty states can also be customized, the passed children will be rendered inside an EmptyState component.
-It's worth to customize empty state using this prop so the other table features will behave  accordingly (e.g. the topbar, pagination and totalizers).
+It's worth to customize empty state using this prop so the other table features will behave accordingly (e.g. the topbar, pagination and totalizers).
 
 ```js
 const sampleData = require('./sampleData').default

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -194,6 +194,8 @@ class SimpleTable extends Component {
                         // Header row
                         const title =
                           schema.properties[property].title || property
+                        const headerRight =
+                          schema.properties[property].headerRight || false
                         const headerRenderer =
                           schema.properties[property].headerRenderer
                         const arrowIsDown =
@@ -209,24 +211,25 @@ class SimpleTable extends Component {
                             }}
                             className={`flex items-center w-100 h-100 c-muted-2 f6 truncate ph4 ${
                               columnIndex === 0 && fixFirstColumn ? 'br' : ''
-                            } bt bb b--muted-4 overflow-x-hidden`}>
+                            } bt bb b--muted-4 overflow-x-hidden ${
+                              headerRight ? 'tr' : 'tl'
+                            }`}>
                             {schema.properties[property].sortable ? (
-                              <span
-                                className="pointer c-muted-1 b t-small"
+                              <div
+                                className="w-100 pointer c-muted-1 b t-small"
                                 onClick={() => {
                                   onSort(this.toggleSortType(property))
                                 }}>
-                                {`${title} `}
+                                {!headerRight && `${title} `}
                                 {arrowIsDown ? (
                                   <ArrowDown size={ARROW_SIZE} />
                                 ) : arrowIsUp ? (
                                   <ArrowUp size={ARROW_SIZE} />
                                 ) : null}
-                              </span>
-                            ) : columnIndex === 0 && fixFirstColumn ? (
-                              <div className="w-100 flex items-center">
-                                <span>{title}</span>
+                                {headerRight && ` ${title}`}
                               </div>
+                            ) : columnIndex === 0 && fixFirstColumn ? (
+                              <div className="w-100">{title}</div>
                             ) : headerRenderer ? (
                               headerRenderer({
                                 columnIndex,
@@ -236,7 +239,7 @@ class SimpleTable extends Component {
                                 title,
                               })
                             ) : (
-                              title
+                              <span className="w-100">{title}</span>
                             )}
                           </div>
                         )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add property to align right the text of a header cell.

#### What problem is this solving?
Useful when a column is a sortable of monetary values which was not possible before.

#### How should this be manually tested?
`yarn styleguide` in this branch.

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
