### PR TITLE
Feature/toast link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - **Button** `href` prop, along with `<a>` tag props `target`, `rel`, `referrerPolicy`, `download`.
+- **Button** `inverted-tertiary` variation.
+- **Toast** Allow a link as a prop, via the `href` option on the action parameter.
 
 ## [8.52.1] - 2019-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **Button** `href` prop, along with `<a>` tag props `target`, `rel`, `referrerPolicy`, `download`.
 
 ## [8.52.1] - 2019-06-13
 

--- a/react/components/Button/README.md
+++ b/react/components/Button/README.md
@@ -157,6 +157,16 @@ Box types
 </div>
 ```
 
+Link mode
+
+```js
+<div>
+  <div className="mb4">
+    <Button variation="primary" href="http://vtex.com" target="_blank">Sign in</Button>
+  </div>
+</div>
+```
+
 Cancelling out button paddings. Useful for visually aligning tertiary buttons
 
 ```js

--- a/react/components/Button/README.md
+++ b/react/components/Button/README.md
@@ -12,39 +12,49 @@ Our Styleguide defines 3 main variations based on the button visual proeminence.
 Types
 
 ```js
-<div>
-  <div>
-    <span className="mr4">
+<div className="flex justify-center">
+  <div className="flex flex-column items-center w-100">
+    <span className="mb4">
       <Button variation="primary">Primary</Button>
     </span>
-    <span className="mr4">
+    <span className="mb4">
       <Button variation="secondary">Secondary</Button>
     </span>
-    <span className="mr4">
+    <span className="mb4">
       <Button variation="tertiary">Tertiary</Button>
     </span>
-    <span className="mr4">
+    <span className="mb4">
       <Button variation="danger">Danger</Button>
     </span>
-    <span className="mr4">
+    <span className="mb4">
       <Button variation="danger-tertiary">Danger Tertiary</Button>
     </span>
+    <span className="bg-base--inverted w-100 pa4 flex justify-center">
+      <span className="mb4">
+        <Button variation="inverted-tertiary">Inverted Tertiary</Button>
+      </span>
+    </span>
   </div>
-  <div className="mt4">
-    <span className="mr4">
+  <div className="flex flex-column items-center w-100">
+    <span className="mb4">
       <Button variation="primary" disabled>Primary</Button>
     </span>
-    <span className="mr4">
+    <span className="mb4">
       <Button variation="secondary" disabled>Secondary</Button>
     </span>
-    <span className="mr4">
+    <span className="mb4">
       <Button variation="tertiary" disabled>Tertiary</Button>
     </span>
-    <span className="mr4">
+    <span className="mb4">
       <Button variation="danger" disabled>Danger</Button>
     </span>
-    <span className="mr4">
+    <span className="mb4">
       <Button variation="danger-tertiary" disabled>Danger Tertiary</Button>
+    </span>
+    <span className="bg-base--inverted w-100 pa4 flex justify-center">
+      <span className="mb4">
+        <Button variation="inverted-tertiary" disabled>Inverted Tertiary</Button>
+      </span>
     </span>
   </div>
 </div>

--- a/react/components/Button/README.md
+++ b/react/components/Button/README.md
@@ -170,10 +170,8 @@ Box types
 Link mode
 
 ```js
