### PR TITLE
Hotfix/filter tag clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.55.3] - 2019-06-27
+
 ### Fixed
 
  - Updates eslint dependency to fix a possible security vulnerability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
  - Updates eslint dependency to fix a possible security vulnerability.
+- **FilterBar** properly remove filter statement when filterTag clear button is clicked.
 
 ## [8.55.2] - 2019-06-26
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.55.2",
+  "version": "8.55.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.55.2",
+  "version": "8.55.3",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/FilterBar/index.js
+++ b/react/components/FilterBar/index.js
@@ -75,16 +75,8 @@ class FilterBar extends PureComponent {
   }
 
   handleFilterClear = subject => {
-    const { alwaysVisibleFilters, options, statements } = this.props
-    const newStatements = statements.map(_st => {
-      if (_st.subject === subject) {
-        return {
-          subject: subject,
-          verb: options[subject].verbs[0].value,
-        }
-      }
-      return _st
-    })
+    const { alwaysVisibleFilters, statements } = this.props
+    const newStatements = statements.filter(_st => _st.subject !== subject)
     this.changeStatementsCallback(newStatements)
     !alwaysVisibleFilters.includes(subject) &&
       this.toggleExtraFilterOption(subject)


### PR DESCRIPTION
#### What is the purpose of this pull request?

 - Fixes vtex/styleguide/issues/697

#### What problem is this solving?

- When clicking the clear button on a FilterTag in a FilterBar, the filter statement should be removed, instead it is just cleating the object of the statement.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
