### PR TITLE
Fix/search table selection itens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Table** when search is performed, the selection of itens is removed
+
 ## [8.68.1] - 2019-07-23
 
 ### Fixed
@@ -32,6 +36,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `word-break` css property to the label of the `Radio` component.
 
 ## [8.66.0] - 2019-07-18
+
+## [9.66.0] - 2019-07-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [8.66.0] - 2019-07-18
 
-## [9.66.0] - 2019-07-18
-
 ### Added
 
 - Icons: Bold, Italic, Underline, Ordered List, Unordered List, Text, Image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.69.0] - 2019-07-25
+
 ### Fixed
 
 - **Table** when search is performed, the selection of itens is removed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.68.1",
+  "version": "8.69.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.68.1",
+  "version": "8.69.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -83,6 +83,9 @@ class Toolbar extends PureComponent {
   }
 
   handleInputSearchSubmit = e => {
+    this.props.handleDeselectAllLines && 
+      this.props.handleDeselectAllLines()
+    
     this.props.actions.inputSearch.onSubmit &&
       this.props.actions.inputSearch.onSubmit(e)
   }
@@ -437,6 +440,7 @@ Toolbar.propTypes = {
   schema: PropTypes.object.isRequired,
   hiddenFields: PropTypes.array,
   toggleColumn: PropTypes.func,
+  handleDeselectAllLines: PropTypes.func,
   handleHideAllColumns: PropTypes.func,
   handleShowAllColumns: PropTypes.func,
   handleToggleDensity: PropTypes.func,

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -83,9 +83,8 @@ class Toolbar extends PureComponent {
   }
 
   handleInputSearchSubmit = e => {
-    this.props.handleDeselectAllLines && 
-      this.props.handleDeselectAllLines()
-    
+    this.props.onDeselectAllLines && this.props.onDeselectAllLines()
+
     this.props.actions.inputSearch.onSubmit &&
       this.props.actions.inputSearch.onSubmit(e)
   }
@@ -103,10 +102,10 @@ class Toolbar extends PureComponent {
       },
       hiddenFields,
       schema,
-      handleHideAllColumns,
-      handleShowAllColumns,
-      toggleColumn,
-      handleToggleDensity,
+      onHideAllColumns,
+      onShowAllColumns,
+      onToggleColumn,
+      onToggleDensity,
       selectedDensity,
       loading,
     } = this.props
@@ -184,7 +183,7 @@ class Toolbar extends PureComponent {
                               isKeySelected ? 'b--emphasis' : 'b--transparent'
                             } pointer hover-bg-muted-5 bl bw1`}
                             onClick={() => {
-                              handleToggleDensity(key)
+                              onToggleDensity(key)
                               this.handleToggleBox('isDensityBoxVisible')
                               density.handleCallback &&
                                 density.handleCallback(key)
@@ -236,14 +235,14 @@ class Toolbar extends PureComponent {
                       <Button
                         variation="secondary"
                         size="small"
-                        onClick={handleShowAllColumns}>
+                        onClick={onShowAllColumns}>
                         {fields.showAllLabel}
                       </Button>
                       <div className="mh4">
                         <Button
                           variation="secondary"
                           size="small"
-                          onClick={handleHideAllColumns}>
+                          onClick={onHideAllColumns}>
                           {fields.hideAllLabel}
                         </Button>
                       </div>
@@ -255,7 +254,7 @@ class Toolbar extends PureComponent {
                         <div
                           key={index}
                           className="flex justify-between ph6 pv3 pointer hover-bg-muted-5"
-                          onClick={() => toggleColumn(field)}>
+                          onClick={() => onToggleColumn(field)}>
                           <span className="w-70 truncate">
                             {schema.properties[field].title || field}
                           </span>
@@ -439,11 +438,11 @@ Toolbar.propTypes = {
   }),
   schema: PropTypes.object.isRequired,
   hiddenFields: PropTypes.array,
-  toggleColumn: PropTypes.func,
-  handleDeselectAllLines: PropTypes.func,
-  handleHideAllColumns: PropTypes.func,
-  handleShowAllColumns: PropTypes.func,
-  handleToggleDensity: PropTypes.func,
+  onToggleColumn: PropTypes.func,
+  onDeselectAllLines: PropTypes.func,
+  onHideAllColumns: PropTypes.func,
+  onShowAllColumns: PropTypes.func,
+  onToggleDensity: PropTypes.func,
   selectedDensity: PropTypes.string,
   loading: PropTypes.bool,
 }

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -264,6 +264,7 @@ class Table extends PureComponent {
             toolbar={toolbar}
             hiddenFields={hiddenFields}
             toggleColumn={this.toggleColumn}
+            handleDeselectAllLines={this.handleDeselectAllLines}
             handleHideAllColumns={this.onHideAllColumns}
             handleShowAllColumns={this.onShowAllColumns}
             handleToggleDensity={this.toggleTableRowHeight}

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -54,7 +54,7 @@ class Table extends PureComponent {
     }
   }
 
-  toggleTableRowHeight = density => {
+  handleTableRowHeight = density => {
     const { tableRowHeight } = this.state
     const newHeight = this.getRowHeight(density)
     if (tableRowHeight !== newHeight) {
@@ -65,7 +65,7 @@ class Table extends PureComponent {
     }
   }
 
-  toggleColumn = key => {
+  handleToggleColumn = key => {
     const { hiddenFields } = this.state
     const newFieldsArray = hiddenFields.slice()
     const index = hiddenFields.indexOf(key)
@@ -73,10 +73,13 @@ class Table extends PureComponent {
     this.setState({ hiddenFields: newFieldsArray })
   }
 
-  onShowAllColumns = () => this.setState({ hiddenFields: [] })
+  handleShowAllColumns = () => {
+    this.setState({ hiddenFields: [] })
+  }
 
-  onHideAllColumns = () =>
+  handleHideAllColumns = () => {
     this.setState({ hiddenFields: Object.keys(this.props.schema.properties) })
+  }
 
   getScrollbarWidth = () => {
     if (!window || !document || !document.documentElement)
@@ -263,11 +266,11 @@ class Table extends PureComponent {
             loading={loading}
             toolbar={toolbar}
             hiddenFields={hiddenFields}
-            toggleColumn={this.toggleColumn}
-            handleDeselectAllLines={this.handleDeselectAllLines}
-            handleHideAllColumns={this.onHideAllColumns}
-            handleShowAllColumns={this.onShowAllColumns}
-            handleToggleDensity={this.toggleTableRowHeight}
+            onToggleColumn={this.handleToggleColumn}
+            onDeselectAllLines={this.handleDeselectAllLines}
+            onHideAllColumns={this.handleHideAllColumns}
+            onShowAllColumns={this.handleShowAllColumns}
+            onToggleDensity={this.handleTableRowHeight}
             selectedDensity={selectedDensity}
             schema={schema}
             actions={toolbar}


### PR DESCRIPTION
#### What is the purpose of this pull request?
`Table`: Make the array that holds the information about the selected itens empty when perform a search.

#### What problem is this solving?
`Table`: Remove itens selection when a search is performed.

#### How should this be manually tested?
1. Go to https://testesuggestions--sandboxintegracao.myvtex.com/admin/suggestion/pending
2. Select some itens in the table.
3. Try to search for `Meia`.
4. Then you should see that any item is selected.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/36630479/61638388-ade00d80-ac6f-11e9-80c9-745e5a1bfb1f.png)
![image](https://user-images.githubusercontent.com/36630479/61638400-b59fb200-ac6f-11e9-80d8-0ec1bf7da9d2.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
