### PR TITLE
Added InputCustom to Table V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `InputCustom` to `EXPERIMENTAL_TableV2`
+
 ## [9.74.3] - 2019-08-29
 
 ### Changed

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -368,3 +368,115 @@ function StateHookExample() {
 }
 ;<StateHookExample />
 ```
+
+### UNSAFE Custom Input
+
+The `UNSAFE_InputCustom` provides a simple way of passing a custom input to the `Table`'s toolbar.
+
+⚠️ Be aware that this component is temporary and WILL change in the future!
+
+```js
+// Imports
+const useTableState = require('./hooks/useTableState.ts').default
+const Input = require('../Input/index.js').default
+
+/** Define the columns */
+const columns = [
+  {
+    id: 'name',
+    title: 'Name',
+  },
+  {
+    id: 'email',
+    title: 'Email',
+  },
+  {
+    id: 'number',
+    title: 'Number',
+  },
+  {
+    id: 'country',
+    title: 'Country',
+  },
+]
+
+/** Define the items */
+const items = [
+  {
+    name: "T'Chala",
+    email: 'black.panther@gmail.com',
+    number: 1.88191,
+    country: '🇰🇪Wakanda',
+  },
+  {
+    name: 'Peter Parker',
+    email: 'spider.man@gmail.com',
+    number: 3.09191,
+    country: '🇺🇸USA',
+  },
+  {
+    name: 'Shang-Chi',
+    email: 'kungfu.master@gmail.com',
+    number: 39.09222,
+    country: '🇨🇳China',
+  },
+  {
+    name: 'Natasha Romanoff',
+    email: 'black.widow@gmail.com',
+    number: 5.09291,
+    country: '🇷🇺Russia',
+  },
+]
+
+/** Custom hook to filter items and keep track of input props */
+function useItemsFilter() {
+  const [displayItems, setDisplayItems] = React.useState(items)
+  const [inputValue, setInputValue] = React.useState('')
+
+  return {
+    displayItems,
+    value: inputValue,
+    placeholder: 'Hey, This input is custom 🙂',
+    onChange: e => setInputValue(e.currentTarget.value),
+    onClear: () => {
+      setInputValue('')
+      setDisplayItems(items)
+    },
+    onSubmit: e => {
+      e.preventDefault()
+      const isInputClear = inputValue === ''
+      const filterFn = item =>
+        item.name.toLowerCase().includes(inputValue.toLowerCase())
+      setDisplayItems(isInputClear ? items : items.filter(filterFn))
+    },
+  }
+}
+
+/** Custom input example */
+function InputCustom({ onSubmit, ...inputProps }) {
+  return (
+    <form onSubmit={onSubmit}>
+      <Input {...inputProps} />
+    </form>
+  )
+}
+
+function UnsafeInputExample() {
+  const { displayItems, ...inputProps } = useItemsFilter()
+  const tableState = useTableState({
+    columns,
+    items: displayItems,
+  })
+
+  return (
+    <Table state={tableState}>
+      <Table.Toolbar>
+        <Table.Toolbar.UNSAFE_InputCustom
+          input={<InputCustom {...inputProps} />}
+        />
+      </Table.Toolbar>
+    </Table>
+  )
+}
+;<UnsafeInputExample />
+```

--- a/react/components/EXPERIMENTAL_Table/Toolbar/InputCustom.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/InputCustom.tsx
@@ -1,0 +1,17 @@
+import React, { FC, InputHTMLAttributes } from 'react'
+
+import { NAMESPACES } from '../constants'
+
+export type InputCustomProps = InputHTMLAttributes<HTMLInputElement> & {
+  input: Element
+}
+
+const UNSAFE_InputCustom: FC<InputCustomProps> = ({ input }) => {
+  return (
+    <span className="order-0 w-40" id={NAMESPACES.TOOLBAR.INPUT_SEARCH}>
+      {input}
+    </span>
+  )
+}
+
+export default UNSAFE_InputCustom

--- a/react/components/EXPERIMENTAL_Table/Toolbar/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/index.tsx
@@ -3,21 +3,24 @@ import React, { FC } from 'react'
 import Container from './Container'
 import ButtonGroup from './ButtonGroup'
 import InputSearch, { InputSearchProps } from './InputSearch'
+import UNSAFE_InputCustom, { InputCustomProps } from './InputCustom'
 
 interface Composites {
   InputSearch: FC<InputSearchProps>
   ButtonGroup: FC
+  UNSAFE_InputCustom: FC<InputCustomProps>
 }
 
 type ToolbarChild = {
   type: {
-    name: 'InputSearch' | 'ButtonGroup'
+    name: 'InputSearch' | 'ButtonGroup' | 'UNSAFE_InputCustom'
   }
 }
 
 const Toolbar: FC & Composites = ({ children }) => {
   const hasSearchBar = React.Children.toArray(children).some(
-    (child: ToolbarChild) => child.type.name === 'InputSearch'
+    (child: ToolbarChild) =>
+      child.type.name === 'InputSearch' || 'UNSAFE_InputCustom'
   )
   return (
     <Container justify={hasSearchBar ? 'between' : 'end'}>{children}</Container>
@@ -26,5 +29,6 @@ const Toolbar: FC & Composites = ({ children }) => {
 
 Toolbar.InputSearch = InputSearch
 Toolbar.ButtonGroup = ButtonGroup
+Toolbar.UNSAFE_InputCustom = UNSAFE_InputCustom
 
 export default Toolbar


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
To avoid blocking development, the table toolbar may receive a custom input.
It's important to notice that this feature will be deprecated when the `Autocomplete` is implemented.

#### How should this be manually tested?
`yarn start`?

#### Screenshots or example usage
No need

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
