### PR TITLE
Fix prop types strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `Action Menu` props to accept formatted message texts
+- `Page Header` props to accept formatted message texts
+- `Pagination` props to accept formatted message texts
+- `Table` props to accept formatted message texts
+- `Alert` props to accept formatted message texts
+- `Menu` props to accept formatted message texts
+
+### Fixed
+
+- Sortable columns title's breaking entirely when using Formatted Message on `Table` component
+
 ## [8.72.6] - 2019-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.72.7] - 2019-08-13
+
 ### Changed
 
 - `Action Menu` props to accept formatted message texts

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.72.6",
+  "version": "8.72.7",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.72.6",
+  "version": "8.72.7",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/ActionMenu/index.js
+++ b/react/components/ActionMenu/index.js
@@ -139,7 +139,7 @@ ActionMenu.propTypes = {
   /** @deprecated Button icon: use buttonProps instead */
   icon: PropTypes.element,
   /** Button text label */
-  label: PropTypes.string,
+  label: PropTypes.node,
   /** Hide the automatic caret icon */
   hideCaretIcon: PropTypes.bool,
   /** Menu width*/

--- a/react/components/ActionMenu/index.js
+++ b/react/components/ActionMenu/index.js
@@ -147,7 +147,7 @@ ActionMenu.propTypes = {
   /** Menu options */
   options: PropTypes.arrayOf(
     PropTypes.shape({
-      label: PropTypes.string,
+      label: PropTypes.node,
       handleCallback: PropTypes.func,
       /** whether option has inline toggle */
       toggle: PropTypes.shape({

--- a/react/components/Alert/index.js
+++ b/react/components/Alert/index.js
@@ -111,7 +111,7 @@ Alert.propTypes = {
   /** If this object is defined, an action button will appear on the right side of the alert. */
   action: PropTypes.shape({
     onClick: PropTypes.func.isRequired,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.node.isRequired,
   }),
 }
 

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -119,8 +119,6 @@ class Menu extends Component {
 
     const isRight = align === 'right'
 
-    console.log(options)
-
     return (
       <div className="relative">
         <div ref={this.containerElement}>{children}</div>

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -119,6 +119,8 @@ class Menu extends Component {
 
     const isRight = align === 'right'
 
+    console.log(options)
+
     return (
       <div className="relative">
         <div ref={this.containerElement}>{children}</div>
@@ -220,7 +222,7 @@ Menu.propTypes = {
   /** Menu options */
   options: PropTypes.arrayOf(
     PropTypes.shape({
-      label: PropTypes.string,
+      label: PropTypes.node,
       onClick: PropTypes.func,
       /** whether option has inline toggle */
       toggle: PropTypes.shape({

--- a/react/components/Modal/TopBar.js
+++ b/react/components/Modal/TopBar.js
@@ -39,7 +39,7 @@ const TopBar = props => {
 }
 
 TopBar.propTypes = {
-  title: PropTypes.string,
+  title: PropTypes.node,
   onClose: PropTypes.func,
   showBottomShadow: PropTypes.bool,
   responsiveFullScreen: PropTypes.bool,

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -163,7 +163,7 @@ Modal.propTypes = {
   /** Node to be displayed as the bottom bar of the modal. */
   bottomBar: PropTypes.node,
   /** Modal title to be displayed in top of the modal. */
-  title: PropTypes.string,
+  title: PropTypes.node,
   /** If true, the modal will expand to fullscreen in small view ports (e.g. mobile) */
   responsiveFullScreen: PropTypes.bool,
   /** If true, show top bar with title */

--- a/react/components/PageHeader/index.js
+++ b/react/components/PageHeader/index.js
@@ -61,9 +61,9 @@ PageHeader.propTypes = {
   /** Title for the header */
   title: PropTypes.node.isRequired,
   /** Subtitle for the header */
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.node,
   /** Label for the back button */
-  linkLabel: PropTypes.string,
+  linkLabel: PropTypes.node,
   onLinkClick: PropTypes.func,
   children: PropTypes.node,
 }

--- a/react/components/Pagination/index.js
+++ b/react/components/Pagination/index.js
@@ -118,8 +118,8 @@ Pagination.propTypes = {
   rowsOptions: PropTypes.array,
   currentItemFrom: PropTypes.number.isRequired,
   currentItemTo: PropTypes.number.isRequired,
-  textOf: PropTypes.string.isRequired,
-  textShowRows: PropTypes.string.isRequired,
+  textOf: PropTypes.node.isRequired,
+  textShowRows: PropTypes.node.isRequired,
   totalItems: PropTypes.number.isRequired,
   /**
    * Use this prop if you want to control the number of rows selected, instead of leaving it to the Pagination component.

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -222,13 +222,18 @@ class SimpleTable extends Component {
                                 onClick={() => {
                                   onSort(this.toggleSortType(property))
                                 }}>
-                                {!headerRight && `${title} `}
-                                {arrowIsDown ? (
-                                  <ArrowDown size={ARROW_SIZE} />
-                                ) : arrowIsUp ? (
-                                  <ArrowUp size={ARROW_SIZE} />
-                                ) : null}
-                                {headerRight && ` ${title}`}
+                                {!headerRight && title}
+                                <div
+                                  className={`inline-flex ${
+                                    headerRight ? 'pr2' : 'pl3'
+                                  }`}>
+                                  {arrowIsDown ? (
+                                    <ArrowDown size={ARROW_SIZE} />
+                                  ) : arrowIsUp ? (
+                                    <ArrowUp size={ARROW_SIZE} />
+                                  ) : null}
+                                </div>
+                                {headerRight && title}
                               </div>
                             ) : columnIndex === 0 && fixFirstColumn ? (
                               <div className="w-100">{title}</div>

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -438,7 +438,7 @@ Table.propTypes = {
     onPrevClick: PropTypes.func,
     currentItemFrom: PropTypes.number,
     currentItemTo: PropTypes.number,
-    textOf: PropTypes.string,
+    textOf: PropTypes.node,
     totalItems: PropTypes.number,
   }),
   bulkActions: PropTypes.shape({


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make Table work with FormattedMessage, prevent Menu, Alert, Page Header and Action Menu from emitting warnings when using FormattedMessage.

#### What problem is this solving?

Table not being compatible with the use of FormattedMessage component. And Menu, Alert, Page Header and Action Menu were compatible but would fire a console error because of prop types.

#### How should this be manually tested?

Menu, Alert, Page Header and Action Menu and Table should work as before when using strings for props. And should work the same when using FormattedMessage as props.

#### Screenshots or example usage

There should be no console logs with "[Element] expected string but got object instead".

The behaviour of **sorted** headers when using Formatted Message has changed.

Before:
![image](https://user-images.githubusercontent.com/8623116/62895858-2ba2b080-bd26-11e9-9867-3004e1577354.png)

Now:
![image](https://user-images.githubusercontent.com/8623116/62894341-edf05880-bd22-11e9-804b-8793d41c7447.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
