### PR TITLE
Fix/button tertiary behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.73.8] - 2019-08-22
+
 ### Fixed
 
 - **Button** `tertiary` variation hover text color.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Button** `tertiary` variation hover text color.
+- **Button** `tertiary` variation collapsed example.
+
 ## [9.73.7] - 2019-08-22
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.73.7",
+  "version": "9.73.8",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.73.7",
+  "version": "9.73.8",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Button/README.md
+++ b/react/components/Button/README.md
@@ -180,31 +180,32 @@ Cancelling out button paddings. Useful for visually aligning tertiary buttons
 ```js
 const Box = require('../Box').default
 
-;<div className="flex justify-center">
-  <div className="flex flex-column w-60">
-    <div className="t-heading-6 mb4">Using collapse props</div>
-    <div className="w-100 mb4">
-      <Box />
-    </div>
-    <div className="mb4 flex justify-between">
-      <Button variation="tertiary" collapseLeft>Collapse left</Button>
-      <Button variation="tertiary" collapseRight>Collapse right</Button>
-    </div>
-  </div>
-</div>
-
-;<div className="flex justify-center mt6">
-  <div className="flex flex-column w-60">
-    <div className="t-heading-6 mb4">No collapse props</div>
-    <div className="w-100 mb4">
-      <Box />
-    </div>
-    <div className="mb4 flex justify-between">
-      <Button variation="tertiary">Default</Button>
-      <Button variation="tertiary">Default</Button>
+;<>
+  <div className="flex justify-center">
+    <div className="flex flex-column w-60">
+      <div className="t-heading-6 mb4">✅Do: use collapse props</div>
+      <div className="w-100 mb4">
+        <Box />
+      </div>
+      <div className="mb4 flex justify-between">
+        <Button variation="tertiary" collapseLeft>Collapse left</Button>
+        <Button variation="tertiary" collapseRight>Collapse right</Button>
+      </div>
     </div>
   </div>
-</div>
+  <div className="flex justify-center mt6">
+    <div className="flex flex-column w-60">
+      <div className="t-heading-6 mb4">❌Don't: no collapse props</div>
+      <div className="w-100 mb4">
+        <Box />
+      </div>
+      <div className="mb4 flex justify-between">
+        <Button variation="tertiary">Default</Button>
+        <Button variation="tertiary">Default</Button>
+      </div>
+    </div>
+  </div>
+</>;
 ```
 Colored container background
 

--- a/react/components/Button/README.md
+++ b/react/components/Button/README.md
@@ -207,6 +207,25 @@ const Box = require('../Box').default
       </div>
     </div>
   </div>
