### PR TITLE
Add the Tooltip component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- **Tooltip** added.
+- **Tooltip** component.
 
 ## [9.76.1] - 2019-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.77.0] - 2019-09-03
+
 ### Added
 
 - **Tooltip** component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Tooltip** added.
+
 ## [9.76.1] - 2019-09-02
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.76.1",
+  "version": "9.77.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.76.1",
+  "version": "9.77.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/Tooltip.ts
+++ b/react/Tooltip.ts
@@ -1,0 +1,1 @@
+export { default } from './components/Tooltip'

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -221,6 +221,8 @@ class Button extends Component {
         onMouseOut={this.props.onMouseOut}
         onMouseUp={this.props.onMouseUp}
         onMouseDown={this.props.onMouseDown}
+        onFocus={this.props.onFocus}
+        onBlur={this.props.onBlur}
         ref={this.props.forwardedRef}
         style={style}
         // Button-mode exclusive props
@@ -316,6 +318,10 @@ Button.propTypes = {
   onMouseUp: PropTypes.func,
   /** onMouseDown event */
   onMouseDown: PropTypes.func,
+  /** onFocus event */
+  onFocus: PropTypes.func,
+  /** onBlur event */
+  onBlur: PropTypes.func,
   /** Cancels out left padding */
   collapseLeft: PropTypes.bool,
   /** Cancels out right padding */

--- a/react/components/Tooltip/Portal.tsx
+++ b/react/components/Tooltip/Portal.tsx
@@ -30,8 +30,6 @@ const propTypes = {
   ]),
   /**
    * Callback fired once the children has been mounted into the `container`.
-   *
-   * This prop will be deprecated and removed in v5, the ref can be used instead.
    */
   onRendered: PropTypes.func,
 }

--- a/react/components/Tooltip/Portal.tsx
+++ b/react/components/Tooltip/Portal.tsx
@@ -1,0 +1,76 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import { setRef } from '../utils/react'
+
+function getContainer(container) {
+  container = typeof container === 'function' ? container() : container
+  return ReactDOM.findDOMNode(container)
+}
+
+const useEnhancedEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
+
+const propTypes = {
+  /**
+   * The children to render into the `container`.
+   */
+  children: PropTypes.node,
+  /**
+   * A node, component instance, or function that returns either.
+   * The `container` will have the portal children appended to it.
+   * By default, it uses the body of the top-level document object,
+   * so it's simply `document.body` most of the time.
+   */
+  container: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.instanceOf(React.Component),
+    PropTypes.instanceOf(typeof Element === 'undefined' ? Object : Element),
+  ]),
+  /**
+   * Callback fired once the children has been mounted into the `container`.
+   *
+   * This prop will be deprecated and removed in v5, the ref can be used instead.
+   */
+  onRendered: PropTypes.func,
+}
+
+/**
+ * Portals provide a first-class way to render children into a DOM node
+ * that exists outside the DOM hierarchy of the parent component.
+ */
+const Portal = (props: PropTypes.InferProps<typeof propTypes>, ref) => {
+  const { children, container, onRendered } = props
+  const [mountNode, setMountNode] = React.useState(null)
+
+  useEnhancedEffect(() => {
+    setMountNode(getContainer(container) || document.body)
+  }, [container])
+
+  useEnhancedEffect(() => {
+    if (mountNode) {
+      setRef(ref, mountNode)
+      return () => {
+        setRef(ref, null)
+      }
+    }
+
+    return undefined
+  }, [ref, mountNode])
+
+  useEnhancedEffect(() => {
+    if (onRendered && mountNode) {
+      onRendered()
+    }
+  }, [onRendered, mountNode])
+
+  return mountNode ? ReactDOM.createPortal(children, mountNode) : mountNode
+}
+
+Portal.propTypes = propTypes
+
+export default React.forwardRef<
+  HTMLElement,
+  PropTypes.InferProps<typeof propTypes>
+>(Portal)

--- a/react/components/Tooltip/README.md
+++ b/react/components/Tooltip/README.md
@@ -8,9 +8,9 @@
 ### 👎 Don'ts
 
 - Don't change the tooltip colors.
-- Don't use long texts in tooltips - a good character limit is 200.
+- Don't use long texts in tooltips - a good character limit is 220.
 
-### Positioning tooltip
+#### Positioning tooltip
 
 The position where the tooltip appears can be set and its fallback position too. By default the tooltip appears at the top and follows clockwise.
 
@@ -33,7 +33,7 @@ const Button = require('../Button').default
 </div>
 ```
 
-### Label and Informative text
+#### Label and Informative text
 
 ```jsx
 const Edit = require('../icon/Edit').default
@@ -48,7 +48,7 @@ const Info = require('../icon/Info').default
     </Tooltip>
   </div>
   <div className="ph9">
-    <Tooltip label="Info">
+    <Tooltip label="Lorem ipsum dolor sit amet, consectetur adipiscing elit.">
       <span className="c-on-base pointer">
         <Info />
       </span>
@@ -57,7 +57,7 @@ const Info = require('../icon/Info').default
 </div>
 ```
 
-### Hover vs Focused
+#### Hover vs Focused
 
 ```jsx
 const Button = require('../Button').default

--- a/react/components/Tooltip/README.md
+++ b/react/components/Tooltip/README.md
@@ -63,15 +63,15 @@ const Info = require('../icon/Info').default
 const Button = require('../Button').default
 
 ;<div className="flex w-100 items-center justify-center">
-  <Tooltip label="Tooltip text">
-    <div className="pa3">
+  <div className="pa3">
+    <Tooltip label="Tooltip text">
       <Button variation="tertiary">Hover</Button>
-    </div>
-  </Tooltip>
-  <Tooltip label="Tooltip text" trigger="focus">
-    <div className="pa3">
+    </Tooltip>
+  </div>
+  <div className="pa3">
+    <Tooltip label="Tooltip text" trigger="focus">
       <Button variation="tertiary">Focused</Button>
