### PR TITLE
Fix invalid prop-type for the positionFixed prop in the DatePicker component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Invalid `PropType` for the `positionFixed` prop in `DatePicker` component.
+
 ## [9.74.1] - 2019-08-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.74.2] - 2019-08-29
+
 ### Fixed
 
 - Invalid `PropType` for the `positionFixed` prop in `DatePicker` component.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.74.1",
+  "version": "9.74.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.74.1",
+  "version": "9.74.2",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/DatePicker/index.js
+++ b/react/components/DatePicker/index.js
@@ -246,7 +246,7 @@ DatePicker.propTypes = {
   /** Value of the selected date  */
   value: PropTypes.instanceOf(Date).isRequired,
   /** Sets the popper to position fixed. Fixes issues with overflow: hidden. */
-  positionFixed: PropTypes.boolean,
+  positionFixed: PropTypes.bool,
 }
 
 export default withForwardedRef(DatePicker)


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

It is necessary for the [PR #85](https://github.com/vtex/admin-collections/pull/85)

#### What problem is this solving?
The `positionFixed` prop in the `DatePicker` component was using `boolean` instead of `bool` in the `propTypes`.

#### How should this be manually tested?
[Workspace](https://vitoria--storecomponents.myvtex.com/admin/collections/768/).

#### Screenshots or example usage
Not necessary.

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
