### PR TITLE
Update vtex-tachyons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `vtex-tachyons` major version from `2` to `3`.
+
 ## [8.62.1] - 2019-07-11
 
 ### Fixed
@@ -48,7 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add `showBottomBarBorder` prop to `Modal`
+ - Add `showBottomBarBorder` prop to `Modal`
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-select": "^2.1.2",
     "react-virtualized": "^9.19.1",
     "uuid": "^3.3.2",
-    "vtex-tachyons": "^2.10.0"
+    "vtex-tachyons": "^3.2.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update `vtex-tachyons` to latest major.

#### What problem is this solving?
Some elements like colors have been fixed by designers and are not yet used by the Styleguide.

#### Screenshots or example usage
2.x:
<img width="819" alt="Screen Shot 2019-07-11 at 11 33 16" src="https://user-images.githubusercontent.com/2573602/61060020-58367600-a3d0-11e9-9c4a-3e30e0baa185.png">

3.x:
<img width="826" alt="Screen Shot 2019-07-11 at 11 29 06" src="https://user-images.githubusercontent.com/2573602/61060041-5d93c080-a3d0-11e9-8ec9-c7ef59ea2d1e.png">

In 3.x, the blue color is lighter.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
