### PR TITLE
Fix Alert's content position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.51.2] - 2019-06-06
+
 ### Fixed
 
 - Position of elements in **Alert** to top

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Position of elements in **Alert** to top
+
 ## [8.51.1] - 2019-06-06
 
+### Fixed
+
+- Development documentation
+
 ## [8.51.0] - 2019-05-29
+
 ### Added
+
 - **DatePicker** Add `positionFixed` prop, which fixes issues related to `overflow: hidden`.
 
 ## [8.50.1] - 2019-05-28
+
 ### Changed
+
 - Only automatically add `key` prop to `Tabs` children when the prop is not present.
 
 ## [8.50.0] - 2019-05-28
@@ -25,7 +37,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **EXPERIMENTAL_Select** horizontal growth to make it simpler to the user.
 
 ## [8.49.1] - 2019-05-26
+
 ### Changed
+
 - **ButtonWithIcon** Prop `icon` is not required anymore.
 
 ## [8.49.0] - 2019-05-24

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.51.1",
+  "version": "8.51.2",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.51.1",
+  "version": "8.51.2",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Alert/README.md
+++ b/react/components/Alert/README.md
@@ -28,6 +28,17 @@ For low-priority notification prefer a <a href="#/Components/Notification/ToastP
     </Alert>
   </div>
   <div className="mb5">
+    <Alert type="warning" onClose={() => console.log('Closed!')}>
+      This is a large Alert. Lorem ipsum dolor sit amet, consectetur adipiscing
+      elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+      voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+      sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+      mollit anim id est laborum.
+    </Alert>
+  </div>
+  <div className="mb5">
     <Alert type="error" onClose={() => console.log('Closed!')}>
       You can't delete this item.
     </Alert>

--- a/react/components/Alert/index.js
+++ b/react/components/Alert/index.js
@@ -20,6 +20,7 @@ class Alert extends Component {
 
   render() {
     const { type, onClose, action, forwardedRef } = this.props
+    const innerVerticalPadding = 'pv3'
     let classes = 'ph5 pv4 br2 '
     let showIcon = false
     let Icon = 'div'
@@ -56,8 +57,9 @@ class Alert extends Component {
       <div
         ref={forwardedRef}
         className={`vtex-alert flex justify-between t-body c-on-base ${classes}`}>
-        <div className="flex-ns flex-grow-1 items-center">
-          <div className="flex items-center flex-grow-1">
+        <div className="flex-ns flex-grow-1 items-start">
+          <div
+            className={`flex items-start flex-grow-1 ${innerVerticalPadding}`}>
             {showIcon && (
               <div className={color}>
                 <Icon block color="currentColor" size={18} />
@@ -70,7 +72,8 @@ class Alert extends Component {
           </div>
 
           {displayAction && (
-            <div className="flex flex-grow-1 justify-end">
+            <div
+              className={`flex flex-grow-1 justify-end ${innerVerticalPadding}`}>
               <div className="nt4-ns nb4">
                 <Button variation="tertiary" onClick={handleActionClick}>
                   {action.label}
@@ -83,7 +86,7 @@ class Alert extends Component {
         {onClose && (
           <div
             title="Close"
-            className="vtex-alert__close-icon pointer flex items-center pv2 c-on-base pa3"
+            className={`vtex-alert__close-icon pointer pv2 c-on-base ph3 ${innerVerticalPadding}`}
             onClick={onClose}
             tabIndex={0}>
             <CloseIcon block color="currentColor" size={16} />


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix Alert's content children position to top.

#### What problem is this solving?
Center alignment.

#### Screenshots or example usage
<img width="849" alt="Screen Shot 2019-06-06 at 11 13 22" src="https://user-images.githubusercontent.com/2573602/59040061-58c97300-884c-11e9-81ea-0ed93ca84664.png">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
