### PR TITLE
Add disabled state for toolbar options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.67.0] - 2019-07-22
+
 ### Added
 
 - Disabled state for upload & download options in `Table` toolbar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Disabled state for upload & download options in `Table` toolbar
+
 ## [8.66.1] - 2019-07-22
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.66.1",
+  "version": "8.67.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.66.1",
+  "version": "8.67.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -129,6 +129,8 @@ class Toolbar extends PureComponent {
       size: 'small',
     }
 
+    const forcedColor = 'c-on-base'
+
     return (
       <div
         id="toolbar"
@@ -270,17 +272,20 @@ class Toolbar extends PureComponent {
             <div title={download.label} className="mh2">
               <ButtonWithIcon
                 icon={
-                  <span className="c-on-base mh2">
+                  <span
+                    className={`${download.disabled ? '' : forcedColor} mh2`}>
                     <IconDownload size={MEDIUM_ICON_SIZE} />
                   </span>
                 }
-                disabled={loading}
                 variation="tertiary"
+                disabled={download.disabled}
                 isLoading={download.isLoading}
                 size="small"
                 onClick={download.handleCallback}>
                 {download.label && (
-                  <span className="c-on-base">{download.label}</span>
+                  <span className={`${download.disabled ? '' : forcedColor}`}>
+                    {download.label}
+                  </span>
                 )}
               </ButtonWithIcon>
             </div>
@@ -290,18 +295,20 @@ class Toolbar extends PureComponent {
               <ButtonWithIcon
                 icon={
                   <span
-                    className="c-on-base mh2"
+                    className={`${upload.disabled ? '' : forcedColor} mh2`}
                     style={ICON_OPTICAL_COMPENSATION}>
                     <IconUpload size={HEAVY_ICON_SIZE} />
                   </span>
                 }
-                disabled={loading}
-                isLoading={upload.isLoading}
                 variation="tertiary"
+                disabled={upload.disabled}
+                isLoading={upload.isLoading}
                 size="small"
                 onClick={upload.handleCallback}>
                 {upload.label && (
-                  <span className="c-on-base">{upload.label}</span>
+                  <span className={`${upload.disabled ? '' : forcedColor}`}>
+                    {upload.label}
+                  </span>
                 )}
               </ButtonWithIcon>
             </div>
@@ -392,11 +399,13 @@ Toolbar.propTypes = {
       label: PropTypes.string,
       handleCallback: PropTypes.func,
       isLoading: PropTypes.bool,
+      disabled: PropTypes.bool,
     }),
     upload: PropTypes.shape({
       label: PropTypes.string,
       handleCallback: PropTypes.func,
       isLoading: PropTypes.bool,
+      disabled: PropTypes.bool,
     }),
     extraActions: PropTypes.shape({
       label: PropTypes.string,

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -406,10 +406,12 @@ Table.propTypes = {
     download: PropTypes.shape({
       label: PropTypes.string,
       handleCallback: PropTypes.func,
+      disabled: PropTypes.bool,
     }),
     upload: PropTypes.shape({
       label: PropTypes.string,
       handleCallback: PropTypes.func,
+      disabled: PropTypes.bool,
     }),
     extraActions: PropTypes.shape({
       label: PropTypes.string,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add disabled state for toolbar upload & download options.

#### What problem is this solving?
Download button has to be disabled in my app when there is nothing to be downloaded.

#### How should this be manually tested?
Checkout and add `disabled: true` locally.

#### Screenshots or example usage
Enabled:
![Screen Shot 2019-07-19 at 15 10 11](https://user-images.githubusercontent.com/2573602/61556493-4c822980-aa38-11e9-8897-2e3be36e89a9.png)

Disabled:
![Screen Shot 2019-07-19 at 15 10 02](https://user-images.githubusercontent.com/2573602/61556498-5146dd80-aa38-11e9-921c-4c41e65fbd17.png)

Both:
![Screen Shot 2019-07-19 at 15 12 41](https://user-images.githubusercontent.com/2573602/61556504-5572fb00-aa38-11e9-9e1d-7b87bbe9d1ef.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
