### PR TITLE
Feature/bulkactions onchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Table** add bulkActions.onChange prop as callback to any selection changes
+
 ## [8.54.0] - 2019-06-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.54.1] - 2019-06-14
+
 ### Added
 
 - **Table** add bulkActions.onChange prop as callback to any selection changes

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.54.0",
+  "version": "8.54.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.54.0",
+  "version": "8.54.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -1284,6 +1284,8 @@ There are two "select all" items.
 - The **upper checkbox** on the left side selects the currently visible items, in the example below, 5.
 - The **Select all** button on the right side, selects all items from the database (by concept, since you will probably only load the visible items). Since not all items might be loaded in the table, the callback will only return a flag telling your app to handle all items for the next database operation.
 
+Check the console when selecting/unselecting rows or clicking an action button in the example below to see the action parameters
+
 ```js
 const itemsCopy = [
   {
@@ -1347,6 +1349,7 @@ const defaultSchema = {
         ),
       },
       totalItems: 122,
+      onChange: params => console.log(params),
       main: {
         label: 'Main Action',
         handleCallback: params => console.log(params),

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -97,9 +97,18 @@ class Table extends PureComponent {
     )
   }
 
+  handleSelectionChange = () => {
+    if (this.props.bulkActions && this.props.bulkActions.onChange) {
+      const selectedParameters = this.state.allLinesSelected
+        ? { allLinesSelected: true }
+        : { selectedRows: this.state.selectedRows }
+        this.props.bulkActions.onChange(selectedParameters)
+    }
+  }
+
   handleSelectAllLines = () => {
     const { items: selectedRows } = this.props
-    this.setState({ selectedRows, allLinesSelected: true })
+    this.setState({ selectedRows, allLinesSelected: true }, this.handleSelectionChange)
   }
 
   handleSelectAllVisibleLines = () => {
@@ -110,7 +119,7 @@ class Table extends PureComponent {
     if (selectedRows.length <= itemsLength && selectedRows.length !== 0) {
       this.handleDeselectAllLines()
     } else {
-      this.setState({ selectedRows: items })
+      this.setState({ selectedRows: items }, this.handleSelectionChange)
     }
   }
 
@@ -120,15 +129,15 @@ class Table extends PureComponent {
 
     if (selectedRows.some(el => el.id === id)) {
       const filteredRows = selectedRows.filter(row => row.id !== id)
-      this.setState({ selectedRows: filteredRows })
+      this.setState({ selectedRows: filteredRows }, this.handleSelectionChange)
     } else {
       selectedRows.push({ ...rowData })
-      this.setState({ selectedRows })
+      this.setState({ selectedRows }, this.handleSelectionChange)
     }
   }
 
   handleDeselectAllLines = () => {
-    this.setState({ selectedRows: [], allLinesSelected: false })
+    this.setState({ selectedRows: [], allLinesSelected: false }, this.handleSelectionChange)
   }
 
   render() {
@@ -413,6 +422,7 @@ Table.propTypes = {
       allRowsSelected: PropTypes.func.isRequired,
     }),
     totalItems: PropTypes.number,
+    onChange: PropTypes.func,
     main: PropTypes.shape({
       label: PropTypes.string.isRequired,
       handleCallback: PropTypes.func.isRequired,

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -102,13 +102,16 @@ class Table extends PureComponent {
       const selectedParameters = this.state.allLinesSelected
         ? { allLinesSelected: true }
         : { selectedRows: this.state.selectedRows }
-        this.props.bulkActions.onChange(selectedParameters)
+      this.props.bulkActions.onChange(selectedParameters)
     }
   }
 
   handleSelectAllLines = () => {
     const { items: selectedRows } = this.props
-    this.setState({ selectedRows, allLinesSelected: true }, this.handleSelectionChange)
+    this.setState(
+      { selectedRows, allLinesSelected: true },
+      this.handleSelectionChange
+    )
   }
 
   handleSelectAllVisibleLines = () => {
@@ -137,7 +140,10 @@ class Table extends PureComponent {
   }
 
   handleDeselectAllLines = () => {
-    this.setState({ selectedRows: [], allLinesSelected: false }, this.handleSelectionChange)
+    this.setState(
+      { selectedRows: [], allLinesSelected: false },
+      this.handleSelectionChange
+    )
   }
 
   render() {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add bulkActions.onChange prop to Table component

#### What problem is this solving?

With that prop, the user can pass a callback to the table component which is called every time there's a change in the selected rows, receiving the same parameters as `main's` and `others'` `handleCallback`.

#### How should this be manually tested?

Go to
https://rafarefactor--bonati.myvtex.com/totalexpress/home?__disableSSR
and try selecting some rows. You'll see that below the table there's a json string updating in real time containing all selected rows

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/22064061/59469351-f273c000-8e0a-11e9-8ad9-03f0fffdc08a.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
