### PR TITLE
Add noUpperCase prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- prop `noUpperCase` to `Button`.
+
 ## [9.73.16] - 2019-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.74.0] - 2019-08-29
+
 ### Added
 
 - prop `noUpperCase` to `Button`.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.73.16",
+  "version": "9.74.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.73.16",
+  "version": "9.74.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -80,7 +80,10 @@ class Button extends Component {
     if (!(isTertiary && (collapseLeft || collapseRight))) {
       labelClasses += `ph${horizontalPadding} `
     }
-    labelClasses += isTertiary && noUpperCase ? 'ttn ' : ''
+
+    if (isTertiary && noUpperCase) {
+      labelClasses += 'ttn '
+    }
 
     if (collapseLeft && isTertiary) {
       labelClasses += 'nl1 ph1 hover-c-link'

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -40,6 +40,7 @@ class Button extends Component {
       rel,
       referrerPolicy,
       download,
+      noUpperCase,
     } = this.props
 
     const disabled = this.props.disabled || isLoading
@@ -79,6 +80,7 @@ class Button extends Component {
     if (!(isTertiary && (collapseLeft || collapseRight))) {
       labelClasses += `ph${horizontalPadding} `
     }
+    labelClasses += isTertiary && noUpperCase ? 'ttn ' : ''
 
     if (collapseLeft && isTertiary) {
       labelClasses += 'nl1 ph1 hover-c-link'
@@ -327,6 +329,8 @@ Button.propTypes = {
   referrerPolicy: PropTypes.string,
   /** Link spec */
   download: PropTypes.string,
+  /** When terciary, the upper case can be prevented */
+  noUpperCase: PropTypes.bool,
 }
 
 export default withForwardedRef(Button)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add no upper case option to tertiary button.

#### What problem is this solving?
Mimic the look of a link while still being a button for semantic purposes.

#### How should this be manually tested?
Checkout && `yarn styleguide`.

#### Screenshots or example usage
<img width="196" alt="Screen Shot 2019-08-22 at 10 59 04" src="https://user-images.githubusercontent.com/2573602/63521574-19b2d180-c4cd-11e9-8d6e-a2b25428b968.png">

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
