### PR TITLE
Apply same spacing to Box in all screen sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Apply same spacing to `Box` in all screen sizes
+
 ## [8.72.0] - 2019-08-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.72.1] - 2019-08-07
+
 ### Fixed
 
 - Apply same spacing to `Box` in all screen sizes

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.72.0",
+  "version": "8.72.1",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.72.0",
+  "version": "8.72.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Box/index.tsx
+++ b/react/components/Box/index.tsx
@@ -11,10 +11,10 @@ const propTypes = {
 type Props = InferProps<typeof propTypes>
 
 const Box: FC<Props> = ({ children, noPadding }) => {
-  const padding = noPadding ? '' : 'pa7-ns'
+  const padding = noPadding ? '' : 'pa7'
   return (
     <div
-      className={`styleguide__box bg-base t-body c-on-base ${padding} br3-ns b--muted-4 bt bb bl-ns br-ns`}>
+      className={`styleguide__box bg-base t-body c-on-base ${padding} br3 b--muted-4 bt bb bl br`}>
       {children}
     </div>
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Apply spacing to `Box` in small screen sizes too.

#### What problem is this solving?

#### How should this be manually tested?

#### Screenshots or example usage
Before:
<img width="415" alt="Screen Shot 2019-08-06 at 15 46 00" src="https://user-images.githubusercontent.com/7659279/62571046-c141ca00-b866-11e9-85a3-f9153e854831.png">

After:
<img width="417" alt="Screen Shot 2019-08-06 at 15 45 50" src="https://user-images.githubusercontent.com/7659279/62571070-d1f24000-b866-11e9-9c57-21d2db93a46a.png">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
