### PR TITLE
Add onExited prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.65.0] - 2019-07-17
+
 ### Added
 
 - `onCloseTransitionFinish` prop to `ModalDialog`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `onExited` prop to `Modal`
+- `onCloseTransitionFinish` prop to `ModalDialog`
 
 ## [8.64.0] - 2019-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `onExited` prop to `Modal`
+
 ## [8.64.0] - 2019-07-17
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.64.0",
+  "version": "8.65.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.64.0",
+  "version": "8.65.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -17,6 +17,7 @@ class Modal extends PureComponent {
   }
 
   componentDidMount() {
+    console.log('altered')
     this.setShadowState(this.contentContainerReference.current)
   }
 
@@ -56,6 +57,7 @@ class Modal extends PureComponent {
       responsiveFullScreen,
       showTopBar,
       showBottomBarBorder,
+      onExited,
     } = this.props
     const { shadowBottom, shadowTop } = this.state
 
@@ -64,6 +66,7 @@ class Modal extends PureComponent {
         open={isOpen}
         little={centered}
         onClose={onClose}
+        onExited={onExited}
         closeOnEsc={closeOnEsc}
         closeOnOverlayClick={closeOnOverlayClick}
         showCloseIcon={showTopBar ? false : showCloseIcon}
@@ -162,6 +165,7 @@ Modal.propTypes = {
   responsiveFullScreen: PropTypes.bool,
   /** If true, show top bar with title */
   showTopBar: PropTypes.bool,
+  onExited: PropTypes.func,
 }
 
 export default Modal

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -164,6 +164,7 @@ Modal.propTypes = {
   responsiveFullScreen: PropTypes.bool,
   /** If true, show top bar with title */
   showTopBar: PropTypes.bool,
+  /** Event fired when the closing transition is finished */
   onCloseTransitionFinish: PropTypes.func,
 }
 

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -56,7 +56,7 @@ class Modal extends PureComponent {
       responsiveFullScreen,
       showTopBar,
       showBottomBarBorder,
-      onExit,
+      onCloseTransitionFinish,
     } = this.props
     const { shadowBottom, shadowTop } = this.state
 
@@ -65,7 +65,7 @@ class Modal extends PureComponent {
         open={isOpen}
         little={centered}
         onClose={onClose}
-        onExited={onExit}
+        onExited={onCloseTransitionFinish}
         closeOnEsc={closeOnEsc}
         closeOnOverlayClick={closeOnOverlayClick}
         showCloseIcon={showTopBar ? false : showCloseIcon}
@@ -164,7 +164,7 @@ Modal.propTypes = {
   responsiveFullScreen: PropTypes.bool,
   /** If true, show top bar with title */
   showTopBar: PropTypes.bool,
-  onExit: PropTypes.func,
+  onCloseTransitionFinish: PropTypes.func,
 }
 
 export default Modal

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -56,7 +56,7 @@ class Modal extends PureComponent {
       responsiveFullScreen,
       showTopBar,
       showBottomBarBorder,
-      onExited,
+      onExit,
     } = this.props
     const { shadowBottom, shadowTop } = this.state
 
@@ -65,7 +65,7 @@ class Modal extends PureComponent {
         open={isOpen}
         little={centered}
         onClose={onClose}
-        onExited={onExited}
+        onExited={onExit}
         closeOnEsc={closeOnEsc}
         closeOnOverlayClick={closeOnOverlayClick}
         showCloseIcon={showTopBar ? false : showCloseIcon}
@@ -164,7 +164,7 @@ Modal.propTypes = {
   responsiveFullScreen: PropTypes.bool,
   /** If true, show top bar with title */
   showTopBar: PropTypes.bool,
-  onExited: PropTypes.func,
+  onExit: PropTypes.func,
 }
 
 export default Modal

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -17,7 +17,6 @@ class Modal extends PureComponent {
   }
 
   componentDidMount() {
-    console.log('altered')
     this.setShadowState(this.contentContainerReference.current)
   }
 

--- a/react/components/ModalDialog/index.js
+++ b/react/components/ModalDialog/index.js
@@ -6,8 +6,8 @@ import Button from '../Button'
 const NOOP = () => {}
 
 class ModalDialog extends Component {
-  handleExit = () => {
-    this.props.onExit && this.props.onExit()
+  handleCloseTransitionFinish = () => {
+    this.props.onCloseTransitionFinish && this.props.onCloseTransitionFinish()
   }
 
   handleConfirmation = () => {
@@ -29,7 +29,7 @@ class ModalDialog extends Component {
       <Modal
         {...this.props}
         onClose={loading ? NOOP : onClose}
-        onExit={this.handleExit}>
+        onCloseTransitionFinish={this.handleCloseTransitionFinish}>
         {this.props.children}
         <div className="vtex-modal__confirmation flex justify-end mt8">
           <span className="mr4">
@@ -67,7 +67,7 @@ ModalDialog.propTypes = {
   }).isRequired,
   onClose: PropTypes.func,
   loading: PropTypes.bool,
-  onExit: PropTypes.func,
+  onCloseTransitionFinish: PropTypes.func,
 }
 
 export default ModalDialog

--- a/react/components/ModalDialog/index.js
+++ b/react/components/ModalDialog/index.js
@@ -7,7 +7,7 @@ const NOOP = () => {}
 
 class ModalDialog extends Component {
   handleExit = () => {
-    this.props.onExited && this.props.onExited()
+    this.props.onExit && this.props.onExit()
   }
 
   handleConfirmation = () => {
@@ -29,7 +29,7 @@ class ModalDialog extends Component {
       <Modal
         {...this.props}
         onClose={loading ? NOOP : onClose}
-        onExited={this.handleExit}>
+        onExit={this.handleExit}>
         {this.props.children}
         <div className="vtex-modal__confirmation flex justify-end mt8">
           <span className="mr4">
@@ -67,7 +67,7 @@ ModalDialog.propTypes = {
   }).isRequired,
   onClose: PropTypes.func,
   loading: PropTypes.bool,
-  onExited: PropTypes.func,
+  onExit: PropTypes.func,
 }
 
 export default ModalDialog

--- a/react/components/ModalDialog/index.js
+++ b/react/components/ModalDialog/index.js
@@ -7,7 +7,6 @@ const NOOP = () => {}
 
 class ModalDialog extends Component {
   handleExit = () => {
-    console.log('exited!')
     this.props.onExited && this.props.onExited()
   }
 

--- a/react/components/ModalDialog/index.js
+++ b/react/components/ModalDialog/index.js
@@ -6,6 +6,11 @@ import Button from '../Button'
 const NOOP = () => {}
 
 class ModalDialog extends Component {
+  handleExit = () => {
+    console.log('exited!')
+    this.props.onExited && this.props.onExited()
+  }
+
   handleConfirmation = () => {
     this.props.confirmation &&
       this.props.confirmation.onClick &&
@@ -22,7 +27,10 @@ class ModalDialog extends Component {
     const { confirmation, cancelation, loading, onClose } = this.props
 
     return (
-      <Modal {...this.props} onClose={loading ? NOOP : onClose}>
+      <Modal
+        {...this.props}
+        onClose={loading ? NOOP : onClose}
+        onExited={this.handleExit}>
         {this.props.children}
         <div className="vtex-modal__confirmation flex justify-end mt8">
           <span className="mr4">
@@ -60,6 +68,7 @@ ModalDialog.propTypes = {
   }).isRequired,
   onClose: PropTypes.func,
   loading: PropTypes.bool,
+  onExited: PropTypes.func,
 }
 
 export default ModalDialog


### PR DESCRIPTION
#### What is the purpose of this pull request?
as the title says. 

#### What problem is this solving?
The prop `onExited` already exists in `ResponsiveModal` (react component internally used). Just passed the prop to parent component ( `ModalDialog`) as  `onCloseTransitionFinish`.
What `onCloseTransitionFinish` does? The function you pass to this prop will be fired when the Modal has exited and the animation is finished.

#### How should this be manually tested?
1. [Workspace](https://mariana--storecomponents.myvtex.com/admin/collections).

#### Screenshots or example usage
![a](https://user-images.githubusercontent.com/20481790/61322871-0ed99280-a7e5-11e9-81f7-03a1dc4c41a4.gif)



#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
