### PR TITLE
FloatingActionBar now has better props shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- **FloatingActionBar** now has a better props shape.
+- **FloatingActionBar** now has better props shape.
 
 ## [8.67.0] - 2019-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.68.0] - 2019-07-23
+
 ### Fixed
 
 - **FloatingActionBar** now has better props shape.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **FloatingActionBar** now has a better props shape.
+
 ## [8.67.0] - 2019-07-22
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.67.0",
+  "version": "8.68.0",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.67.0",
+  "version": "8.68.0",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/FloatingActionBar/README.md
+++ b/react/components/FloatingActionBar/README.md
@@ -7,13 +7,17 @@
 - This component can be used anywhere but it will always show at the bottom of the page.
 
 ### Usage
-See the action bar at the bottom of this page.
 
+See the action bar at the bottom of this page.
 
 ```js
 <FloatingActionBar
-  onSave={() => alert('This was invoked because save was pressed')}
-  saveLabel="save"
-  cancelLabel="cancel"
+  save={{
+    label: 'save',
+    onClick: () => alert('This was invoked because save was pressed')
+  }}
+  cancel={{
+    label: 'cancel'
+  }}
 />
 ```

--- a/react/components/FloatingActionBar/README.md
+++ b/react/components/FloatingActionBar/README.md
@@ -17,7 +17,6 @@ class ActionBar extends React.Component {
     this.state = { loading: false }
   }
   render() {
-  console.log(this.state.loading)
     return (
       <FloatingActionBar
         save={{

--- a/react/components/FloatingActionBar/README.md
+++ b/react/components/FloatingActionBar/README.md
@@ -11,13 +11,33 @@
 See the action bar at the bottom of this page.
 
 ```js
-<FloatingActionBar
-  save={{
-    label: 'save',
-    onClick: () => alert('This was invoked because save was pressed')
-  }}
-  cancel={{
-    label: 'cancel'
-  }}
-/>
+class ActionBar extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { loading: false }
+  }
+  render() {
+  console.log(this.state.loading)
+    return (
+      <FloatingActionBar
+        save={{
+          label: 'save',
+          isLoading: this.state.loading,
+          onClick: () => {
+            this.setState({ loading: true })
+            setTimeout(() => {
+              alert('This was invoked because save was pressed')
+              this.setState({ loading: false })
+            }, 2000)
+          },
+        }}
+        cancel={{
+          label: 'cancel',
+        }}
+      />
+    )
+  }
+}
+
+;<ActionBar />
 ```

--- a/react/components/FloatingActionBar/index.js
+++ b/react/components/FloatingActionBar/index.js
@@ -4,15 +4,18 @@ import Button from '../Button'
 
 import './action-bar.global.css'
 
-const FloatingActionBar = ({ onSave, onCancel, cancelLabel, saveLabel }) => (
+const FloatingActionBar = ({
+  save: { label: saveLabel, ...saveProps } = {},
+  cancel: { label: cancelLabel, ...cancelProps } = {},
+}) => (
   <div className="styleguide__floating-action-bar shadow-active w-100 bg-base tr pv5 pr7-ns absolute fixed bottom-0 left-0 z-2">
     <span className="mr5">
-      <Button variation="tertiary" onClick={onCancel}>
+      <Button variation="tertiary" {...cancelProps}>
         {cancelLabel}
       </Button>
     </span>
     <span>
-      <Button variation="primary" onClick={onSave}>
+      <Button variation="primary" {...saveProps}>
         {saveLabel}
       </Button>
     </span>
@@ -20,14 +23,20 @@ const FloatingActionBar = ({ onSave, onCancel, cancelLabel, saveLabel }) => (
 )
 
 FloatingActionBar.propTypes = {
-  /** Invoked when save button is pressed */
-  onSave: PropTypes.func.isRequired,
-  /** Invoked when cancel button is pressed */
-  onCancel: PropTypes.func,
-  /** Label to save button*/
-  saveLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  /** Label to cancel button*/
-  cancelLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** The Save button props (label + Styleguide Button props) */
+  save: PropTypes.shape({
+    /** Label to save button */
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    /** Styleguide Button props */
+    ...Button.propTypes,
+  }),
+  /** The Cancel button props (label + Styleguide Button props) */
+  cancel: PropTypes.shape({
+    /** Label to save button */
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    /** Styleguide Button props */
+    ...Button.propTypes,
+  }),
 }
 
 export default FloatingActionBar


### PR DESCRIPTION
#### What is the purpose of this pull request?

`FloatingActionBar` should have better props shape so it can be more customizable.

#### What problem is this solving?

There was no possible way to add different props to the `Save` and `Cancel` buttons. For example, before this PR, you cannot set a `loading` state to them.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/61666876-f0750a80-acae-11e9-8ccc-49409955d8bd.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
