### PR TITLE
Expand click area for table checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Expanded checkbox click area for table row selection 
+
 ## [8.72.3] - 2019-08-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.72.4] - 2019-08-09
+
 ### Changed
 
 - Expanded checkbox click area for table row selection 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.72.3",
+  "version": "8.72.4",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.72.3",
+  "version": "8.72.4",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/CheckboxContainer.js
+++ b/react/components/Table/CheckboxContainer.js
@@ -22,8 +22,10 @@ class CheckboxContainer extends Component {
 
     return (
       <div
+        className="h-75 flex items-center"
         onClick={e => {
           e.stopPropagation()
+          onClick(id)
           // prevents the onRowClick event from happening
         }}>
         <Checkbox
@@ -32,7 +34,6 @@ class CheckboxContainer extends Component {
           value={`${id}`}
           id={`${id}`}
           name={`row_${id}`}
-          onChange={() => onClick(id)}
           disabled={disabled}
         />
       </div>

--- a/react/components/Table/CheckboxContainer.js
+++ b/react/components/Table/CheckboxContainer.js
@@ -21,21 +21,23 @@ class CheckboxContainer extends Component {
     const { checked, partial, id, onClick, disabled } = this.props
 
     return (
-      <div
-        className="h-75 flex items-center"
-        onClick={e => {
-          e.stopPropagation()
-          onClick(id)
-          // prevents the onRowClick event from happening
-        }}>
-        <Checkbox
-          checked={checked}
-          partial={partial}
-          value={`${id}`}
-          id={`${id}`}
-          name={`row_${id}`}
-          disabled={disabled}
-        />
+      <div className="flex items-center justify-center aspect-ratio--object">
+        <div
+          className="br2 h2 w2 flex items-center justify-center"
+          onClick={e => {
+            e.stopPropagation()
+            onClick(id)
+            // prevents the onRowClick event from happening
+          }}>
+          <Checkbox
+            checked={checked}
+            partial={partial}
+            value={`${id}`}
+            id={`${id}`}
+            name={`row_${id}`}
+            disabled={disabled}
+          />
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a little bit of click area inside the Table's checkbox cell

#### What problem is this solving?
Users are reporting that misclicks are very common and often cause unwanted onRowClick effects, such as navigation.

#### How should this be manually tested?
You may visit [this link](https://artur--sandboxintegracao.myvtex.com/admin/suggestion/pending) to see this alteration in action. Clicking slightly below or above the checkbox will cause the line to be selected instead of calling the onRowClick navigation.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3827456/62396702-37ce8700-b54a-11e9-9202-ad4886310d41.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
