### PR TITLE
Change NumericStepper lean mode to use input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
+
 - Change **NumericStepper** lean mode to use input instead of div
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.57.1] - 2019-06-28
+
 ### Changed
 
 - Change **NumericStepper** lean mode to use input instead of div

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Change **NumericStepper** lean mode to use input instead of div
+
+### Added
+
+- Add hover status to **NumericStepper** lean mode
+
 ## [8.57.0] - 2019-06-27
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.57.0",
+  "version": "8.57.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.57.0",
+  "version": "8.57.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -189,7 +189,9 @@ class NumericStepper extends Component {
       }
     }
 
-    const borderClasses = lean ? 'bn ' : 'ba b--muted-4 bw1 '
+    if (lean) inputClasses += 'br2 hover-b--muted-4 ba outline-transparent'
+
+    const borderClasses = lean ? 'b--transparent ' : 'ba b--muted-4 bw1 '
 
     const buttonDisabledClasses = lean
       ? 'c-disabled bg-transparent '
@@ -207,27 +209,20 @@ class NumericStepper extends Component {
           </span>
         )}
         <div className="flex self-start">
-          {lean ? (
-            <div
-              className={`order-1 flex items-center justify-center ${inputClasses}`}>
-              {displayValue}
-            </div>
-          ) : (
-            <input
-              type="tel"
-              className={`z-1 order-1 tc bw1 ${borderClasses} br0 ${inputClasses} ${hideDecorators}`}
-              style={{
-                ...(block && {
-                  width: 0,
-                }),
-                WebkitAppearance: 'none',
-              }}
-              value={displayValue}
-              onChange={this.handleTypeQuantity}
-              onFocus={this.handleFocusInput}
-              onBlur={this.handleBlurInput}
-            />
-          )}
+          <input
+            type="tel"
+            className={`z-1 order-1 tc bw1 ${borderClasses} br0 ${inputClasses} ${hideDecorators}`}
+            style={{
+              ...(block && {
+                width: 0,
+              }),
+              WebkitAppearance: 'none',
+            }}
+            value={displayValue}
+            onChange={this.handleTypeQuantity}
+            onFocus={this.handleFocusInput}
+            onBlur={this.handleBlurInput}
+          />
           <div className="z-2 order-2 flex-none">
             <button
               type="button"


### PR DESCRIPTION
#### What is the purpose of this pull request?
 Muda NumericStepper modo lean para usar input em vez de div
 Adiciona hover para modo lean do numeric stepper

#### What problem is this solving?
 O numericStepper tem uma prop 'lean' que está descrita como "Lean mode, with subtler styling" mas ela também muda o container do número, no estilo normal ele é um Input e no lean ele se torna uma div.
 Isso tira a funcionalidade de poder escrever a quantidade diretamente além de acabar sendo uma mudança brusca para algo que deveria ser só de style (input -> div).

#### How should this be manually tested?
 Running locally

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/13491046/60359307-16a8d280-99af-11e9-8796-6b84536e38d4.png)
![image](https://user-images.githubusercontent.com/13491046/60359326-245e5800-99af-11e9-9ef8-44f982bcc251.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
