### PR TITLE
Fix pageheader not accepting formattedmessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.54.0] - 2019-06-13
+
 ### Fixed
 
 - **PageHeader** warning when using formattedMessage as title.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PageHeader** warning when using formattedMessage as title.
+
 ## [8.53.1] - 2019-06-13
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.53.1",
+  "version": "8.54.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.53.1",
+  "version": "8.54.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/PageHeader/index.js
+++ b/react/components/PageHeader/index.js
@@ -59,7 +59,7 @@ class PageHeader extends PureComponent {
 
 PageHeader.propTypes = {
   /** Title for the header */
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
   /** Subtitle for the header */
   subtitle: PropTypes.string,
   /** Label for the back button */


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix pageHeader emitting a warning when the prop title is a formattedMessage node.

#### What problem is this solving?

Error warnings that shouldn't be there.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
