### PR TITLE
Fix/select all reversible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Table** bulk actions `select all` button now disables all checkboxes so nothing can be unselected
+
 ## [8.54.1] - 2019-06-14
 
 ### Added

--- a/react/components/Table/CheckboxContainer.js
+++ b/react/components/Table/CheckboxContainer.js
@@ -6,6 +6,7 @@ import Checkbox from '../Checkbox'
 class CheckboxContainer extends Component {
   static defaultProps = {
     partial: false,
+    disabled: false,
   }
 
   static propTypes = {

--- a/react/components/Table/CheckboxContainer.js
+++ b/react/components/Table/CheckboxContainer.js
@@ -12,11 +12,12 @@ class CheckboxContainer extends Component {
     checked: PropTypes.bool.isRequired,
     partial: PropTypes.bool,
     onClick: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   }
 
   render() {
-    const { checked, partial, id, onClick } = this.props
+    const { checked, partial, id, onClick, disabled } = this.props
 
     return (
       <div
@@ -30,6 +31,7 @@ class CheckboxContainer extends Component {
           value={`${id}`}
           name={`row_${id}`}
           onChange={() => onClick(id)}
+          disabled={disabled}
         />
       </div>
     )

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -213,6 +213,7 @@ class Table extends PureComponent {
               )}
               onClick={() => this.handleSelectLine(rowData)}
               id={rowData.id}
+              disabled={this.state.allLinesSelected}
             />
           ),
         },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Disable all bulk action checkboxes when `SELECT ALL` is pressed

#### What problem is this solving?

The `SELECT ALL` button should select all items in the table, even those who don't show in the current page or haven't been fetched. After the button is pressed, no row should be unselected since that won't really won't affect the flag `allLinesSelected`, which is `true`. This solves the following issue:
https://github.com/vtex/styleguide/issues/688

#### How should this be manually tested?

Go to
https://rafarefactor--bonati.myvtex.com/totalexpress/home?__disableSSR
and try selecting any item in the table, then click `SELECT ALL`. The checkboxes should be disabled.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/22064061/59462718-bb95ae00-8dfa-11e9-9509-8cae833cfe02.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
