### PR TITLE
Replace min-h-100 with vh version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.73.9] - 2019-08-22
+
 ### Fixed
 
 - Make Layout component always have the height of its viewport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Make Layout component always have the height of its viewport
+
 ## [9.73.8] - 2019-08-22
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.73.8",
+  "version": "9.73.9",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.73.8",
+  "version": "9.73.9",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Layout/index.js
+++ b/react/components/Layout/index.js
@@ -6,7 +6,7 @@ class Layout extends Component {
     const { fullWidth, pageHeader, children } = this.props
 
     return (
-      <div className="styleguide__layout flex justify-center pb7 bg-muted-5 min-h-100">
+      <div className="styleguide__layout flex justify-center pb7 bg-muted-5 min-vh-100">
         <div className={fullWidth ? 'w-100' : 'w-100 mw8'}>
           {pageHeader}
           <div className="layout__container ph7-ns">{children}</div>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the layout in admin pages with content smaller than the window height.

#### What problem is this solving?

Currently, the `<Layout />` component uses `min-height: 100%` instead of `min-height: 100vh`. The `Layout` will only have the window height (100%) if its parent has a defined height, which it doesn't.

#### How should this be manually tested?

Just go to an admin page and change the class of a layout component to `min-vh-100`.

#### Screenshots or example usage

**Before**:
![image](https://user-images.githubusercontent.com/12702016/63546027-23edc380-c4ff-11e9-8620-57bdb9c653f2.png)

**After**: 
![image](https://user-images.githubusercontent.com/12702016/63546035-28b27780-c4ff-11e9-8254-b5a6aefda5ea.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
