### PR TITLE
Fix/button wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `Button` label text leaving button when too big (`nowrap` class)
+- Potential bug when using more then one `Button` prop related to the label
+
+### Added
+
+- `Button` prop `noWrap`, which allows the button's label not to wrap
+
 ## [9.75.3] - 2019-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix release v9.76.0 and get changes from v9.75.3
+
 ## [9.76.0] - 2019-08-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.76.1] - 2019-09-02
+
 ### Fixed
 
 - Fix release v9.76.0 and get changes from v9.75.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.76.0] - 2019-08-30
+
 ### Fixed
 
 - Fix `Button` label text leaving button when too big (`nowrap` class)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.75.3",
+  "version": "9.76.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"
@@ -12,9 +12,7 @@
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "settingsSchema": {},
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.76.0",
+  "version": "9.76.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"
@@ -12,7 +12,9 @@
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
-  "registries": ["smartcheckout"],
+  "registries": [
+    "smartcheckout"
+  ],
   "settingsSchema": {},
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.75.3",
+  "version": "9.76.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.76.0",
+  "version": "9.76.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -41,6 +41,7 @@ class Button extends Component {
       referrerPolicy,
       download,
       noUpperCase,
+      noWrap,
     } = this.props
 
     const disabled = this.props.disabled || isLoading
@@ -52,7 +53,7 @@ class Button extends Component {
       variation === 'danger-tertiary'
 
     let classes = 'vtex-button bw1 ba fw5 v-mid relative pa0 '
-    let labelClasses = 'flex items-center justify-center h-100 pv2 nowrap '
+    let labelClasses = 'flex items-center justify-center h-100 pv2 '
     let loaderSize = 15
     let horizontalPadding = 0
 
@@ -90,6 +91,9 @@ class Button extends Component {
     }
     if (collapseRight && isTertiary) {
       labelClasses += 'nr1 ph1 hover-c-link'
+    }
+    if (noWrap) {
+      labelClasses += 'nowrap '
     }
 
     if (iconOnly) {
@@ -334,6 +338,8 @@ Button.propTypes = {
   download: PropTypes.string,
   /** When terciary, the upper case can be prevented */
   noUpperCase: PropTypes.bool,
+  /** Disables label wrapping */
+  noWrap: PropTypes.bool,
 }
 
 export default withForwardedRef(Button)

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -87,10 +87,10 @@ class Button extends Component {
     }
 
     if (collapseLeft && isTertiary) {
-      labelClasses += 'nl1 ph1 hover-c-link'
+      labelClasses += 'nl1 ph1 hover-c-link '
     }
     if (collapseRight && isTertiary) {
-      labelClasses += 'nr1 ph1 hover-c-link'
+      labelClasses += 'nr1 ph1 hover-c-link '
     }
     if (noWrap) {
       labelClasses += 'nowrap '


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix button label not wrapping and leaving the button

#### What problem is this solving?

The `nowrap` class was recently added to the button, but it sometimes breaks the UI, like the example image of iphone 5SE. It was changed to be a prop instead of hard coded.

#### How should this be manually tested?

You can see a button being used WITH the prop `noWrap` here:
https://rafaprtest--parceiro01.myvtex.com/_v/segment/admin-login/v1/login?returnUrl=%2Fadmin

You can see a button being used WITHOUT the prop `noWrap` here:
https://rafaprtest2--parceiro01.myvtex.com/_v/segment/admin-login/v1/login?returnUrl=%2Fadmin

#### Screenshots or example usage

Before the fix, Black & Decker in prod:
![image](https://user-images.githubusercontent.com/22064061/64044420-1e1a6280-cb3d-11e9-9d41-cce220e3c7d5.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
