### PR TITLE
Update proptypes verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Proptypes verification of `ButtonGroup`
+
 ## [8.72.1] - 2019-08-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.72.2] - 2019-08-08
+
 ### Fixed
 
 - Proptypes verification of `ButtonGroup`

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.72.1",
+  "version": "8.72.2",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.72.1",
+  "version": "8.72.2",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -220,7 +220,7 @@ class Button extends Component {
         // Button-mode exclusive props
         type={iconOnly || href ? undefined : this.props.type}
         // Link-mode exclusive props
-        {...href && linkModeProps}>
+        {...(href && linkModeProps)}>
         {isLoading ? (
           <Fragment>
             <span className="top-0 left-0 w-100 h-100 absolute flex justify-center items-center">

--- a/react/components/ButtonGroup/index.js
+++ b/react/components/ButtonGroup/index.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
 
 import Button from '../Button'
 import ButtonWithIcon from '../ButtonWithIcon'
 import ActionMenu from '../ActionMenu'
+import { childrenOf } from '../utils'
 
 class ButtonGroup extends Component {
   render() {
@@ -37,13 +37,7 @@ class ButtonGroup extends Component {
 ButtonGroup.defaultProps = {}
 
 ButtonGroup.propTypes = {
-  buttons: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.instanceOf(Button),
-      PropTypes.instanceOf(ButtonWithIcon),
-      PropTypes.instanceOf(ActionMenu),
-    ])
-  ),
+  buttons: childrenOf(Button, ButtonWithIcon, ActionMenu),
 }
 
 export default ButtonGroup

--- a/react/components/ColorPicker/ColorHistory.js
+++ b/react/components/ColorPicker/ColorHistory.js
@@ -14,9 +14,7 @@ class ColorHistory extends React.Component {
     const color = rgba || hsva || hex || '#FFFFFF'
     const colorInRGB = colorutil.any.to.rgb(color)
     const styleColorBox = {
-      backgroundColor: `rgba(${colorInRGB.r},${colorInRGB.g},${colorInRGB.b},${
-        colorInRGB.a
-      })`,
+      backgroundColor: `rgba(${colorInRGB.r},${colorInRGB.g},${colorInRGB.b},${colorInRGB.a})`,
       height: '1.5rem',
     }
     const output = {

--- a/react/components/utils/index.js
+++ b/react/components/utils/index.js
@@ -1,0 +1,9 @@
+import PropTypes from 'prop-types'
+
+export const childrenOf = (...types) => {
+  const fieldType = PropTypes.shape({
+    type: PropTypes.oneOf(types),
+  })
+
+  return PropTypes.oneOfType([fieldType, PropTypes.arrayOf(fieldType)])
+}

--- a/react/docs/Pathline.js
+++ b/react/docs/Pathline.js
@@ -18,12 +18,8 @@ export const styles = ({ space, fontFamily, fontSize, color }) => ({
 })
 
 export function PathlineRenderer({ classes, children }) {
-  const npmString = `import ${
-    children.componentName
-  } from '@vtex/styleguide/lib/${children.dir}'`
-  const vtexIOString = `import { ${
-    children.componentName
-  } } from 'vtex.styleguide'`
+  const npmString = `import ${children.componentName} from '@vtex/styleguide/lib/${children.dir}'`
+  const vtexIOString = `import { ${children.componentName} } from 'vtex.styleguide'`
 
   return (
     <div className={classes.pathline}>

--- a/react/modules/deprecated.js
+++ b/react/modules/deprecated.js
@@ -40,11 +40,7 @@ export default function deprecated({ useNewComponent, useNewProps }) {
       componentDidMount() {
         if (useNewComponent) {
           console.warn(
-            `"${
-              useNewComponent.old
-            }" component is deprecated, you should use "${
-              useNewComponent.new
-            }" instead`
+            `"${useNewComponent.old}" component is deprecated, you should use "${useNewComponent.new}" instead`
           )
         }
         if (useNewProps) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix warning message: `Failed prop type: Right-hand side of 'instanceof' is not callable`

#### How should this be manually tested?
Checkout branch, run styleguide locally and open the `Components/Forms/ButtonGroup` url. No message should appear. Add a component not in the list of authorized components and watch the warning in console.

#### Screenshots or example usage
When adding a `Card` to the list:
![Screen Shot 2019-08-02 at 16 58 43](https://user-images.githubusercontent.com/2573602/62395750-947c7280-b547-11e9-9167-d33fdbd4be7c.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