-<div>
-  <div className="mb4">
-    <Button variation="primary" href="http://vtex.com" target="_blank">Sign in</Button>
-  </div>
+<div className="mb4">
+  <Button variation="primary" href="http://vtex.com" target="_blank">Sign in</Button>
 </div>
 ```
 

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -35,6 +35,12 @@ class Button extends Component {
       isActiveOfGroup,
       isFirstOfGroup,
       isLastOfGroup,
+      href,
+      onClick,
+      target,
+      rel,
+      referrerPolicy,
+      download,
     } = this.props
 
     const disabled = this.props.disabled || isLoading
@@ -148,6 +154,10 @@ class Button extends Component {
       classes += 'w-100 '
     }
 
+    if (href) {
+      classes += 'inline-flex items-center no-underline '
+    }
+
     const style = {}
 
     if (iconOnly) {
@@ -161,17 +171,32 @@ class Button extends Component {
       style.borderColor = '#0c389f'
     }
 
+    if (href && onClick) {
+      console.warn(
+        'A <Button> component is being used with both the props href, which turns it into an <a> element, and onClick, which turns it into a <button> element. This is behaviour is inconsistent and is not supported. Please choose only one of the props'
+      )
+    }
+
+    const linkModeProps = {
+      target,
+      rel,
+      referrerPolicy,
+      download,
+    }
+
+    const Element = href ? 'a' : 'button'
+
     return (
-      <button
+      <Element
         id={this.props.id}
         autoFocus={iconOnly ? undefined : this.props.autoFocus}
         disabled={iconOnly ? undefined : this.props.disabled}
         name={iconOnly ? undefined : this.props.name}
-        type={iconOnly ? undefined : this.props.type}
         value={iconOnly ? undefined : this.props.value}
         tabIndex={0}
         className={classes}
-        onClick={this.handleClick}
+        href={onClick ? undefined : href}
+        onClick={href ? undefined : this.handleClick}
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.props.onMouseLeave}
         onMouseOver={this.props.onMouseOver}
@@ -179,7 +204,11 @@ class Button extends Component {
         onMouseUp={this.props.onMouseUp}
         onMouseDown={this.props.onMouseDown}
         ref={this.props.forwardedRef}
-        style={style}>
+        style={style}
+        // Button-mode exclusive props
+        type={iconOnly || href ? undefined : this.props.type}
+        // Link-mode exclusive props
+        {...href && linkModeProps}>
         {isLoading ? (
           <Fragment>
             <span className="top-0 left-0 w-100 h-100 absolute flex justify-center items-center">
@@ -193,7 +222,7 @@ class Button extends Component {
         ) : (
           <div className={labelClasses}>{children}</div>
         )}
-      </button>
+      </Element>
     )
   }
 }
@@ -252,8 +281,11 @@ Button.propTypes = {
   value: PropTypes.string,
   /** Label of the Button */
   children: PropTypes.node.isRequired,
-  /** onClick event */
+  /** onClick event. Shouldn't be used together with href */
   onClick: PropTypes.func,
+  /** URL for link mode. Converts the button internally to a link,
+   * and shouldn't be used together with onClick */
+  href: PropTypes.string,
   /** onMouseEnter event */
   onMouseEnter: PropTypes.func,
   /** onMouseLeave event */
@@ -278,6 +310,14 @@ Button.propTypes = {
   isLastOfGroup: PropTypes.bool,
   /** */
   isActiveOfGroup: PropTypes.bool,
+  /** Link spec */
+  target: PropTypes.string,
+  /** Link spec */
+  rel: PropTypes.string,
+  /** Link spec */
+  referrerPolicy: PropTypes.string,
+  /** Link spec */
+  download: PropTypes.string,
 }
 
 export default withForwardedRef(Button)

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -125,6 +125,14 @@ class Button extends Component {
           }
           break
         }
+        case 'inverted-tertiary': {
+          if (disabled) {
+            classes += 'bg-transparent b--transparent c-disabled '
+          } else {
+            classes += 'bg-transparent b--transparent c-on-base--inverted '
+          }
+          break
+        }
         case 'danger': {
           if (disabled) {
             classes += 'bg-disabled b--muted-5 c-on-disabled '
@@ -250,6 +258,7 @@ Button.propTypes = {
     'primary',
     'secondary',
     'tertiary',
+    'inverted-tertiary',
     'danger',
     'danger-tertiary',
   ]),

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -36,7 +36,6 @@ class Button extends Component {
       isFirstOfGroup,
       isLastOfGroup,
       href,
-      onClick,
       target,
       rel,
       referrerPolicy,
@@ -197,8 +196,8 @@ class Button extends Component {
         value={iconOnly ? undefined : this.props.value}
         tabIndex={0}
         className={classes}
-        href={onClick ? undefined : href}
-        onClick={href ? undefined : this.handleClick}
+        href={href}
+        onClick={this.handleClick}
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.props.onMouseLeave}
         onMouseOver={this.props.onMouseOver}

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -179,12 +179,6 @@ class Button extends Component {
       style.borderColor = '#0c389f'
     }
 
-    if (href && onClick) {
-      console.warn(
-        'A <Button> component is being used with both the props href, which turns it into an <a> element, and onClick, which turns it into a <button> element. This is behaviour is inconsistent and is not supported. Please choose only one of the props'
-      )
-    }
-
     const linkModeProps = {
       target,
       rel,
@@ -290,10 +284,9 @@ Button.propTypes = {
   value: PropTypes.string,
   /** Label of the Button */
   children: PropTypes.node.isRequired,
-  /** onClick event. Shouldn't be used together with href */
+  /** onClick event. */
   onClick: PropTypes.func,
-  /** URL for link mode. Converts the button internally to a link,
-   * and shouldn't be used together with onClick */
+  /** URL for link mode. Converts the button internally to a link. */
   href: PropTypes.string,
   /** onMouseEnter event */
   onMouseEnter: PropTypes.func,

--- a/react/components/ToastProvider/README.md
+++ b/react/components/ToastProvider/README.md
@@ -173,13 +173,13 @@ const Content = () => (
                 variation="secondary"
                 onClick={
                   () => showToast({
-                    message: 'Alright alright alright',
+                    message: 'All right all right all right',
                     duration: 3000,
                     horizontalPosition: 'right'
                   })
                 }
               >
-                Alright
+                All right
               </Button>
             </div>
           </div>

--- a/react/components/ToastProvider/README.md
+++ b/react/components/ToastProvider/README.md
@@ -173,13 +173,13 @@ const Content = () => (
                 variation="secondary"
                 onClick={
                   () => showToast({
-                    message: 'Right',
+                    message: 'Alright alright alright',
                     duration: 3000,
                     horizontalPosition: 'right'
                   })
                 }
               >
-                Right
+                Alright
               </Button>
             </div>
           </div>

--- a/react/components/ToastProvider/README.md
+++ b/react/components/ToastProvider/README.md
@@ -148,6 +148,48 @@ const Content = () => (
     <div className="mb5">
       Toast position
     </div>
+    <div className="mb8">
+      <ToastConsumer>
+        {({showToast, hideToast}) => (
+          <div className="flex">
+            <div className="mr5">
+              <Button
+                size="small"
+                variation="secondary"
+                onClick={
+                  () => showToast({
+                    message: 'Everything you own in the box to the left',
+                    duration: 3000,
+                    horizontalPosition: 'left'
+                  })
+                }
+              >
+                To the left, to the left
+              </Button>
+            </div>
+            <div className="mr5">
+              <Button
+                size="small"
+                variation="secondary"
+                onClick={
+                  () => showToast({
+                    message: 'Right',
+                    duration: 3000,
+                    horizontalPosition: 'right'
+                  })
+                }
+              >
+                Right
+              </Button>
+            </div>
+          </div>
+        )}
+      </ToastConsumer>
+    </div>
+
+    <div className="mb5">
+      Link on toast action
+    </div>
     <ToastConsumer>
       {({showToast, hideToast}) => (
         <div className="flex">
@@ -157,28 +199,17 @@ const Content = () => (
               variation="secondary"
               onClick={
                 () => showToast({
-                  message: 'Everything you own in the box to the left',
-                  duration: 3000,
-                  horizontalPosition: 'left'
+                  message: 'Item added to cart',
+                  duration: 8000,
+                  action: {
+                    label: 'See cart',
+                    href: 'http://vtex.com',
+                    target: '_blank'
+                  }
                 })
               }
             >
-              To the left, to the left
-            </Button>
-          </div>
-          <div className="mr5">
-            <Button
-              size="small"
-              variation="secondary"
-              onClick={
-                () => showToast({
-                  message: 'Right',
-                  duration: 3000,
-                  horizontalPosition: 'right'
-                })
-              }
-            >
-              Right
+              Add to cart
             </Button>
           </div>
         </div>

--- a/react/components/ToastProvider/Toast.js
+++ b/react/components/ToastProvider/Toast.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import CloseIcon from '../icon/Close'
+import Button from '../Button'
 
 const nextFrame = callback => {
   const FRAME_DURATION = 16
@@ -189,12 +190,12 @@ export default class Toast extends Component {
             {hasAction && (
               <div className="flex flex-grow-1 justify-end items-center">
                 <div className={`${isSingleLine ? 'nt4' : 'nt4-ns'} nb4`}>
-                  <button
+                  <Button
                     ref={this.buttonElement}
-                    className="bg-transparent b--transparent c-on-base--inverted bw1 ba br2 t-action v-mid relative pv4 pl5 pr4 pointer"
+                    variation="inverted-tertiary"
                     onClick={this.handleActionClick}>
                     {action.label}
-                  </button>
+                  </Button>
                 </div>
               </div>
             )}

--- a/react/components/ToastProvider/Toast.js
+++ b/react/components/ToastProvider/Toast.js
@@ -164,7 +164,11 @@ export default class Toast extends Component {
   render() {
     const { isOpen, isSingleLine } = this.state
     const { action, dismissable, horizontalPosition, message } = this.props
-    const hasAction = !!(action && action.onClick && action.label)
+    const hasAction = !!(
+      action &&
+      action.label &&
+      (action.onClick || action.href)
+    )
 
     return (
       <div
@@ -193,6 +197,10 @@ export default class Toast extends Component {
                   <Button
                     ref={this.buttonElement}
                     variation="inverted-tertiary"
+                    href={action.href}
+                    target={action.target}
+                    rel={action.rel}
+                    download={action.download}
                     onClick={this.handleActionClick}>
                     {action.label}
                   </Button>
@@ -221,7 +229,11 @@ Toast.propTypes = {
   horizontalPosition: PropTypes.oneOf(['left', 'right']),
   action: PropTypes.shape({
     label: PropTypes.string.isRequired,
-    onClick: PropTypes.func.isRequired,
+    onClick: PropTypes.func,
+    href: PropTypes.func,
+    target: PropTypes.string,
+    rel: PropTypes.string,
+    download: PropTypes.string,
   }),
   visible: PropTypes.bool,
   duration: PropTypes.number,


### PR DESCRIPTION
#### What is the purpose of this pull request?
- **Button** Adds a link mode to the Button component, via the `href` prop, along with `<a>` tag props `target`, `rel`, `referrerPolicy`, `download`.
- **Button** `inverted-tertiary` variation.
- **Toast** Allow a link as a prop, via the `href` option on the action parameter.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