-    </div>
-  </Tooltip>
+    </Tooltip>
+  </div>
 </div>
 ```

--- a/react/components/Tooltip/README.md
+++ b/react/components/Tooltip/README.md
@@ -1,58 +1,76 @@
-#### Basic Tooltip ✨
+#### Tooltips are a small informative text that appear when an item is being, hovered, focused or touched.
+
+### 👍 Dos
+
+- Do use tooltips when you want to add a label to an specific icon.
+- Do use tooltips when you want to add an informative text in situations where more clarification may be needed.
+
+### 👎 Don'ts
+
+- Don't change the tooltip colors.
+- Don't use long texts in tooltips - a good character limit is 200.
+
+### Positioning tooltip
+
+The position where the tooltip appears can be set and its fallback position too. By default the tooltip appears at the top and follows clockwise.
 
 ```jsx
-<div className="flex w-100">
-  <Tooltip label="Tooltip!" position="left">
-    <div className="ba br3 pa3">Tooltip on left</div>
-  </Tooltip>
-  <Tooltip label="Tooltip!" position="top">
-    <div className="ba br3 pa3 ml2">Tooltip on top</div>
-  </Tooltip>
-  <Tooltip label="Tooltip!" position="bottom">
-    <div className="ba br3 pa3 ml2">Tooltip on bottom</div>
-  </Tooltip>
-  <Tooltip label="Tooltip!" position="right">
-    <div className="ba br3 pa3 ml2">Tooltip on right</div>
-  </Tooltip>
-</div>
-```
-
-#### Off the screen
-
-```jsx
-<div className="flex flex-column w-100">
-  <Tooltip
-    label="Tooltip will be at the bottom!"
-    position="right"
-    fallbackPosition="left">
-    <div className="ba br3 pa3">Tooltip on the right with left as fallback</div>
-  </Tooltip>
-  <Tooltip label="Tooltip will be on bottom!" position="right">
-    <div className="ba br3 pa3 mt2">
-      Tooltip on right with bottom as default fallback
-    </div>
-  </Tooltip>
-</div>
-```
-
-#### On click/focus
-
-```jsx
-const ButtonWithIcon = require('../ButtonWithIcon').default
 const Button = require('../Button').default
-const IconHelp = require('../icon/Help').default
 
-;<div className="flex w-100 items-center">
-  <Tooltip label="Tooltip!">
+;<div className="flex w-100 justify-between">
+  <Tooltip label="Tooltip text">
+    <Button variation="tertiary">Top</Button>
+  </Tooltip>
+  <Tooltip label="Tooltip text" position="left">
+    <Button variation="tertiary">Left</Button>
+  </Tooltip>
+  <Tooltip label="Tooltip text" position="right">
+    <Button variation="tertiary">Right</Button>
+  </Tooltip>
+  <Tooltip label="Tooltip text" position="bottom">
+    <Button variation="tertiary">Bottom</Button>
+  </Tooltip>
+</div>
+```
+
+### Label and Informative text
+
+```jsx
+const Edit = require('../icon/Edit').default
+const Info = require('../icon/Info').default
+
+;<div className="flex w-100 justify-center items-center">
+  <div className="ph9">
+    <Tooltip label="Edit">
+      <span className="c-on-base pointer">
+        <Edit />
+      </span>
+    </Tooltip>
+  </div>
+  <div className="ph9">
+    <Tooltip label="Info">
+      <span className="c-on-base pointer">
+        <Info />
+      </span>
+    </Tooltip>
+  </div>
+</div>
+```
+
+### Hover vs Focused
+
+```jsx
+const Button = require('../Button').default
+
+;<div className="flex w-100 items-center justify-center">
+  <Tooltip label="Tooltip text">
     <div className="pa3">
-      <Button variation="tertiary">Tooltip on hover by default</Button>
+      <Button variation="tertiary">Hover</Button>
     </div>
   </Tooltip>
-  <Tooltip label="Tooltip!" trigger="focus">
+  <Tooltip label="Tooltip text" trigger="focus">
     <div className="pa3">
-      <ButtonWithIcon variation="tertiary" icon={<IconHelp />}>
-        Tooltip on focus/click
-      </ButtonWithIcon>
+      <Button variation="tertiary">Focused</Button>
     </div>
   </Tooltip>
 </div>

