### PR TITLE
Fix collapse of tertiary button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.70.1] - 2019-07-26
+
 ### Fixed
 
 - **Button** tertiary now correctly collapse (including compensating the border width)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Button** tertiary now correctly collapse (including compensating the border width)
+
 ## [8.70.0] - 2019-07-25
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.70.0",
+  "version": "8.70.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.70.0",
+  "version": "8.70.1",
   "scripts": {
     "test": "react-scripts test --env=jsdom --testPathIgnorePatterns=\"<rootDir>/react/node_modules\" --moduleDirectories=node_modules --testMatch=\"<rootDir>/react/**/?(*.)+(spec|test).js\" --setupTestFrameworkScriptFile=\"<rootDir>/setupTests.js\"",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -45,6 +45,11 @@ class Button extends Component {
     const disabled = this.props.disabled || isLoading
     const iconOnly = icon || this.props.iconOnly
 
+    const isTertiary =
+      variation === 'tertiary' ||
+      variation === 'inverted-tertiary' ||
+      variation === 'danger-tertiary'
+
     let classes = 'vtex-button bw1 ba fw5 v-mid relative pa0 '
     let labelClasses = 'flex items-center justify-center h-100 pv2 '
     let loaderSize = 15
@@ -75,9 +80,15 @@ class Button extends Component {
 
     if (collapseLeft) {
       classes += `nl${horizontalPadding} `
+      if (isTertiary) {
+        labelClasses += 'nl1 '
+      }
     }
     if (collapseRight) {
       classes += `nr${horizontalPadding} `
+      if (isTertiary) {
+        labelClasses += 'nr1 '
+      }
     }
 
     if (iconOnly) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix styleguide button tertiary when collapse property is passed

#### How should this be manually tested?

By checking the visual of collapsed tertiary button

#### Screenshots or example usage

##### Before

![before](https://user-images.githubusercontent.com/1321766/61957469-b4cf8e80-af95-11e9-9003-9be5a5237e63.png)

##### After fix
![Fixed](https://user-images.githubusercontent.com/1321766/61957470-b4cf8e80-af95-11e9-9c29-dad94224e69d.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
