### PR TITLE
Collapse button is not correctly aligned when the header title is longer than the width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Collapse button is not correctly aligned when the header title is longer than the width in the `Collapsible` component.
+
 ## [8.68.0] - 2019-07-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.68.1] - 2019-07-23
+
 ### Fixed
 
 - Collapse button is not correctly aligned when the header title is longer than the width in the `Collapsible` component.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.68.0",
+  "version": "8.68.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.68.0",
+  "version": "8.68.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Collapsible/index.js
+++ b/react/components/Collapsible/index.js
@@ -112,7 +112,7 @@ class Collapsible extends Component {
     return (
       <div className={jsFocusVisible}>
         <div
-          className="flex flex-wrap items-center pointer"
+          className="flex flex-row items-center pointer"
           tabIndex={0}
           role="button"
           onClick={() => handleClick(callback, !isOpen)}
@@ -120,7 +120,7 @@ class Collapsible extends Component {
           aria-expanded={isOpen}>
           {align === 'left' ? (
             <Fragment>
-              <div className={`${color} mr3`}>
+              <div className={`${color} mr3 self-center`}>
                 {isOpen ? <CaretUp /> : <CaretDown />}
               </div>
               <div className="flex-grow-1">{header}</div>
@@ -128,7 +128,7 @@ class Collapsible extends Component {
           ) : (
             <Fragment>
               <div className="flex-grow-1">{header}</div>
-              <div className={`${color} ml3`}>
+              <div className={`${color} ml3 self-center`}>
                 {isOpen ? <CaretUp /> : <CaretDown />}
               </div>
             </Fragment>


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
![collapse_button_problem](https://user-images.githubusercontent.com/12852518/61658139-14c6ec00-ac9b-11e9-9e93-3771ac2714d1.gif)

#### How should this be manually tested?
[Click here to access the workspace.](https://waza--storecomponents.myvtex.com/admin/collections/374)

#### Screenshots or example usage
![collapse_button_sollutioon](https://user-images.githubusercontent.com/12852518/61658232-4cce2f00-ac9b-11e9-8e3f-a74986b9d18c.gif)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