--- a/react/components/Tooltip/README.md
+++ b/react/components/Tooltip/README.md
@@ -22,10 +22,10 @@
 ```jsx
 <div className="flex flex-column w-100">
   <Tooltip
-    label="Tooltip will be on bottom!"
+    label="Tooltip will be at the bottom!"
     position="right"
     fallbackPosition="left">
-    <div className="ba br3 pa3">Tooltip on right with left as fallback</div>
+    <div className="ba br3 pa3">Tooltip on the right with left as fallback</div>
   </Tooltip>
   <Tooltip label="Tooltip will be on bottom!" position="right">
     <div className="ba br3 pa3 mt2">

--- a/react/components/Tooltip/README.md
+++ b/react/components/Tooltip/README.md
@@ -1,0 +1,59 @@
+#### Basic Tooltip ✨
+
+```jsx
+<div className="flex w-100">
+  <Tooltip label="Tooltip!" position="left">
+    <div className="ba br3 pa3">Tooltip on left</div>
+  </Tooltip>
+  <Tooltip label="Tooltip!" position="top">
+    <div className="ba br3 pa3 ml2">Tooltip on top</div>
+  </Tooltip>
+  <Tooltip label="Tooltip!" position="bottom">
+    <div className="ba br3 pa3 ml2">Tooltip on bottom</div>
+  </Tooltip>
+  <Tooltip label="Tooltip!" position="right">
+    <div className="ba br3 pa3 ml2">Tooltip on right</div>
+  </Tooltip>
+</div>
+```
+
+#### Off the screen
+
+```jsx
+<div className="flex flex-column w-100">
+  <Tooltip
+    label="Tooltip will be on bottom!"
+    position="right"
+    fallbackPosition="left">
+    <div className="ba br3 pa3">Tooltip on right with left as fallback</div>
+  </Tooltip>
+  <Tooltip label="Tooltip will be on bottom!" position="right">
+    <div className="ba br3 pa3 mt2">
+      Tooltip on right with bottom as default fallback
+    </div>
+  </Tooltip>
+</div>
+```
+
+#### On click/focus
+
+```jsx
+const ButtonWithIcon = require('../ButtonWithIcon').default
+const Button = require('../Button').default
+const IconHelp = require('../icon/Help').default
+
+;<div className="flex w-100 items-center">
+  <Tooltip label="Tooltip!">
+    <div className="pa3">
+      <Button variation="tertiary">Tooltip on hover by default</Button>
+    </div>
+  </Tooltip>
+  <Tooltip label="Tooltip!" trigger="focus">
+    <div className="pa3">
+      <ButtonWithIcon variation="tertiary" icon={<IconHelp />}>
+        Tooltip on focus/click
+      </ButtonWithIcon>
+    </div>
+  </Tooltip>
+</div>
+```

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -62,7 +62,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   }, [visible])
 
   const popupClasses = classNames(
-    'absolute pa3 bg-near-black white br2 shadow-1 f6',
+    'absolute pa3 bg-base--inverted c-on-base--inverted br2 shadow-1 f6',
     {
       dn: (!visible && !showPopup) || !childRect || !popupRect,
       'o-0': !visible || !hasComputedDimensions(popupRect),
@@ -170,10 +170,11 @@ const getPopupPositionRecursively = (
           originalPosition
         )
   }
+
+  const top = Math.min(styles.top, verticalMax - popupRect.height - 1)
+  const left = Math.min(styles.left, horizontalMax - popupRect.width - 1)
   return {
-    ...styles,
-    top: Math.min(styles.top, verticalMax - popupRect.height - 1),
-    left: Math.min(styles.left, horizontalMax - popupRect.width - 1),
+    transform: `translate3d(${left}px, -${document.body.offsetHeight - top}px, 0)`
   }
 }
 

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -68,7 +68,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   }, [visible])
 
   const popupClasses = classNames(
-    'absolute pv2 ph3 bg-base--inverted c-on-base--inverted br2 shadow-1 mw5 overflow-hidden',
+    'absolute pv3 ph4 bg-base--inverted c-on-base--inverted br2 shadow-1 mw5 overflow-hidden',
     style.popup,
     {
       dn: (!visible && !showPopup) || !childRect || !popupRect,

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -86,7 +86,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
     fallbackPosition
   )
 
-  return positionStyle ? (
+  return (
     <Portal>
       <div
         role="tooltip"
@@ -97,16 +97,16 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
         }}
         ref={popupRef}
         onTransitionEnd={() => setShowPopup(visible)}>
-        <span style={{ maxWidth: '220ch' }}>{label}</span>
+        {label}
       </div>
     </Portal>
-  ) : null
+  )
 }
 
 const getStyles = (childRect, popupRect, position, fallbackPosition) => {
-  return childRect && popupRect && window
+  return childRect && popupRect && window && hasComputedDimensions(popupRect)
     ? getPopupPosition(childRect, popupRect, position, fallbackPosition)
-    : {}
+    : { top: 0, left: 0 }
 }
 
 const FALLBACK_POSITION = {
@@ -137,26 +137,24 @@ const getPopupPositionRecursively = (
   const horizontalMax = window.innerWidth + window.pageXOffset
   const verticalMax = window.innerHeight + window.pageYOffset
   const styles = {
-    left: hasComputedDimensions(popupRect)
-      ? childRect.left +
-        window.pageXOffset +
-        (childRect.width - popupRect.width) / 2 +
-        (position === 'right'
-          ? (childRect.width + popupRect.width) / 2 + OFFSET
-          : 0) -
-        (position === 'left'
-          ? (childRect.width + popupRect.width) / 2 + OFFSET
-          : 0)
-      : 0,
-    top: hasComputedDimensions(popupRect)
-      ? childRect.top +
-        window.pageYOffset -
-        (position === 'top' ? popupRect.height + OFFSET : 0) +
-        (position === 'bottom' ? childRect.height + OFFSET : 0) +
-        (position === 'right' || position === 'left'
-          ? (childRect.height - popupRect.height) / 2
-          : 0)
-      : 0,
+    left:
+      childRect.left +
+      window.pageXOffset +
+      (childRect.width - popupRect.width) / 2 +
+      (position === 'right'
+        ? (childRect.width + popupRect.width) / 2 + OFFSET
+        : 0) -
+      (position === 'left'
+        ? (childRect.width + popupRect.width) / 2 + OFFSET
+        : 0),
+    top:
+      childRect.top +
+      window.pageYOffset -
+      (position === 'top' ? popupRect.height + OFFSET : 0) +
+      (position === 'bottom' ? childRect.height + OFFSET : 0) +
+      (position === 'right' || position === 'left'
+        ? (childRect.height - popupRect.height) / 2
+        : 0),
   }
 
   const collisions = {
@@ -188,9 +186,14 @@ const getPopupPositionRecursively = (
     window.pageXOffset + 1,
     Math.min(styles.left, horizontalMax - popupRect.width - 1)
   )
+
+  const transform = `translate3d(${Math.round(left)}px, -${Math.round(
+    document.body.offsetHeight - top
+  )}px, 0)`
+
   return {
-    transform: `translate3d(${left}px, -${document.body.offsetHeight -
-      top}px, 0)`,
+    transform,
+    WebkitTransform: transform,
   }
 }
 

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -1,0 +1,157 @@
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import React, { FC, useEffect, useRef, useState } from 'react'
+
+import Portal from './Portal'
+import { useRect } from './hooks'
+
+export type Position = 'top' | 'right' | 'bottom' | 'left'
+
+const OFFSET = 8
+const hasComputedDimensions = rect => rect && rect.width && rect.height
+
+const propTypes = {
+  position: PropTypes.oneOf<Position>(['top', 'bottom', 'left', 'right']),
+  fallbackPosition: PropTypes.oneOf<Position>(['top', 'bottom', 'left', 'right']),
+  label: PropTypes.string.isRequired,
+  visible: PropTypes.bool,
+  delay: PropTypes.number,
+  duration: PropTypes.number,
+  timmingFn: PropTypes.string,
+  childRef: PropTypes.shape({
+    current: PropTypes.instanceOf(HTMLElement),
+  }),
+}
+
+const defaultProps = {
+  visible: false,
+  delay: 0,
+  duration: 200,
+  timmingFn: 'ease-in-out',
+}
+
+const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
+  position,
+  fallbackPosition,
+  label,
+  visible,
+  delay,
+  duration,
+  timmingFn,
+  childRef,
+}) => {
+  const [showPopup, setShowPopup] = useState(visible)
+  const popupRef = useRef<HTMLDivElement>()
+  const childRect = useRect(childRef, visible)
+  const popupRect = useRect(popupRef, visible)
+
+  useEffect(() => {
+    if (visible) {
+      setShowPopup(true)
+    }
+  }, [visible])
+
+  const popupClasses = classNames(
+    'absolute pa3 bg-near-black white br2 shadow-1 f6',
+    {
+      dn: (!visible && !showPopup) || !childRect || !popupRect,
+      'o-0': !visible || !hasComputedDimensions(popupRect),
+      'o-100': visible && hasComputedDimensions(popupRect),
+    }
+  )
+
+  const positionStyle = getStyles(
+    childRect,
+    popupRect,
+    position,
+    fallbackPosition
+  )
+
+  return positionStyle ? (
+    <Portal>
+      <div
+        role="tooltip"
+        className={popupClasses}
+        style={{
+          ...positionStyle,
+          transition: `opacity ${duration}ms ${timmingFn} ${delay}ms`,
+        }}
+        ref={popupRef}
+        onTransitionEnd={() => setShowPopup(visible)}>
+        {label}
+      </div>
+    </Portal>
+  ) : null
+}
+
+const getStyles = (childRect, popupRect, position, fallbackPosition) => {
+  return childRect && popupRect && window
+    ? positionDefault(childRect, popupRect, position, fallbackPosition)
+    : {}
+}
+
+const FALLBACK_POSITION = {
+  top: 'right',
+  right: 'bottom',
+  bottom: 'left',
+  left: 'top',
+}
+
+const getFallbackPosition = (position, fallback) =>
+  fallback || FALLBACK_POSITION[position]
+
+const positionDefault = (childRect, popupRect, position, fallbackPosition) => {
+  const horizontalMax = window.innerWidth + window.pageXOffset
+  const verticalMax = window.innerHeight + window.pageYOffset
+  const styles = {
+    left: hasComputedDimensions(popupRect)
+      ? childRect.left +
+        window.pageXOffset +
+        (childRect.width - popupRect.width) / 2 +
+        (position === 'right'
+          ? (childRect.width + popupRect.width) / 2 + OFFSET
+          : 0) -
+        (position === 'left'
+          ? (childRect.width + popupRect.width) / 2 + OFFSET
+          : 0)
+      : 0,
+    top: hasComputedDimensions(popupRect)
+      ? childRect.top +
+        window.pageYOffset -
+        (position === 'top' ? popupRect.height + OFFSET : 0) +
+        (position === 'bottom' ? childRect.height + OFFSET : 0) +
+        (position === 'right' || position === 'left'
+          ? (childRect.height - popupRect.height) / 2
+          : 0)
+      : 0,
+  }
+
+  const collisions = {
+    top: styles.top < window.pageYOffset,
+    right: (styles.left + popupRect.width) > horizontalMax,
+    bottom: styles.top + popupRect.height > verticalMax,
+    left: styles.left < window.pageXOffset,
+  }
+
+  if (!Object.values(collisions).some(collision => !collision)) {
+    return null
+  }
+
+  return collisions[position]
+    ? positionDefault(
+        childRect,
+        popupRect,
+        getFallbackPosition(position, fallbackPosition),
+        null
+      )
+    : {
+        ...styles,
+        top: Math.min(styles.top, verticalMax - popupRect.height - 1),
+        left: Math.min(styles.left, horizontalMax - popupRect.width - 1),
+      }
+}
+
+TooltipPopup.propTypes = propTypes
+TooltipPopup.defaultProps = defaultProps
+
+export default TooltipPopup

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -6,8 +6,9 @@ import Portal from './Portal'
 import { useRect } from './hooks'
 
 export type Position = 'top' | 'right' | 'bottom' | 'left'
+export type Size = 'mini' | 'small'
 
-const OFFSET = 8
+const OFFSET = 16
 const hasComputedDimensions = rect => rect && rect.width && rect.height
 
 const propTypes = {
@@ -15,6 +16,8 @@ const propTypes = {
   label: PropTypes.node.isRequired,
   /** Tooltip position */
   position: PropTypes.oneOf<Position>(['top', 'bottom', 'left', 'right']),
+  /** Tooltip font size */
+  size: PropTypes.oneOf<Size>(['mini', 'small']),
   /** Fallback position (when the tooltip cannot appear in the original position) */
   fallbackPosition: PropTypes.oneOf<Position>([
     'top',
@@ -42,6 +45,7 @@ const defaultProps = {
 
 const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   position,
+  size,
   fallbackPosition,
   label,
   visible,
@@ -62,11 +66,13 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   }, [visible])
 
   const popupClasses = classNames(
-    'absolute pa3 bg-base--inverted c-on-base--inverted br2 shadow-1 f6',
+    'absolute pv2 ph3 bg-base--inverted c-on-base--inverted br2 shadow-1',
     {
       dn: (!visible && !showPopup) || !childRect || !popupRect,
       'o-0': !visible || !hasComputedDimensions(popupRect),
       'o-100': visible && hasComputedDimensions(popupRect),
+      't-mini': size === 'mini',
+      't-small': size === 'small'
     }
   )
 

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -66,13 +66,13 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   }, [visible])
 
   const popupClasses = classNames(
-    'absolute pv2 ph3 bg-base--inverted c-on-base--inverted br2 shadow-1',
+    'absolute pv2 ph3 bg-base--inverted c-on-base--inverted br2 shadow-1 mw5 overflow-hidden',
     {
       dn: (!visible && !showPopup) || !childRect || !popupRect,
       'o-0': !visible || !hasComputedDimensions(popupRect),
       'o-100': visible && hasComputedDimensions(popupRect),
       't-mini': size === 'mini',
-      't-small': size === 'small'
+      't-small': size === 'small',
     }
   )
 
@@ -94,7 +94,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
         }}
         ref={popupRef}
         onTransitionEnd={() => setShowPopup(visible)}>
-        {label}
+        <span style={{ maxWidth: '220ch' }}>{label}</span>
       </div>
     </Portal>
   ) : null
@@ -177,10 +177,17 @@ const getPopupPositionRecursively = (
         )
   }
 
-  const top = Math.min(styles.top, verticalMax - popupRect.height - 1)
-  const left = Math.min(styles.left, horizontalMax - popupRect.width - 1)
+  const top = Math.max(
+    window.pageYOffset + 1,
+    Math.min(styles.top, verticalMax - popupRect.height - 1)
+  )
+  const left = Math.max(
+    window.pageXOffset + 1,
+    Math.min(styles.left, horizontalMax - popupRect.width - 1)
+  )
   return {
-    transform: `translate3d(${left}px, -${document.body.offsetHeight - top}px, 0)`
+    transform: `translate3d(${left}px, -${document.body.offsetHeight -
+      top}px, 0)`,
   }
 }
 

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -68,7 +68,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   }, [visible])
 
   const popupClasses = classNames(
-    'absolute pv2 ph3 bg-base--inverted c-on-base--inverted br2 shadow-1 mw5 overflow-hidden truncate',
+    'absolute pv2 ph3 bg-base--inverted c-on-base--inverted br2 shadow-1 mw5 overflow-hidden',
     style.popup,
     {
       dn: (!visible && !showPopup) || !childRect || !popupRect,

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -5,6 +5,8 @@ import React, { FC, useEffect, useRef, useState } from 'react'
 import Portal from './Portal'
 import { useRect } from './hooks'
 
+import style from './tooltip.css'
+
 export type Position = 'top' | 'right' | 'bottom' | 'left'
 export type Size = 'mini' | 'small'
 
@@ -66,7 +68,8 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   }, [visible])
 
   const popupClasses = classNames(
-    'absolute pv2 ph3 bg-base--inverted c-on-base--inverted br2 shadow-1 mw5 overflow-hidden',
+    'absolute pv2 ph3 bg-base--inverted c-on-base--inverted br2 shadow-1 mw5 overflow-hidden truncate',
+    style.popup,
     {
       dn: (!visible && !showPopup) || !childRect || !popupRect,
       'o-0': !visible || !hasComputedDimensions(popupRect),

--- a/react/components/Tooltip/hooks.ts
+++ b/react/components/Tooltip/hooks.ts
@@ -1,4 +1,4 @@
-import { get } from 'lodash'
+import get from 'lodash/get'
 import { RefObject, useState, useRef, useLayoutEffect } from 'react'
 
 import observeRect from './utils/dom'
@@ -7,8 +7,8 @@ import { setRef } from '../utils/react'
 export type Trigger = 'click' | 'hover' | 'focus'
 
 export function useRect(nodeRef, observe = true) {
-  let [rect, setRect] = useState(null)
-  let observerRef = useRef(null)
+  const [rect, setRect] = useState(null)
+  const observerRef = useRef(null)
   useLayoutEffect(() => {
     if (!observerRef.current && nodeRef.current) {
       observerRef.current = observeRect(nodeRef.current, setRect)

--- a/react/components/Tooltip/hooks.ts
+++ b/react/components/Tooltip/hooks.ts
@@ -24,8 +24,8 @@ export function useRect(nodeRef, observe = true) {
 export function useTooltip({
   trigger,
 }: {
-  trigger: Trigger
-}): [
+  trigger?: Trigger
+} = {}): [
   (c: React.ReactElement) => object,
   { childRef: RefObject<HTMLElement>; visible: boolean }
 ] {

--- a/react/components/Tooltip/hooks.ts
+++ b/react/components/Tooltip/hooks.ts
@@ -29,7 +29,7 @@ export function useTooltip({
   (c: React.ReactElement) => object,
   { childRef: RefObject<HTMLElement>; visible: boolean }
 ] {
-  const childRef = useRef()
+  const childRef = useRef<HTMLElement>()
   const [visible, setVisible] = useState(false)
   const handleTooltip = (child: React.ReactElement & { ref?: any }) => {
     return {
@@ -61,6 +61,17 @@ export function useTooltip({
         : {}),
       ...(trigger === 'click' || trigger === 'focus'
         ? {
+            onClick: (...args) => {
+              // Firefox and Safari, both on Mac OS, doesn't focus on click, like
+              // Google Chrome does, so...
+              if (childRef.current) {
+                childRef.current.focus()
+              }
+              const onClick = get(child, 'props.onClick')
+              if (onClick) {
+                return onClick.call(child.props, ...args)
+              }
+            },
             onFocus: (...args) => {
               setVisible(true)
               const onFocus = get(child, 'props.onFocus')

--- a/react/components/Tooltip/hooks.ts
+++ b/react/components/Tooltip/hooks.ts
@@ -1,0 +1,83 @@
+import { get } from 'lodash'
+import { RefObject, useState, useRef, useLayoutEffect } from 'react'
+
+import observeRect from './utils/dom'
+import { setRef } from '../utils/react'
+
+export type Trigger = 'click' | 'hover' | 'focus'
+
+export function useRect(nodeRef, observe = true) {
+  let [rect, setRect] = useState(null)
+  let observerRef = useRef(null)
+  useLayoutEffect(() => {
+    if (!observerRef.current && nodeRef.current) {
+      observerRef.current = observeRect(nodeRef.current, setRect)
+    }
+    if (observerRef.current && observe) {
+      observerRef.current.observe()
+    }
+    return () => observerRef.current && observerRef.current.unobserve()
+  }, [observe, nodeRef.current])
+  return rect
+}
+
+export function useTooltip({
+  trigger,
+}: {
+  trigger: Trigger
+}): [
+  (c: React.ReactElement) => object,
+  { childRef: RefObject<HTMLElement>; visible: boolean }
+] {
+  const childRef = useRef()
+  const [visible, setVisible] = useState(false)
+  const handleTooltip = (child: React.ReactElement & { ref?: any }) => {
+    return {
+      ref: node => {
+        // Keep your own reference
+        if (node) {
+          setRef(childRef, node)
+        }
+        // Call the original ref, if any
+        setRef(child.ref, node)
+      },
+      ...(trigger === 'hover'
+        ? {
+            onMouseEnter: (...args) => {
+              setVisible(true)
+              const onMouseEnter = get(child, 'props.onMouseEnter')
+              if (onMouseEnter) {
+                return onMouseEnter.call(child.props, ...args)
+              }
+            },
+            onMouseLeave: (...args) => {
+              setVisible(false)
+              const onMouseLeave = get(child, 'props.onMouseLeave')
+              if (onMouseLeave) {
+                return onMouseLeave.call(child.props, ...args)
+              }
+            },
+          }
+        : {}),
+      ...(trigger === 'click' || trigger === 'focus'
+        ? {
+            onFocus: (...args) => {
+              setVisible(true)
+              const onFocus = get(child, 'props.onFocus')
+              if (onFocus) {
+                return onFocus.call(child.props, ...args)
+              }
+            },
+            onBlur: (...args) => {
+              setVisible(false)
+              const onBlur = get(child, 'props.onBlur')
+              if (onBlur) {
+                return onBlur.call(child.props, ...args)
+              }
+            },
+          }
+        : {}),
+    }
+  }
+  return [handleTooltip, { childRef, visible }]
+}

--- a/react/components/Tooltip/index.tsx
+++ b/react/components/Tooltip/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import { get } from 'lodash'
+import get from 'lodash/get'
 import React, {
   FC,
   cloneElement,

--- a/react/components/Tooltip/index.tsx
+++ b/react/components/Tooltip/index.tsx
@@ -13,37 +13,46 @@ import React, {
 import TooltipPopup, { Position } from './TooltipPopup'
 import { useTooltip, Trigger } from './hooks'
 
-
 const propTypes = {
-  label: PropTypes.string.isRequired,
+  /** Label to be shown. As element, can be a string, number...*/
+  label: PropTypes.node.isRequired,
+  /** Tooltip position */
   position: PropTypes.oneOf<Position>(['top', 'right', 'bottom', 'left']),
-  fallbackPosition: PropTypes.oneOf<Position>(['top', 'right', 'bottom', 'left']),
+  /** Fallback position. Used when the tooltip cannot be shown in the original position */
+  fallbackPosition: PropTypes.oneOf<Position>([
+    'top',
+    'right',
+    'bottom',
+    'left',
+  ]),
+  /** Event to trigger the tooltip */
   trigger: PropTypes.oneOf<Trigger>(['click', 'hover', 'focus']),
+  /** Element that will trigger the event */
   children: PropTypes.element.isRequired,
+  /** Delay to show and hide the tooltip (ms) */
+  delay: PropTypes.number,
+  /** Tooltip animation duration (ms) */
+  duration: PropTypes.number,
+  /** Tooltip timming function used to animate the tooltip */
+  timmingFn: PropTypes.string,
 }
 
-const defaultProps: { trigger: Trigger; position: Position } = {
+type Props = PropTypes.InferProps<typeof propTypes>
+
+const defaultProps: Props = {
   trigger: 'hover',
   position: 'top',
+  delay: 0,
+  duration: 200,
+  timmingFn: 'ease-in-out',
 }
 
-const Tooltip: FC<PropTypes.InferProps<typeof propTypes>> = ({
-  trigger,
-  label,
-  position,
-  fallbackPosition,
-  children,
-}) => {
+const Tooltip: FC<Props> = ({ trigger, children, ...popupProps }) => {
   const [handleTooltip, tooltip] = useTooltip({ trigger })
   const child = Children.only(children)
   return (
     <>
-      <TooltipPopup
-        {...tooltip}
-        fallbackPosition={fallbackPosition}
-        position={position}
-        label={label}
-      />
+      <TooltipPopup {...tooltip} {...popupProps} />
       {cloneElement(child, handleTooltip(child))}
     </>
   )

--- a/react/components/Tooltip/index.tsx
+++ b/react/components/Tooltip/index.tsx
@@ -1,0 +1,55 @@
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import { get } from 'lodash'
+import React, {
+  FC,
+  cloneElement,
+  Children,
+  useRef,
+  useEffect,
+  useState,
+} from 'react'
+
+import TooltipPopup, { Position } from './TooltipPopup'
+import { useTooltip, Trigger } from './hooks'
+
+
+const propTypes = {
+  label: PropTypes.string.isRequired,
+  position: PropTypes.oneOf<Position>(['top', 'right', 'bottom', 'left']),
+  fallbackPosition: PropTypes.oneOf<Position>(['top', 'right', 'bottom', 'left']),
+  trigger: PropTypes.oneOf<Trigger>(['click', 'hover', 'focus']),
+  children: PropTypes.element.isRequired,
+}
+
+const defaultProps: { trigger: Trigger; position: Position } = {
+  trigger: 'hover',
+  position: 'top',
+}
+
+const Tooltip: FC<PropTypes.InferProps<typeof propTypes>> = ({
+  trigger,
+  label,
+  position,
+  fallbackPosition,
+  children,
+}) => {
+  const [handleTooltip, tooltip] = useTooltip({ trigger })
+  const child = Children.only(children)
+  return (
+    <>
+      <TooltipPopup
+        {...tooltip}
+        fallbackPosition={fallbackPosition}
+        position={position}
+        label={label}
+      />
+      {cloneElement(child, handleTooltip(child))}
+    </>
+  )
+}
+
+Tooltip.propTypes = propTypes
+Tooltip.defaultProps = defaultProps
+
+export default Tooltip

--- a/react/components/Tooltip/index.tsx
+++ b/react/components/Tooltip/index.tsx
@@ -10,7 +10,7 @@ import React, {
   useState,
 } from 'react'
 
-import TooltipPopup, { Position } from './TooltipPopup'
+import TooltipPopup, { Position, Size } from './TooltipPopup'
 import { useTooltip, Trigger } from './hooks'
 
 const propTypes = {
@@ -18,6 +18,8 @@ const propTypes = {
   label: PropTypes.node.isRequired,
   /** Tooltip position */
   position: PropTypes.oneOf<Position>(['top', 'right', 'bottom', 'left']),
+  /** Tooltip font size */
+  size: PropTypes.oneOf<Size>(['mini', 'small']),
   /** Fallback position. Used when the tooltip cannot be shown in the original position */
   fallbackPosition: PropTypes.oneOf<Position>([
     'top',
@@ -42,6 +44,7 @@ type Props = PropTypes.InferProps<typeof propTypes>
 const defaultProps: Props = {
   trigger: 'hover',
   position: 'top',
+  size: 'mini',
   delay: 0,
   duration: 200,
   timmingFn: 'ease-in-out',

--- a/react/components/Tooltip/tooltip.css
+++ b/react/components/Tooltip/tooltip.css
@@ -1,0 +1,4 @@
+.popup {
+  max-height: 11rem;
+  white-space: normal;
+}

--- a/react/components/Tooltip/tooltip.css
+++ b/react/components/Tooltip/tooltip.css
@@ -1,4 +1,3 @@
 .popup {
   max-height: 11rem;
-  white-space: normal;
 }

--- a/react/components/Tooltip/tooltip.css
+++ b/react/components/Tooltip/tooltip.css
@@ -1,3 +1,4 @@
 .popup {
   max-height: 11rem;
+  will-change: transform;
 }

--- a/react/components/Tooltip/tooltip.css
+++ b/react/components/Tooltip/tooltip.css
@@ -2,3 +2,4 @@
   max-height: 11rem;
   will-change: transform;
 }
+

--- a/react/components/Tooltip/utils/dom.ts
+++ b/react/components/Tooltip/utils/dom.ts
@@ -1,0 +1,62 @@
+const props = ['width', 'height', 'top', 'right', 'bottom', 'left']
+
+const rectChanged = (a = {}, b = {}) => props.some(prop => a[prop] !== b[prop])
+
+const observedNodes = new Map()
+let rafId = null
+
+let run = () => {
+  observedNodes.forEach(state => {
+    if (state.hasRectChanged) {
+      state.callbacks.forEach(cb => cb(state.rect))
+      state.hasRectChanged = false
+    }
+  })
+
+  setTimeout(() => {
+    observedNodes.forEach((state, node) => {
+      if (node) {
+        let newRect = node.getBoundingClientRect()
+        if (rectChanged(newRect, state.rect)) {
+          state.hasRectChanged = true
+          state.rect = newRect
+        }
+      }
+    })
+  }, 0)
+
+  rafId = requestAnimationFrame(run)
+}
+
+export default (node, cb) => {
+  return {
+    observe() {
+      let wasEmpty = observedNodes.size === 0
+      if (observedNodes.has(node)) {
+        observedNodes.get(node).callbacks.push(cb)
+      } else {
+        observedNodes.set(node, {
+          rect: undefined,
+          hasRectChanged: true,
+          callbacks: [cb],
+        })
+      }
+      if (wasEmpty) run()
+    },
+
+    unobserve() {
+      let state = observedNodes.get(node)
+      if (state) {
+        // Remove the callback
+        const index = state.callbacks.indexOf(cb)
+        if (index >= 0) state.callbacks.splice(index, 1)
+
+        // Remove the node reference
+        if (!state.callbacks.length) observedNodes.delete(node)
+
+        // Stop the loop
+        if (!observedNodes.size) cancelAnimationFrame(rafId)
+      }
+    },
+  }
+}

--- a/react/components/Tooltip/utils/dom.ts
+++ b/react/components/Tooltip/utils/dom.ts
@@ -1,3 +1,4 @@
+// From @reach-ui
 const props = ['width', 'height', 'top', 'right', 'bottom', 'left']
 
 const rectChanged = (a = {}, b = {}) => props.some(prop => a[prop] !== b[prop])
@@ -5,7 +6,7 @@ const rectChanged = (a = {}, b = {}) => props.some(prop => a[prop] !== b[prop])
 const observedNodes = new Map()
 let rafId = null
 
-let run = () => {
+const run = () => {
   observedNodes.forEach(state => {
     if (state.hasRectChanged) {
       state.callbacks.forEach(cb => cb(state.rect))
@@ -16,7 +17,7 @@ let run = () => {
   setTimeout(() => {
     observedNodes.forEach((state, node) => {
       if (node) {
-        let newRect = node.getBoundingClientRect()
+        const newRect = node.getBoundingClientRect()
         if (rectChanged(newRect, state.rect)) {
           state.hasRectChanged = true
           state.rect = newRect
@@ -28,35 +29,33 @@ let run = () => {
   rafId = requestAnimationFrame(run)
 }
 
-export default (node, cb) => {
-  return {
-    observe() {
-      let wasEmpty = observedNodes.size === 0
-      if (observedNodes.has(node)) {
-        observedNodes.get(node).callbacks.push(cb)
-      } else {
-        observedNodes.set(node, {
-          rect: undefined,
-          hasRectChanged: true,
-          callbacks: [cb],
-        })
-      }
-      if (wasEmpty) run()
-    },
+export default (node, cb) => ({
+  observe() {
+    const wasEmpty = observedNodes.size === 0
+    if (observedNodes.has(node)) {
+      observedNodes.get(node).callbacks.push(cb)
+    } else {
+      observedNodes.set(node, {
+        rect: null,
+        hasRectChanged: true,
+        callbacks: [cb],
+      })
+    }
+    if (wasEmpty) run()
+  },
 
-    unobserve() {
-      let state = observedNodes.get(node)
-      if (state) {
-        // Remove the callback
-        const index = state.callbacks.indexOf(cb)
-        if (index >= 0) state.callbacks.splice(index, 1)
+  unobserve() {
+    const state = observedNodes.get(node)
+    if (state) {
+      // Remove the callback
+      const index = state.callbacks.indexOf(cb)
+      if (index >= 0) state.callbacks.splice(index, 1)
 
-        // Remove the node reference
-        if (!state.callbacks.length) observedNodes.delete(node)
+      // Remove the node reference
+      if (!state.callbacks.length) observedNodes.delete(node)
 
-        // Stop the loop
-        if (!observedNodes.size) cancelAnimationFrame(rafId)
-      }
-    },
-  }
-}
+      // Stop the loop
+      if (!observedNodes.size) cancelAnimationFrame(rafId)
+    }
+  },
+})

--- a/react/components/Tooltip/utils/dom.ts
+++ b/react/components/Tooltip/utils/dom.ts
@@ -36,7 +36,7 @@ export default (node, cb) => ({
       observedNodes.get(node).callbacks.push(cb)
     } else {
       observedNodes.set(node, {
-        rect: null,
+        rect: undefined,
         hasRectChanged: true,
         callbacks: [cb],
       })

--- a/react/components/utils/react.ts
+++ b/react/components/utils/react.ts
@@ -1,0 +1,8 @@
+export function setRef(ref, value) {
+  if (typeof ref === 'function') {
+    ref(value)
+  } else if (ref) {
+    ref.current = value
+  }
+}
+

--- a/react/package.json
+++ b/react/package.json
@@ -4,6 +4,7 @@
     "lodash": "^4.17.11",
     "react-color": "^2.17.0",
     "react-datepicker": "^2.0.0",
+    "react-dom": "^16.9.0",
     "react-number-format": "^4.0.6",
     "react-outside-click-handler": "^1.2.2",
     "react-overlays": "^1.1.2",
@@ -15,8 +16,11 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
+    "@types/classnames": "^2.2.9",
     "@types/jest": "^24.0.15",
+    "@types/lodash": "^4.14.137",
     "@types/node": "^12.6.2",
-    "@types/react": "^16.8.23"
+    "@types/react": "^16.8.23",
+    "@types/react-dom": "^16.9.0"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -94,6 +94,11 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
+"@types/classnames@^2.2.9":
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"
+  integrity sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==
+
 "@types/jest-diff@*":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
@@ -106,6 +111,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/lodash@^4.14.137":
+  version "4.14.137"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.137.tgz#8a4804937dc6462274ffcc088df8f14fc1b368e2"
+  integrity sha512-g4rNK5SRKloO+sUGbuO7aPtwbwzMgjK+bm9BBhLD7jGUiGR7zhwYEhSln/ihgYQBeIJ5j7xjyaYzrWTcu3UotQ==
+
 "@types/node@^12.6.2":
   version "12.6.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
@@ -115,6 +125,21 @@
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
   integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
+
+"@types/react-dom@^16.9.0":
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.0.tgz#ba6ddb00bf5de700b0eb91daa452081ffccbfdea"
+  integrity sha512-OL2lk7LYGjxn4b0efW3Pvf2KBVP0y1v3wip1Bp7nA79NkOpElH98q3WdCEdDj93b2b0zaeBG9DvriuKjIK5xDA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.9.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.2.tgz#6d1765431a1ad1877979013906731aae373de268"
+  integrity sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/react@^16.8.23":
   version "16.8.24"
@@ -1159,7 +1184,7 @@ lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.13:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-loose-envify@^1.0.0, loose-envify@^1.3.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -1607,6 +1632,16 @@ react-datepicker@^2.0.0:
     react-onclickoutside "^6.7.1"
     react-popper "^1.0.2"
 
+react-dom@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
+  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.15.0"
+
 react-input-autosize@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
@@ -1851,6 +1886,14 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+scheduler@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 semver@^5.3.0:
   version "5.7.0"

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -105,6 +105,7 @@ module.exports = {
             'react/components/Tag/index.js',
             'react/components/ProgressBar/index.js',
             'react/components/Totalizer/index.js',
+            'react/components/Tooltip/index.tsx',
           ],
         },
         {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the `Tooltip` Component ✨ ([Figma's spec](https://www.figma.com/file/hXb2U8ARb4WgpE6LMXG92h/Componentes?node-id=0%3A1))

#### What problem is this solving?

There was no tooltip component implemented on Styleguide

#### How should this be manually tested?

Clone this repo and run `yarn && yarn start`

#### Screenshots or example usage

![tooltip](https://user-images.githubusercontent.com/15948386/64127524-611c4600-cd88-11e9-8279-31b0f3f1af46.gif)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
