### PR TITLE
Add padding-top to titleless Modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.61.0] - 2019-07-11
+
 ### Fixed
 
 - Add padding-top to **Modal** iff without `title` prop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add padding-top to **Modal** iff without `title` prop
+
 ## [8.60.4] - 2019-07-11
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.60.4",
+  "version": "8.61.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.60.4",
+  "version": "8.61.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -106,8 +106,8 @@ class Modal extends PureComponent {
           className={`${
             responsiveFullScreen ? 'ph7 ph8-ns' : 'ph6 ph8-ns'
           } overflow-auto flex-shrink-1 flex-grow-1 ${bottomBar ? '' : 'pb8'} ${
-            styles.scrollBar
-          }`}
+            title ? '' : 'pt5 pt6-ns'
+          } ${styles.scrollBar}`}
           ref={this.contentContainerReference}
           onScroll={this.handleScroll}>
           {children}


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Add padding-top to **Modal** iff without `title` prop

#### What problem is this solving?
Modal without title prop on admin with weird spaces

#### How should this be manually tested?
Running locally

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/13491046/61006303-63da5c00-a340-11e9-8ba2-dd7106212439.png)
After:
![image](https://user-images.githubusercontent.com/13491046/61006443-b87dd700-a340-11e9-9d71-91fcbd0906c7.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
