### PR TITLE
Fix Toggle click area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Toggle click area
+
 ## [8.73.0] - 2019-08-15
 
 ### Added

--- a/react/components/Toggle/index.js
+++ b/react/components/Toggle/index.js
@@ -165,7 +165,7 @@ class Toggle extends Component {
           <input
             id={id}
             type="checkbox"
-            className="h1 w1 absolute o-0"
+            className="h-100 w-100 absolute o-0 pointer"
             disabled={disabled}
             checked={checked}
             name={this.props.name}


### PR DESCRIPTION
#### What is the purpose of this pull request?

The buttons in the Table component that toggle the visibility of the columns have a bug where they don't work if you click a certain part of the button.

#### What problem is this solving?

The button should respond to clicks in its whole area

#### Screenshots or example usage

![PR](https://user-images.githubusercontent.com/52426881/63373025-93c44880-c35d-11e9-906f-1ae0d59676a1.jpg)


#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
