### PR TITLE
Reorder markup and remove unnecessary classes from NumericStepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Accessibility navigation with tab in Numeric Stepper.
+
 ## [9.73.15] - 2019-08-28
 
 ### Fixed

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -209,43 +209,7 @@ class NumericStepper extends Component {
           </span>
         )}
         <div className="flex self-start">
-          <input
-            type="tel"
-            className={`z-1 order-1 tc bw1 ${borderClasses} br0 ${inputClasses} ${hideDecorators}`}
-            style={{
-              ...(block && {
-                width: 0,
-              }),
-              WebkitAppearance: 'none',
-            }}
-            value={displayValue}
-            onChange={this.handleTypeQuantity}
-            onFocus={this.handleFocusInput}
-            onBlur={this.handleBlurInput}
-          />
-          <div className="z-2 order-2 flex-none">
-            <button
-              type="button"
-              className={`br2 pa0 bl-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
-                isMax ? buttonDisabledClasses : buttonEnabledClasses
-              }`}
-              style={{
-                borderTopLeftRadius: 0,
-                borderBottomLeftRadius: 0,
-                width: lean ? '2em' : '3em',
-                transition: 'opacity 150ms',
-              }}
-              disabled={isMax}
-              aria-label="+"
-              tabIndex={0}
-              onClick={this.handleIncreaseValue}>
-              <div className="b">
-                {/* fullwidth plus sign (U+FF0B) http://graphemica.com/%EF%BC%8B */}
-                ＋
-              </div>
-            </button>
-          </div>
-          <div className="z-2 order-0 flex-none">
+          <div className="z-2 flex-none">
             <button
               type="button"
               className={`br2 pa0 br-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
@@ -268,6 +232,42 @@ class NumericStepper extends Component {
                 {/* fullwidth hyphen-minus (U+FF0D) http://graphemica.com/%EF%BC%8D */}
                 －
               </span>
+            </button>
+          </div>
+          <input
+            type="tel"
+            className={`tc bw1 ${borderClasses} br0 ${inputClasses} ${hideDecorators}`}
+            style={{
+              ...(block && {
+                width: 0,
+              }),
+              WebkitAppearance: 'none',
+            }}
+            value={displayValue}
+            onChange={this.handleTypeQuantity}
+            onFocus={this.handleFocusInput}
+            onBlur={this.handleBlurInput}
+          />
+          <div className="z-2 flex-none">
+            <button
+              type="button"
+              className={`br2 pa0 bl-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
+                isMax ? buttonDisabledClasses : buttonEnabledClasses
+              }`}
+              style={{
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+                width: lean ? '2em' : '3em',
+                transition: 'opacity 150ms',
+              }}
+              disabled={isMax}
+              aria-label="+"
+              tabIndex={0}
+              onClick={this.handleIncreaseValue}>
+              <div className="b">
+                {/* fullwidth plus sign (U+FF0B) http://graphemica.com/%EF%BC%8B */}
+                ＋
+              </div>
             </button>
           </div>
         </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix an accessibility issue with the `NumericStepper` component.

#### What problem is this solving?

Wrong tab order. See gifs below.

#### How should this be manually tested?



#### Screenshots or example usage

**Before**: 
![](https://media.giphy.com/media/j4kp8bdXiyQjH2yPd7/giphy.gif)

**After**:
![](https://media.giphy.com/media/QVb9wOP6raryc3QuZl/giphy.gif)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
