### PR TITLE
Fix radio circle position to items-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Radio circle position to `items-start`
+
 ## [9.75.0] - 2019-08-29
 
 ### Added

--- a/react/components/Radio/index.js
+++ b/react/components/Radio/index.js
@@ -30,7 +30,7 @@ class Radio extends PureComponent {
 
     return (
       <div
-        className={classNames('flex items-center mb3 relative', {
+        className={classNames('flex items-start mb3 relative', {
           pointer: !disabled,
         })}
         ref={this.container}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix radio circle position to items-start

#### What problem is this solving?
Closes https://github.com/vtex/styleguide/issues/798
Radio circle was not positioned as the Figma component.

#### Screenshots or example usage
| Before| After|
|-|-|
|<img width="329" alt="Screen Shot 2019-08-29 at 11 51 44" src="https://user-images.githubusercontent.com/5608421/63951187-ae7c7880-ca53-11e9-8421-b7929b60547f.png">|<img width="362" alt="Screen Shot 2019-08-29 at 11 52 29" src="https://user-images.githubusercontent.com/5608421/63951204-b63c1d00-ca53-11e9-8be8-ba0493dbdb7f.png">|

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
