### PR TITLE
Adding prop and update the state when component updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.72.8] - 2019-08-15
+
 ### Added
 
 - Optional prop `selectedRows` that can control the table selected items

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Optional prop `selectedRows` that can control the table selected items
+
 ## [8.72.7] - 2019-08-13
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.72.7",
+  "version": "8.72.8",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.72.7",
+  "version": "8.72.8",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -31,9 +31,14 @@ class Table extends PureComponent {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    if(this.props.bulkActions && this.props.bulkActions.selectedRows) {
-      this.setState({selectedRows: this.props.bulkActions.selectedRows})
+  componentDidUpdate() {
+    const { bulkActions } = this.props
+    const { selectedRows } = this.state
+
+    if(bulkActions 
+      && bulkActions.selectedRows
+      && bulkActions.selectedRows != selectedRows) {
+      this.setState({selectedRows: bulkActions.selectedRows})
     }
   }
 

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -35,9 +35,9 @@ class Table extends PureComponent {
     const { bulkActions } = this.props
     const { selectedRows } = this.state
 
-    if(bulkActions 
+    if(bulkActions
       && bulkActions.selectedRows
-      && bulkActions.selectedRows != selectedRows) {
+      && bulkActions.selectedRows !== selectedRows) {
       this.setState({selectedRows: bulkActions.selectedRows})
     }
   }

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -26,8 +26,14 @@ class Table extends PureComponent {
       tableRowHeight: this.getRowHeight(props.density),
       selectedDensity: props.density,
       allChecked: false,
-      selectedRows: [],
+      selectedRows: this.props.bulkActions.selectedRows || [],
       allLinesSelected: false,
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if(this.props.bulkActions && this.props.bulkActions.selectedRows) {
+      this.setState({selectedRows: this.props.bulkActions.selectedRows})
     }
   }
 
@@ -450,6 +456,7 @@ Table.propTypes = {
     }),
     totalItems: PropTypes.number,
     onChange: PropTypes.func,
+    selectedRows: PropTypes.array,
     main: PropTypes.shape({
       label: PropTypes.string.isRequired,
       handleCallback: PropTypes.func.isRequired,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Here we will add a prop called `selectedRows` that contains the information about the selected items. If this prop is not `undefined`, then the selectedRows will be controlled outside the component(by the caller), if `undefined` the table will control the selected elements.

#### What problem is this solving?

When you need to control the deselect some items in the table when an event happens, this is not possible with the current props.

#### How should this be manually tested?
1. Go to https://laercio--basedevmkp.myvtex.com/admin/suggestion/pending
2. Select some items using the bulk actions(1 one or more)
3. Then Choose `Approve as new product`
4. Close the modal(yes, just close it)
5. Then the items should be unselected.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/36630479/62717719-cde72f00-b9da-11e9-8f99-cc9a80154a69.png)
![image](https://user-images.githubusercontent.com/36630479/62717744-d50e3d00-b9da-11e9-9fc2-687e4c183873.png)
![image](https://user-images.githubusercontent.com/36630479/62717764-ddff0e80-b9da-11e9-987b-70914ae4b1e3.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
