### PR TITLE
ActionMenu width is constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **ActionMenu**: set default `menuWidth` to `292` to make it consistent with `Menu`'s width previous behavior.
+
+### Fixed
+
+- **Menu** uses `width` property instead of always using `DEFAULT_WIDTH`.
+
 ## [8.72.4] - 2019-08-09
 
 ### Changed
 
-- Expanded checkbox click area for table row selection 
+- Expanded checkbox click area for table row selection
 
 ## [8.72.3] - 2019-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.72.5] - 2019-08-12
+
 ### Changed
 
 - **ActionMenu**: set default `menuWidth` to `292` to make it consistent with `Menu`'s width previous behavior.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.72.4",
+  "version": "8.72.5",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.72.4",
+  "version": "8.72.5",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/ActionMenu/index.js
+++ b/react/components/ActionMenu/index.js
@@ -118,7 +118,7 @@ ActionMenu.defaultProps = {
   options: [],
   align: 'right',
   hideCaretIcon: false,
-  menuWidth: '100%',
+  menuWidth: 292,
   shouldCloseOnClick: true,
   isGrouped: false,
   isFirstOfGroup: false,

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -114,7 +114,7 @@ class Menu extends Component {
   }
 
   render() {
-    const { options, align, open, onClose, children } = this.props
+    const { options, align, open, onClose, children, width } = this.props
     const { hasCalculatedSize, isUpwards, isVisible, menuHeight } = this.state
 
     const isRight = align === 'right'
@@ -153,7 +153,7 @@ class Menu extends Component {
                   [isRight ? 'right' : 'left']: isRight
                     ? clientWidth - right
                     : left + scrollLeft,
-                  width: DEFAULT_WIDTH,
+                  width: width || DEFAULT_WIDTH,
                 }}
                 className={`absolute z-999 ba b--muted-4 br2 shadow-5 ${
                   isRight ? 'right-0' : 'left-0'


### PR DESCRIPTION
#### What is the purpose of this pull request?

1. `Menu` component uses `width` property and `DEFAULT_WIDTH` as fallback.
2. `ActionMenu` default `menuWidth` changed to `292` (same as `DEFAULT_WIDTH`), otherwise, it would always be the full width of the document body.

#### What problem is this solving?

I needed a smaller `Menu` from `ActionMenu`, however, the `menuWidth` wasn't working.

#### How should this be manually tested?
1. `git checkout fix/action-menu-width`
2. `yarn start`
3. Go to [http://localhost:6060/#/Components/Forms/ActionMenu](http://localhost:6060/#/Components/Forms/ActionMenu)
4. Add the `menuWidth` property to any `ActionMenu`, change the size and check the results.

#### Screenshots or example usage
`menuWidth` set to `100`:
<img width="735" alt="Screen Shot 2019-08-09 at 15 48 33" src="https://user-images.githubusercontent.com/10400340/62801931-2d1d7000-babd-11e9-89f4-698582c06e41.png">

`menuWidth` set to `400`:
<img width="735" alt="Screen Shot 2019-08-09 at 15 48 22" src="https://user-images.githubusercontent.com/10400340/62801952-39093200-babd-11e9-9986-a3a3a9bceee6.png">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
