### PR TITLE
Add break-word on label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.66.1] - 2019-07-22
+
 ### Added
 
 - `word-break` css property to the label of the `Radio` component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `word-break` css property to the label of the `Radio` component.
+
 ## [8.66.0] - 2019-07-18
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.66.0",
+  "version": "8.66.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.66.0",
+  "version": "8.66.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Radio/index.js
+++ b/react/components/Radio/index.js
@@ -89,7 +89,7 @@ class Radio extends PureComponent {
           ref={this.radio}
         />
         <label
-          style={{ wordBreak: 'break-all' }}
+          style={{ wordBreak: 'break-word' }}
           className={classNames(
             { 'c-disabled': disabled },
             { 'c-on-base pointer': !disabled },

--- a/react/components/Radio/index.js
+++ b/react/components/Radio/index.js
@@ -89,6 +89,7 @@ class Radio extends PureComponent {
           ref={this.radio}
         />
         <label
+          style={{ wordBreak: 'break-all' }}
           className={classNames(
             { 'c-disabled': disabled },
             { 'c-on-base pointer': !disabled },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add break-word css prop to Radio label.

#### What problem is this solving?
Fixes https://github.com/vtex/styleguide/issues/552

#### How should this be manually tested?
Checkout and resize browser window.

#### Screenshots or example usage
Before:
<img width="416" alt="Screen Shot 2019-07-18 at 11 58 08" src="https://user-images.githubusercontent.com/2573602/61468470-ba085a00-a953-11e9-8668-84e7d4157cec.png">

After:
<img width="392" alt="Screen Shot 2019-07-18 at 11 58 00" src="https://user-images.githubusercontent.com/2573602/61468480-becd0e00-a953-11e9-9958-ef9994641f4b.png">

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
