### PR TITLE
Move appearance inline style to class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Move `appearance: none` inline style to class in `Input` component.
 
 ## [9.74.3] - 2019-08-29
 

--- a/react/components/Input/Input.css
+++ b/react/components/Input/Input.css
@@ -1,4 +1,4 @@
-/* Edge-specific */
+/* removes edge clear button on input */
 .hideDecorators::-ms-clear{
   display: none;
 }

--- a/react/components/Input/Input.css
+++ b/react/components/Input/Input.css
@@ -1,3 +1,4 @@
+/* Edge-specific */
 .hideDecorators::-ms-clear{
   display: none;
 }

--- a/react/components/Input/edge.css
+++ b/react/components/Input/edge.css
@@ -1,3 +1,7 @@
 .hideDecorators::-ms-clear{
   display: none;
 }
+
+.noAppearance {
+  appearance: none;
+}

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
-import { hideDecorators } from './edge.css'
+import styles from './edge.css'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
 
 class Input extends Component {
@@ -97,7 +97,7 @@ class Input extends Component {
     let prefixClasses = `${borderRadiusBase} br-0 br--left `
     let suffixClasses = `${borderRadiusBase} bl-0 br--right `
 
-    let classes = `${widthClass} ${box} ${hideDecorators} ${borderRadius} bn outline-0 `
+    let classes = `${widthClass} ${box} ${styles.hideDecorators} ${styles.noAppearance} ${borderRadius} bn outline-0 `
     let labelClasses = 'vtex-input__label db mb3 w-100 c-on-base '
     let prefixAndSuffixClasses =
       'vtex-input__prefix c-muted-2 fw5 flex items-center c-muted-2 t-body '
@@ -223,9 +223,6 @@ class Input extends Component {
             type={this.props.type}
             value={this.props.value}
             id={this.props.id}
-            style={{
-              WebkitAppearance: 'none',
-            }}
           />
           {suffix && (
             <span className={`${prefixAndSuffixClasses} ${suffixClasses}`}>

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
-import styles from './edge.css'
+import styles from './Input.css'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
 
 class Input extends Component {

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
-import { hideDecorators } from '../Input/edge.css'
+import styles from '../Input/Input.css'
 
 const normalizeMin = min => (min == null ? -Infinity : min)
 const normalizeMax = max => (max == null ? Infinity : max)
@@ -211,7 +211,7 @@ class NumericStepper extends Component {
         <div className="flex self-start">
           <input
             type="tel"
-            className={`z-1 order-1 tc bw1 ${borderClasses} br0 ${inputClasses} ${hideDecorators}`}
+            className={`z-1 order-1 tc bw1 ${borderClasses} br0 ${inputClasses} ${styles.hideDecorators}`}
             style={{
               ...(block && {
                 width: 0,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Move the `appearance: none` from an inline style to a CSS class in the `Input` component.

#### What problem is this solving?
In AMP pages, the prefix on the `appearance` property is prohibited, and renaming it to just `appearance` would probably make it not work in the browsers that only support the prefixed version, so moving it to a class and letting postcss add the prefix fixes the issue.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.