### PR TITLE
Fix button link block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.73.11] - 2019-08-26
+
 ### Fixed
 
 - Add a class to Button component to fix its label alignment when using `href` and `block` props.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add a class to Button component to fix its label alignment when using `href` and `block` props.
+
 ## [9.73.10] - 2019-08-23
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.73.10",
+  "version": "9.73.11",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.73.10",
+  "version": "9.73.11",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -166,6 +166,7 @@ class Button extends Component {
 
     if (block) {
       classes += 'w-100 '
+      labelClasses += 'w-100 '
     }
 
     if (href) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix a bug in `Button` component.

#### What problem is this solving?

When the prop `href` and `block` are used, the label is not horizontally aligned in center.

#### How should this be manually tested?

https://augusto--vtexgame1.myvtex.com/cart

#### Screenshots or example usage

Before:

![Screen Shot 2019-08-23 at 16 35 36](https://user-images.githubusercontent.com/1315451/63619627-93c68180-c5c5-11e9-9293-375042576bed.png)

After:

![Screen Shot 2019-08-23 at 16 37 11](https://user-images.githubusercontent.com/1315451/63619634-99bc6280-c5c5-11e9-83a1-7990216fbb0c.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