+  <div className="flex justify-center mt6">
+    <div className="flex flex-column w-60">
+      <div className="t-heading-6 mb4">Collapse props don't work on primary and secondary variations (and it shouldn't)</div>
+      <div className="w-100 mb4">
+        <Box />
+      </div>
+      <div className="mb4 flex justify-between">
+        <Button variation="primary" collapseLeft>Collapse left</Button>
+        <Button variation="primary" collapseRight>Collapse right</Button>
+      </div>
+      <div className="w-100 mb4">
+        <Box />
+      </div>
+      <div className="mb4 flex justify-between">
+        <Button variation="secondary" collapseLeft>Collapse left</Button>
+        <Button variation="secondary" collapseRight>Collapse right</Button>
+      </div>
+    </div>
+  </div>
 </>;
 ```
 Colored container background

--- a/react/components/Button/README.md
+++ b/react/components/Button/README.md
@@ -183,7 +183,7 @@ const Box = require('../Box').default
 ;<>
   <div className="flex justify-center">
     <div className="flex flex-column w-60">
-      <div className="t-heading-6 mb4">✅Do: use collapse props</div>
+      <div className="t-heading-6 mb4">Use collapse props when tertiary button is alone, to align it with the other elements</div>
       <div className="w-100 mb4">
         <Box />
       </div>
@@ -195,13 +195,15 @@ const Box = require('../Box').default
   </div>
   <div className="flex justify-center mt6">
     <div className="flex flex-column w-60">
-      <div className="t-heading-6 mb4">❌Don't: no collapse props</div>
+      <div className="t-heading-6 mb4">Don't collapse when the button is not alone</div>
       <div className="w-100 mb4">
         <Box />
       </div>
-      <div className="mb4 flex justify-between">
+      <div className="mb4 flex">
         <Button variation="tertiary">Default</Button>
-        <Button variation="tertiary">Default</Button>
+        <div className="ml2">
+          <Button variation="secondary">Another Button</Button>
+        </div>
       </div>
     </div>
   </div>

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -81,13 +81,13 @@ class Button extends Component {
     if (collapseLeft) {
       classes += `nl${horizontalPadding} `
       if (isTertiary) {
-        labelClasses += 'nl1 '
+        labelClasses += 'nl1 hover-c-link'
       }
     }
     if (collapseRight) {
       classes += `nr${horizontalPadding} `
       if (isTertiary) {
-        labelClasses += 'nr1 '
+        labelClasses += 'nr1 hover-c-link'
       }
     }
 

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -76,19 +76,15 @@ class Button extends Component {
         break
     }
 
-    labelClasses += `ph${horizontalPadding} `
-
-    if (collapseLeft) {
-      classes += `nl${horizontalPadding} `
-      if (isTertiary) {
-        labelClasses += 'nl1 hover-c-link'
-      }
+    if (!(isTertiary && (collapseLeft || collapseRight))) {
+      labelClasses += `ph${horizontalPadding} `
     }
-    if (collapseRight) {
-      classes += `nr${horizontalPadding} `
-      if (isTertiary) {
-        labelClasses += 'nr1 hover-c-link'
-      }
+
+    if (collapseLeft && isTertiary) {
+      labelClasses += 'nl1 ph1 hover-c-link'
+    }
+    if (collapseRight && isTertiary) {
+      labelClasses += 'nr1 ph1 hover-c-link'
     }
 
     if (iconOnly) {

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -216,7 +216,7 @@ class Button extends Component {
         // Button-mode exclusive props
         type={href ? undefined : this.props.type}
         // Link-mode exclusive props
-        {...href && linkModeProps}>
+        {...(href && linkModeProps)}>
         {isLoading ? (
           <Fragment>
             <span className="top-0 left-0 w-100 h-100 absolute flex justify-center items-center">

--- a/react/components/ColorPicker/ColorHistory.js
+++ b/react/components/ColorPicker/ColorHistory.js
@@ -14,9 +14,7 @@ class ColorHistory extends React.Component {
     const color = rgba || hsva || hex || '#FFFFFF'
     const colorInRGB = colorutil.any.to.rgb(color)
     const styleColorBox = {
-      backgroundColor: `rgba(${colorInRGB.r},${colorInRGB.g},${colorInRGB.b},${
-        colorInRGB.a
-      })`,
+      backgroundColor: `rgba(${colorInRGB.r},${colorInRGB.g},${colorInRGB.b},${colorInRGB.a})`,
       height: '1.5rem',
     }
     const output = {

--- a/react/docs/Pathline.js
+++ b/react/docs/Pathline.js
@@ -18,12 +18,8 @@ export const styles = ({ space, fontFamily, fontSize, color }) => ({
 })
 
 export function PathlineRenderer({ classes, children }) {
-  const npmString = `import ${
-    children.componentName
-  } from '@vtex/styleguide/lib/${children.dir}'`
-  const vtexIOString = `import { ${
-    children.componentName
-  } } from 'vtex.styleguide'`
+  const npmString = `import ${children.componentName} from '@vtex/styleguide/lib/${children.dir}'`
+  const vtexIOString = `import { ${children.componentName} } from 'vtex.styleguide'`
 
   return (
     <div className={classes.pathline}>

--- a/react/modules/deprecated.js
+++ b/react/modules/deprecated.js
@@ -40,11 +40,7 @@ export default function deprecated({ useNewComponent, useNewProps }) {
       componentDidMount() {
         if (useNewComponent) {
           console.warn(
-            `"${
-              useNewComponent.old
-            }" component is deprecated, you should use "${
-              useNewComponent.new
-            }" instead`
+            `"${useNewComponent.old}" component is deprecated, you should use "${useNewComponent.new}" instead`
           )
         }
         if (useNewProps) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

 - Fix hover text color on Button tertiary variation (now text color behaves like a Link, using the same token).
 - Fix Button tertiary when collapsed example in readme (enhance DOs and DON'Ts docs and fix broken example)
 - Collapse props now only work when button variation is tertiary.

#### What problem is this solving?

 - Example was broken and hover color was wrong

#### How should this be manually tested?
 - hovering the button in the fixed marvellous example

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
