### PR TITLE
Add import to deprecation Alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.78.6] - 2019-09-06
+
 ### Fixed
 
 - **MultiSelect** docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **MultiSelect** docs.
+
 ## [9.78.5] - 2019-09-06
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.78.5",
+  "version": "9.78.6",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.78.5",
+  "version": "9.78.6",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/MultiSelect/README.md
+++ b/react/components/MultiSelect/README.md
@@ -1,5 +1,6 @@
 ```jsx noeditor
-<Alert type="warning">
+const Alert = require('../Alert').default
+;<Alert type="warning">
   This component will be soon deprecated. Please prefer using the{' '}
   <a
     class="mh2 link fw7"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix errors in the **MultiSelect** documentation page.

#### What problem is this solving?
![image](https://user-images.githubusercontent.com/5971264/64130633-f116bb80-cd99-11e9-968d-5074267e44f9.png)

#### How should this be manually tested?
Go to the **MultiSelect** docs page and the errors will be gone.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5971264/64130662-28856800-cd9a-11e9-9b9d-987aba292ad0.png)
