### PR TITLE
Considers line density as param for rerender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Table** `density` changes are now is nativelly considered for rerender and height recalculation.
+
 ## [8.52.2] - 2019-06-13
+
 ### Added
+
 - **Button** `href` prop, along with `<a>` tag props `target`, `rel`, `referrerPolicy`, `download`.
 - **Button** `inverted-tertiary` variation.
 - **Toast** Allow a link as a prop, via the `href` option on the action parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.52.3] - 2019-06-13
+
 ### Fixed
 
 - **Table** `density` changes are now is nativelly considered for rerender and height recalculation.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.52.2",
+  "version": "8.52.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.52.2",
+  "version": "8.52.3",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -105,6 +105,7 @@ class SimpleTable extends Component {
       items,
       fixFirstColumn,
       disableHeader,
+      density,
       emptyStateLabel,
       emptyStateChildren,
       onRowClick,
@@ -124,6 +125,7 @@ class SimpleTable extends Component {
       schema.properties = this.addLineActionsToSchema(schema, lineActions)
     const properties = Object.keys(schema.properties)
 
+    const tableKey = `vtex-table--${updateTableKey}--${density}`
     return (
       <div className="vh-100 w-100 dt" style={{ height: containerHeight }}>
         {loading ? (
@@ -134,7 +136,7 @@ class SimpleTable extends Component {
           </div>
         ) : (
           <div>
-            <AutoSizer key={updateTableKey}>
+            <AutoSizer key={tableKey}>
               {({ width }) => {
                 const colsWidth = Object.keys(schema.properties).reduce(
                   (acc, curr) => {
@@ -341,6 +343,7 @@ SimpleTable.propTypes = {
   schema: PropTypes.object.isRequired,
   indexColumnLabel: PropTypes.string,
   fixFirstColumn: PropTypes.bool,
+  density: PropTypes.string,
   disableHeader: PropTypes.bool,
   onRowClick: PropTypes.func,
   emptyStateLabel: PropTypes.string,

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -290,6 +290,7 @@ class Table extends PureComponent {
               containerHeight || this.calculateTableHeight(items.length)
             }
             selectedRowsIndexes={map(selectedRows, 'id')}
+            density={selectedDensity}
           />
         )}
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

 - Density is now considered as a rerender param. So when line density is toggled, the table should recalculate i'ts height and rerender the lines.

#### What problem is this solving?

 - Necessity to manually controll render when line density changes.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
