### PR TITLE
Fix/inverted checkbox state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.55.0] - 2019-06-18
+
 ### Fixed
 
 - **Table** issue where the top checkbox state was always inverted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Table** issue where the top checkbox state was always inverted
+- **Table** warnings that happened when using bulk actions
+
 ## [8.54.2] - 2019-06-17
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.54.2",
+  "version": "8.55.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.54.2",
+  "version": "8.55.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Table/BulkActionsSelectedRows.js
+++ b/react/components/Table/BulkActionsSelectedRows.js
@@ -1,7 +1,7 @@
-import { PureComponent } from 'react'
+import { Component } from 'react'
 import PropTypes from 'prop-types'
 
-class BulkActionsSelectedRows extends PureComponent {
+class BulkActionsSelectedRows extends Component {
   shouldComponentUpdate(nextProps) {
     // This prevents the value from showing 0 when bar is closing
     // It reduces the "noise" given to the user from a ux point of view

--- a/react/components/Table/CheckboxContainer.js
+++ b/react/components/Table/CheckboxContainer.js
@@ -30,6 +30,7 @@ class CheckboxContainer extends Component {
           checked={checked}
           partial={partial}
           value={`${id}`}
+          id={`${id}`}
           name={`row_${id}`}
           onChange={() => onClick(id)}
           disabled={disabled}

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -191,7 +191,7 @@ class Table extends PureComponent {
           headerRenderer: () => {
             const { selectedRows } = this.state
             const selectedRowsLength = selectedRows.length
-            const itemsLength = items.length
+            const itemsLength = this.props.items.length
 
             const isChecked = selectedRowsLength === itemsLength
             const isPartial =


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix the bug detailed in the issue https://github.com/vtex/styleguide/issues/693.

#### What problem is this solving?

The bug https://github.com/vtex/styleguide/issues/693.

#### How should this be manually tested?

The table should work as it did before, but with the top checkbox always starting unselected.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
