### PR TITLE
Fix: Button is always submit when has iconOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.72.3] - 2019-08-08
+
 ### Changed
 
 - Condition to unset `Button`'s `type` property now doesn't use `iconOnly` prop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Condition to unset `Button`'s `type` property now doesn't use `iconOnly` prop.
+
 ## [8.72.2] - 2019-08-08
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.72.2",
+  "version": "8.72.3",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.72.2",
+  "version": "8.72.3",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -218,7 +218,7 @@ class Button extends Component {
         ref={this.props.forwardedRef}
         style={style}
         // Button-mode exclusive props
-        type={iconOnly || href ? undefined : this.props.type}
+        type={href ? undefined : this.props.type}
         // Link-mode exclusive props
         {...(href && linkModeProps)}>
         {isLoading ? (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove `iconOnly` from ternary that sets `Button`'s type.

#### What problem is this solving?

`ActionMenu`'s `ButtonWithIcon` with just an icon inside a `<form>` was always submitting the form.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
