### PR TITLE
Misc improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - **EXPERIMENTAL_Select**: `formatCreateLabel` now allows the user to customize the create option message.
+- **Textarea**: `resize` property to control the component's resize behaviour. See [resize CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/resize) for more info.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Spinner** Use CSS animations instead of SVG animations, in order to make the animation work while the page is loading.
+
 ### Added
 
 - **EXPERIMENTAL_Select**: `formatCreateLabel` now allows the user to customize the create option message.
@@ -15,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - **Button** now uses `b--muted-5` instead of `b--disabled` when it is `disabled`.
+
+### Removed
+
+- **Spinner** prop `status`
 
 ## [8.48.1] - 2019-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **EXPERIMENTAL_Select**: `formatCreateLabel` now allows the user to customize the create option message.
+
 ### Changed
 
 - **Button** now uses `b--muted-5` instead of `b--disabled` when it is `disabled`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **Button** now uses `b--muted-5` instead of `b--disabled` when it is `disabled`.
+
 ## [8.48.1] - 2019-05-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.49.0] - 2019-05-24
+
 ### Fixed
 
 - **Spinner** Use CSS animations instead of SVG animations, in order to make the animation work while the page is loading.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.48.1",
+  "version": "8.49.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.48.1",
+  "version": "8.49.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -93,7 +93,7 @@ class Button extends Component {
         default:
         case 'primary': {
           if (disabled) {
-            classes += 'bg-disabled b--disabled c-on-disabled '
+            classes += 'bg-disabled b--muted-5 c-on-disabled '
           } else {
             classes += primaryEnabledClasses
           }
@@ -101,7 +101,7 @@ class Button extends Component {
         }
         case 'secondary': {
           if (disabled) {
-            classes += 'bg-disabled b--disabled c-on-disabled '
+            classes += 'bg-disabled b--muted-5 c-on-disabled '
           } else {
             classes += secondaryEnabledClasses
           }
@@ -121,7 +121,7 @@ class Button extends Component {
         }
         case 'danger': {
           if (disabled) {
-            classes += 'bg-disabled b--disabled c-on-disabled '
+            classes += 'bg-disabled b--muted-5 c-on-disabled '
           } else {
             classes +=
               'bg-danger b--danger c-on-danger hover-bg-danger hover-b--danger hover-c-on-danger '

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -49,6 +49,7 @@ class Select extends Component {
       defaultValue,
       disabled,
       errorMessage,
+      formatCreateLabel,
       label,
       loading,
       multi,
@@ -88,6 +89,7 @@ class Select extends Component {
         Placeholder,
       },
       defaultValue,
+      formatCreateLabel,
       getOptionValue,
       isClearable: clearable,
       isDisabled: disabled,
@@ -212,6 +214,8 @@ Select.propTypes = {
   disabled: PropTypes.bool,
   /** Error message, e.g., validation error message. */
   errorMessage: PropTypes.string,
+  /** Gets the label for the "Create new..." option in the menu. ({inputValue}) => string | null */
+  formatCreateLabel: PropTypes.func,
   /** Label text. */
   label: PropTypes.string,
   /** Is the select in a state of loading (async). */

--- a/react/components/Spinner/README.md
+++ b/react/components/Spinner/README.md
@@ -23,50 +23,6 @@
 <Spinner />
 ```
 
-### Changing status
-
-```js
-class SpinnerStatusExample extends React.Component {
-  constructor(props) {
-    super(props)
-
-    this.state = { loading: true }
-
-    this.scheduleLoading = this.scheduleLoading.bind(this)
-    this.toggleLoading = this.toggleLoading.bind(this)
-  }
-
-  componentDidMount() {
-    this.mounted = true
-    this.scheduleLoading()
-  }
-
-  scheduleLoading() {
-    this.timeout = setTimeout(this.toggleLoading, 2000)
-  }
-
-  toggleLoading() {
-    this.setState(prevState => ({ loading: !prevState.loading }))
-    this.scheduleLoading()
-  }
-
-  componentWillUnmount() {
-    this.mounted = false
-    this.timeout && clearTimeout(this.timeout)
-  }
-
-  render() {
-    return (
-      <div className="flex items-center">
-        <Spinner status={this.state.loading ? 'working' : 'idle'} />
-        <div className="ml5">{this.state.loading ? 'Working' : 'Idle'}</div>
-      </div>
-    )
-  }
-}
-;<SpinnerStatusExample />
-```
-
 #### Custom color and size
 
 ```js

--- a/react/components/Spinner/index.js
+++ b/react/components/Spinner/index.js
@@ -5,51 +5,9 @@ import { baseClassname } from '../icon/utils'
 const radius = 40
 const circ = 2 * radius * Math.PI
 
-const WORKING = 'working'
-const IDLE = 'idle'
-
 class Spinner extends React.Component {
-  constructor(props) {
-    super(props)
-
-    this.strokeAnim = React.createRef()
-
-    this.state = {
-      animating: props.status === WORKING,
-    }
-  }
-
-  onNextLoop = callback => {
-    this.strokeAnim.current.onrepeat = () => {
-      callback()
-      this.strokeAnim.current.onrepeat = null
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    const { status } = this.props
-    const { status: prevStatus } = prevProps
-
-    if (status !== prevStatus) {
-      if (status === IDLE) {
-        this.onNextLoop(() => {
-          this.setState({
-            animating: false,
-          })
-        })
-      } else if (status === WORKING) {
-        this.onNextLoop(() => {
-          this.setState({
-            animating: true,
-          })
-        })
-      }
-    }
-  }
-
   render() {
     const { color, size, block } = this.props
-    const { animating } = this.state
 
     return (
       <svg
@@ -61,42 +19,49 @@ class Spinner extends React.Component {
         preserveAspectRatio="xMidYMid"
         height={size}
         width={size}>
-        <g visibility={animating ? 'inherit' : 'hidden'}>
-          <circle
-            className="vtex-spinner_circle"
-            cx="50"
-            cy="50"
-            fill="none"
-            r={radius}
-            stroke={color || 'currentColor'}
-            strokeWidth="10"
-            strokeDasharray={`0 0 2 ${circ}`}
-            strokeLinecap="round"
-            strokeDashoffset="1"
-            transform="rotate(-90 50 50)">
-            <animate
-              attributeName="stroke-dasharray"
-              dur="1.25s"
-              calcMode="spline"
-              keyTimes="0;0.5;1"
-              keySplines="0.455, 0.030, 0.515, 0.955; 0.455, 0.030, 0.515, 0.955"
-              repeatCount="indefinite"
-              values={`0 0 2 ${circ};
-          0 0 ${circ * 0.75} ${circ};
-          0 ${circ - 2} ${circ * 0.75} ${circ}`}
-              ref={this.strokeAnim}
-            />
-            <animateTransform
-              attributeName="transform"
-              type="rotate"
-              calcMode="linear"
-              values="-90 50 50;275 50 50"
-              keyTimes="0;1"
-              dur="0.625s"
-              repeatCount="indefinite"
-            />
-          </circle>
-        </g>
+        <style>
+          {`
+            @keyframes vtex-spinner-rotate {
+              from {
+                transform-origin: 50% 50%;
+                transform: rotate(0deg);
+              }
+              to {
+                transform-origin: 50% 50%;
+                transform: rotate(360deg);
+              }
+            }
+
+            @keyframes vtex-spinner-fill {
+              0% {
+                stroke-dasharray: 0 0 2 ${circ};
+              }
+              50% {
+                stroke-dasharray: 0 0 ${circ * 0.75} ${circ};
+              }
+              100% {
+                stroke-dasharray: 0 ${circ - 2} ${circ * 0.75} ${circ};
+              }
+            }
+
+            .vtex-spinner_circle {
+              animation: vtex-spinner-fill 1.25s infinite cubic-bezier(0.455, 0.030, 0.515, 0.955), vtex-spinner-rotate 0.625s infinite linear;
+            }
+          `}
+        </style>
+
+        <circle
+          className="vtex-spinner_circle"
+          cx="50"
+          cy="50"
+          fill="none"
+          r={radius}
+          stroke={color || 'currentColor'}
+          strokeWidth="10"
+          strokeDasharray={`0 0 ${circ * 0.75} ${circ}`}
+          strokeLinecap="round"
+          strokeDashoffset="1"
+        />
       </svg>
     )
   }
@@ -107,8 +72,6 @@ Spinner.propTypes = {
   color: PropTypes.string,
   /** Size (diameter) of the spinner */
   size: PropTypes.number,
-  /** Status of the spinner; used for smooth transitioning between different states */
-  status: PropTypes.oneOf(['working', 'idle']),
   /** Sets the display to block */
   block: PropTypes.bool,
 }
@@ -116,7 +79,6 @@ Spinner.propTypes = {
 Spinner.defaultProps = {
   block: false,
   size: 40,
-  status: WORKING,
 }
 
 export default Spinner

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -47,6 +47,7 @@ class Textarea extends Component {
       dataAttributes,
       children,
       maxLength,
+      resize,
     } = this.props
     const { active } = this.state
 
@@ -106,7 +107,7 @@ class Textarea extends Component {
           rows={this.props.rows}
           defaultValue={this.props.defaultValue}
           value={this.props.value}
-          style={{ WebkitAppearance: 'none' }}>
+          style={{ resize, WebkitAppearance: 'none' }}>
           {children}
         </textarea>
 
@@ -139,6 +140,7 @@ Textarea.defaultProps = {
   disabled: false,
   label: '',
   readOnly: false,
+  resize: 'both',
   error: false,
   characterCountdownText: 'characters left',
   rows: 5,
@@ -179,6 +181,8 @@ Textarea.propTypes = {
   readOnly: PropTypes.bool,
   /** Spec attribute */
   required: PropTypes.string,
+  /** Controls if Textarea is resizable and the resize direction. */
+  resize: PropTypes.oneOf(['both', 'horizontal', 'none', 'vertical']),
   /** Spec attribute */
   rows: PropTypes.number,
   /** Spec attribute */


### PR DESCRIPTION
#### What is the purpose of this pull request?
1. Fix `Button`'s disabled border.
2. Set message shown to user on `Select` when the `creatable` prop is `true`.
3. Control `resize` behavior of `Textarea`.
4. Get commits from [https://github.com/vtex/styleguide/pull/536/](https://github.com/vtex/styleguide/pull/536/) that weren't merged.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
Old disabled Button:
<img width="112" alt="Screen Shot 2019-05-24 at 15 35 17" src="https://user-images.githubusercontent.com/10400340/58350589-ae5d5300-7e3c-11e9-9599-b3de2d9b7948.png">

New disabled Button:
<img width="112" alt="Screen Shot 2019-05-24 at 15 35 05" src="https://user-images.githubusercontent.com/10400340/58350595-b74e2480-7e3c-11e9-903e-c2cf3e926f73.png">

You can now translate the message shown when creating an option using `Select`:
<img width="923" alt="Screen Shot 2019-05-24 at 15 36 02" src="https://user-images.githubusercontent.com/10400340/58350837-6ee33680-7e3d-11e9-9635-1ce249fa0dd9.png">

Old resize behavior allows the user to break the UI:
<img width="1206" alt="Screen Shot 2019-05-24 at 15 40 02" src="https://user-images.githubusercontent.com/10400340/58350787-48250000-7e3d-11e9-8976-bdb71e7b9207.png">

Allows `vertical` resize only in `Textarea`:
![ScreenRecording20190524at1](https://user-images.githubusercontent.com/10400340/58350755-317ea900-7e3d-11e9-97c4-1132d2483fa0.gif)

`Spinner` using CSS animations doesn't stop spinning when main thread is busy processing stuff :P

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [x] Requires change to documentation, which has been updated accordingly.
