### PR TITLE
Add ButtonColumns to EXPERIMENTAL_TABLE_V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.78.7] - 2019-09-06
+
 ### Added
 
 - `ButtonColumns` to `EXPERIMENTAL_TableV2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `ButtonColumns` to `EXPERIMENTAL_TableV2`
+
 ## [9.78.6] - 2019-09-06
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.78.6",
+  "version": "9.78.7",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.78.6",
+  "version": "9.78.7",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -27,13 +27,26 @@ Example with simple structure:
 - It receives only strings.
 - If you want to customize it with a component, you can use the `headerRender` prop.
 
+##### headerRender
+
+- Customize the render method of a single header column cell.
+- It receives a function that returns a node (react component).
+- The function has the following params: ({ headerData })
+- Default is render the value as a string.
+- If you have a custom cell component that has a click interaction and at the same time you use the onRowClick Table prop, you might stumble uppon the problem of both click actions being fired. We can work around that by doing a wrapper around cellRenderer to stop click event propagation.
+
 ##### cellRender
 
 - Customize the render method of a single column cell.
 - It receives a function that returns a node (react component).
 - The function has the following params: ({ cellData, rowData })
 - Default is render the value as a string.
-- If you have a custom cell component that has a click interaction and at the same time you use the onRowClick Table prop, you might stumble uppon the problem of both click actions being fired. We can work around that by doing a wrapper around cellRenderer to stop click event propagation, like so:
+- If you have a custom cell component that has a click interaction and at the same time you use the onRowClick Table prop, you might stumble uppon the problem of both click actions being fired. We can work around that by doing a wrapper around cellRenderer to stop click event propagation.
+
+##### hidden
+
+- Defines if a columns is initially hidden or not.
+- ⚠️ You should use the `Columns` button of the toolbar to enable toggle columns visibility.
 
 #### State Hook
 

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -529,6 +529,12 @@ function ToolbarExample() {
     },
   }
 
+  const buttonColumns = {
+    label: 'Toggle visible fields',
+    showAllLabel: 'Show All',
+    hideAllLabel: 'Hide All',
+  }
+
   const density = {
     label: 'Line density',
     lowOptionLabel: 'Low',
@@ -583,6 +589,7 @@ function ToolbarExample() {
       <Table.Toolbar>
         <Table.Toolbar.InputSearch {...inputSearch} />
         <Table.Toolbar.ButtonGroup>
+          <Table.Toolbar.ButtonGroup.Columns {...buttonColumns} />
           <Table.Toolbar.ButtonGroup.Density {...density} />
           <Table.Toolbar.ButtonGroup.Download {...download} />
           <Table.Toolbar.ButtonGroup.Upload {...upload} />

--- a/react/components/EXPERIMENTAL_Table/SimpleTable/Header.tsx
+++ b/react/components/EXPERIMENTAL_Table/SimpleTable/Header.tsx
@@ -5,7 +5,7 @@ import { TABLE_HEADER_HEIGHT, NAMESPACES } from '../constants'
 import useTableContext from '../hooks/useTableContext'
 
 const Header: FC = () => {
-  const { columns } = useTableContext()
+  const { visibleColumns } = useTableContext()
 
   const renderHeader = (headerData: Column, headerIndex: number) => {
     const { headerRender, title, width } = headerData
@@ -26,7 +26,7 @@ const Header: FC = () => {
       style={{
         height: TABLE_HEADER_HEIGHT,
       }}>
-      {columns.map(renderHeader)}
+      {visibleColumns.map(renderHeader)}
     </div>
   )
 }

--- a/react/components/EXPERIMENTAL_Table/SimpleTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/SimpleTable/Row.tsx
@@ -24,7 +24,7 @@ const RowContainer: FC<{ id: string }> = ({ id, children }) => {
  * 🤓Be aware that the subRows are rendered recursivelly
  */
 const Row: FC<RowProps> = ({ data, index, depth }) => {
-  const { columns, nestedRows } = useTableContext()
+  const { visibleColumns, nestedRows } = useTableContext()
   const [collapsed, setCollapsed] = useState(false)
 
   const { children, ...rowData } = data
@@ -56,7 +56,7 @@ const Row: FC<RowProps> = ({ data, index, depth }) => {
   const renderCells = (arrow?: boolean) => {
     return (
       <RowContainer id={`${NAMESPACES.ROW}-${index}-${depth}`} key={rowKey}>
-        {columns.map((column: Column, cellIndex: number) => {
+        {visibleColumns.map((column: Column, cellIndex: number) => {
           const { cellRender, width } = column
           const cellData = rowData[column.id]
           const content = cellRender

--- a/react/components/EXPERIMENTAL_Table/Toolbar/ButtonColumns.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/ButtonColumns.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo, FC } from 'react'
+
+import Toggle from '../../../Toggle'
+import IconColumns from '../../icon/Columns/index'
+import Menu from './Menu/index'
+
+import { ICON_SIZE, COLUMNS_BOX, NAMESPACES } from '../constants'
+import useTableContext from '../hooks/useTableContext'
+
+export type ButtonColumnsProps = {
+  label: string
+  showAllLabel: string
+  hideAllLabel: string
+  alignMenu: Alignment
+  disabled: boolean
+}
+
+const ButtonColumns: FC<ButtonColumnsProps> = ({
+  label,
+  showAllLabel,
+  hideAllLabel,
+  alignMenu,
+  disabled,
+}) => {
+  const {
+    hiddenColumns,
+    columns,
+    hideAllColumns,
+    showAllColumns,
+    toggleColumn,
+  } = useTableContext()
+
+  const calculateFieldsBoxHeight = () => {
+    const estimate = Object.keys(columns).length * COLUMNS_BOX.ITEM_HEIGHT
+    return estimate > COLUMNS_BOX.MAX_HEIGHT ? COLUMNS_BOX.MAX_HEIGHT : estimate
+  }
+
+  const height = useMemo(() => calculateFieldsBoxHeight(), [
+    Object.keys(columns).length,
+  ])
+
+  return (
+    <Menu
+      button={{
+        id: NAMESPACES.TOOLBAR.BUTTON_COLUMNS,
+        title: label,
+        icon: <IconColumns size={ICON_SIZE.MEDIUM} />,
+        disabled: disabled,
+      }}
+      box={{
+        height,
+        alignMenu,
+        width: COLUMNS_BOX.WIDTH,
+        groupActions: [
+          { id: 1, label: showAllLabel, onClick: showAllColumns },
+          { id: 2, label: hideAllLabel, onClick: hideAllColumns },
+        ],
+      }}>
+      {columns.map((column, index) => {
+        const { id, title } = column
+        const togglerFn = () => toggleColumn(id)
+        const isVisible = !hiddenColumns.includes(id)
+        return (
+          <Menu.Item key={index} handleCallback={togglerFn}>
+            {title}
+            <Toggle checked={isVisible} onChange={togglerFn} />
+          </Menu.Item>
+        )
+      })}
+    </Menu>
+  )
+}
+
+export default ButtonColumns

--- a/react/components/EXPERIMENTAL_Table/Toolbar/ButtonColumns.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/ButtonColumns.tsx
@@ -30,14 +30,10 @@ const ButtonColumns: FC<ButtonColumnsProps> = ({
     toggleColumn,
   } = useTableContext()
 
-  const calculateFieldsBoxHeight = () => {
-    const estimate = Object.keys(columns).length * COLUMNS_BOX.ITEM_HEIGHT
-    return estimate > COLUMNS_BOX.MAX_HEIGHT ? COLUMNS_BOX.MAX_HEIGHT : estimate
-  }
-
-  const height = useMemo(() => calculateFieldsBoxHeight(), [
-    Object.keys(columns).length,
-  ])
+  const height = Math.min(
+    columns.length * COLUMNS_BOX.ITEM_HEIGHT,
+    COLUMNS_BOX.MAX_HEIGHT
+  )
 
   return (
     <Menu

--- a/react/components/EXPERIMENTAL_Table/Toolbar/ButtonGroup.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/ButtonGroup.tsx
@@ -4,6 +4,7 @@ import IconDownload from '../../icon/Download/index.js'
 import IconUpload from '../../icon/Upload/index.js'
 
 import Button, { ButtonProps } from './Button'
+import ButtonColumns, { ButtonColumnsProps } from './ButtonColumns'
 import ButtonDensity, { ButtonDensityProps } from './ButtonDensity'
 import ButtonExtraActions, {
   ButtonExtraActionsProps,
@@ -12,9 +13,16 @@ import ButtonNewLine, { ButtonNewLineProps } from './ButtonNewLine'
 
 import { ICON_SIZE, NAMESPACES } from '../constants'
 
-type ButtonType = 'density' | 'download' | 'upload' | 'extraActions' | 'newLine'
+type ButtonType =
+  | 'columns'
+  | 'density'
+  | 'download'
+  | 'upload'
+  | 'extraActions'
+  | 'newLine'
 
 interface Composites {
+  Columns: FC<ButtonColumnsProps>
   Density: FC<ButtonDensityProps>
   Download: FC<ButtonProps>
   Upload: FC<ButtonProps>
@@ -24,12 +32,20 @@ interface Composites {
 
 type Props =
   | ButtonProps
+  | ButtonColumnsProps
   | ButtonDensityProps
   | ButtonExtraActionsProps
   | ButtonNewLineProps
 
 const getButton = (type: ButtonType, props: Props) => {
   switch (type) {
+    case 'columns': {
+      return (
+        <span className="order-0">
+          <ButtonColumns {...(props as ButtonColumnsProps)} />
+        </span>
+      )
+    }
     case 'density': {
       return (
         <span className="order-1">
@@ -91,6 +107,7 @@ const ButtonGroup: FC & Composites = ({ children }) => (
   </div>
 )
 
+ButtonGroup.Columns = getComponent('columns')
 ButtonGroup.Density = getComponent('density')
 ButtonGroup.Download = getComponent('download')
 ButtonGroup.Upload = getComponent('upload')

--- a/react/components/EXPERIMENTAL_Table/Toolbar/Menu/Box.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/Menu/Box.tsx
@@ -1,4 +1,7 @@
 import React, { FC } from 'react'
+
+import Button from '../../../Button/index.js'
+
 import { BOX_ALIGNMENT } from '../../constants'
 
 export type BoxProps = {
@@ -7,6 +10,7 @@ export type BoxProps = {
   alignMenu?: Alignment
   noMargin?: boolean
   borderClasses?: string
+  groupActions?: Array<MenuAction>
 }
 
 const Box: FC<BoxProps> = ({
@@ -15,6 +19,7 @@ const Box: FC<BoxProps> = ({
   width,
   noMargin,
   borderClasses,
+  groupActions,
   children,
 }) => {
   const isAlignRight = alignMenu === BOX_ALIGNMENT.RIGHT
@@ -27,6 +32,20 @@ const Box: FC<BoxProps> = ({
         width: width,
       }}>
       <div className="w-100 b2 br2 bg-base">
+        {groupActions && (
+          <div className="flex inline-flex bb b--muted-4 w-100 justify-center pv4">
+            {groupActions.map(action => (
+              <div className="mh2" key={action.id}>
+                <Button
+                  variation="secondary"
+                  size="small"
+                  onClick={action.onClick}>
+                  {action.label}
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
         <div className="overflow-auto" style={{ height: height }}>
           {children}
         </div>

--- a/react/components/EXPERIMENTAL_Table/Toolbar/Menu/Item.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/Menu/Item.tsx
@@ -3,9 +3,9 @@ import React, { FC } from 'react'
 import { useMenuContext } from './context'
 
 export type ItemProps = {
-  isSelected: boolean
   handleCallback: Function
-  closeMenuOnClick: boolean
+  isSelected?: boolean
+  closeMenuOnClick?: boolean
 }
 
 const Item: FC<ItemProps> = ({

--- a/react/components/EXPERIMENTAL_Table/constants.ts
+++ b/react/components/EXPERIMENTAL_Table/constants.ts
@@ -9,6 +9,7 @@ export const NAMESPACES = {
     CONTAINER: `${NAMESPACE_PREFIX}__toolbar__container`,
     INPUT_SEARCH: `${NAMESPACE_PREFIX}__toolbar__input-search`,
     BUTTON_GROUP: `${NAMESPACE_PREFIX}__toolbar__button-group`,
+    BUTTON_COLUMNS: `${NAMESPACE_PREFIX}__toolbar__button-columns`,
     BUTTON_DENSITY: `${NAMESPACE_PREFIX}__toolbar__button-density`,
     BUTTON_DOWNLOAD: `${NAMESPACE_PREFIX}__toolbar__button-donwload`,
     BUTTON_UPLOAD: `${NAMESPACE_PREFIX}__toolbar__button-upload`,
@@ -29,10 +30,16 @@ export const DENSITY_OPTIONS = [
   TABLE_DENSITIES.HIGH,
 ]
 
+export const COLUMNS_BOX = {
+  MAX_HEIGHT: 192,
+  WIDTH: 292,
+  ITEM_HEIGHT: 36,
+}
+
+export const FIELDS_BOX_ITEM_HEIGHT = 36
 export const TABLE_HEADER_HEIGHT = 36
 export const EMPTY_STATE_SIZE_IN_ROWS = 5
 export const DEFAULT_SCROLLBAR_WIDTH = 17
-export const FIELDS_BOX_ITEM_HEIGHT = 36
 export const NESTED_ROW_PREFIX_WIDTH = 36
 
 export const ICON_SIZE = {

--- a/react/components/EXPERIMENTAL_Table/hooks/useHiddenColumns.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useHiddenColumns.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 
 const getHiddenColumns = (columns: Array<Column>): Array<string> => {
   return columns.filter(col => col.hidden).map(col => col.id)
@@ -8,17 +8,20 @@ const useHiddenColumns = (columns: Array<Column>) => {
   const [hiddenColumns, setHiddenColumns] = useState(getHiddenColumns(columns))
 
   const visibleColumns = useMemo(() => {
-    const reducer = (acc: Array<string>, col: Column) =>
+    const reducer = (acc: Array<Column>, col: Column) =>
       hiddenColumns.includes(col.id) ? acc : [...acc, col]
 
     return columns.reduce(reducer, [])
   }, [hiddenColumns, columns])
 
-  const toggleColumn = (id: string) => {
-    hiddenColumns.includes(id)
-      ? setHiddenColumns(hiddenColumns.filter(col => col !== id))
-      : setHiddenColumns([...hiddenColumns, id])
-  }
+  const toggleColumn = useCallback(
+    (id: string) => {
+      hiddenColumns.includes(id)
+        ? setHiddenColumns(hiddenColumns.filter(col => col !== id))
+        : setHiddenColumns([...hiddenColumns, id])
+    },
+    [hiddenColumns]
+  )
 
   const showAllColumns = () => {
     setHiddenColumns([])

--- a/react/components/EXPERIMENTAL_Table/hooks/useHiddenColumns.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useHiddenColumns.ts
@@ -1,0 +1,41 @@
+import { useState, useMemo } from 'react'
+
+const getHiddenColumns = (columns: Array<Column>): Array<string> => {
+  return columns.filter(col => col.hidden).map(col => col.id)
+}
+
+const useHiddenColumns = (columns: Array<Column>) => {
+  const [hiddenColumns, setHiddenColumns] = useState(getHiddenColumns(columns))
+
+  const visibleColumns = useMemo(() => {
+    const reducer = (acc: Array<string>, col: Column) =>
+      hiddenColumns.includes(col.id) ? acc : [...acc, col]
+
+    return columns.reduce(reducer, [])
+  }, [hiddenColumns, columns])
+
+  const toggleColumn = (id: string) => {
+    hiddenColumns.includes(id)
+      ? setHiddenColumns(hiddenColumns.filter(col => col !== id))
+      : setHiddenColumns([...hiddenColumns, id])
+  }
+
+  const showAllColumns = () => {
+    setHiddenColumns([])
+  }
+
+  const hideAllColumns = () => {
+    setHiddenColumns(columns.map(col => col.id))
+  }
+
+  return {
+    hiddenColumns,
+    setHiddenColumns,
+    visibleColumns,
+    toggleColumn,
+    showAllColumns,
+    hideAllColumns,
+  }
+}
+
+export default useHiddenColumns

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableState.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableState.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 
 import { calculateTableHeight } from '../util'
 import useDensity from './useDensity'
+import useHiddenColumns from './useHiddenColumns'
 
 interface Input {
   columns: Array<Column>
@@ -11,10 +12,17 @@ interface Input {
 
 const useTableState = ({ columns, items, density }: Input): TableState => {
   const { selectedDensity, setSelectedDensity, rowHeight } = useDensity(density)
+  const {
+    hiddenColumns,
+    visibleColumns,
+    toggleColumn,
+    showAllColumns,
+    hideAllColumns,
+  } = useHiddenColumns(columns)
 
   const isEmpty = useMemo(
-    () => items.length === 0 || Object.keys(columns).length === 0,
-    [columns, items]
+    () => items.length === 0 || Object.keys(visibleColumns).length === 0,
+    [visibleColumns, items]
   )
 
   const tableHeight = useMemo(
@@ -24,12 +32,17 @@ const useTableState = ({ columns, items, density }: Input): TableState => {
 
   return {
     columns,
+    visibleColumns,
+    hiddenColumns,
     items,
     isEmpty,
     tableHeight,
     rowHeight,
     selectedDensity,
     setSelectedDensity,
+    toggleColumn,
+    showAllColumns,
+    hideAllColumns,
   }
 }
 

--- a/react/components/EXPERIMENTAL_Table/typings.d.ts
+++ b/react/components/EXPERIMENTAL_Table/typings.d.ts
@@ -1,10 +1,11 @@
 interface MenuAction {
   label: string
   onClick: Function
-  toggle: {
+  toggle?: {
     checked: boolean
     semantic: boolean
   }
+  id?: number | string
 }
 interface Column {
   id: string
@@ -12,6 +13,7 @@ interface Column {
   width?: number
   cellRender?: ({ cellData: any, rowData: any }) => React.ReactNode
   headerRender?: ({ headerData: any }) => React.ReactNode
+  hidden?: boolean
 }
 
 interface TableProps {
@@ -20,13 +22,18 @@ interface TableProps {
 }
 
 interface TableState {
+  visibleColumns?: Array<Column>
   columns?: Array<Column>
   items?: Array<Object>
   isEmpty?: boolean
   tableHeight?: number
   rowHeight?: number
   selectedDensity?: string
+  hiddenColumns?: Array<string>
   setSelectedDensity?: (density: Density) => void
+  toggleColumn?: (id: string) => void
+  showAllColumns?: () => void
+  hideAllColumns?: () => void
 }
 
 type Density = 'low' | 'medium' | 'high'


### PR DESCRIPTION
#### What is the purpose of this pull request?
➕ `ButtonColumns` to `EXPERIMENTAL_TableV2`

#### What problem is this solving?
The `Table v2` toolbar may toggle columns visibility.

#### How should this be manually tested?
`yarn start`?

#### Screenshots or example usage
![Screen Shot 2019-09-02 at 15 58 53 (2)](https://user-images.githubusercontent.com/6964311/64130743-aa759100-cd9a-11e9-956c-dfc7847f6932.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
