### PR TITLE
Fix tsconfig module resolution to be node and not classic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.77.1] - 2019-09-03
+
 ### Fixed
 
 - `tsconfig.json` module resolution to be `node`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `tsconfig.json` module resolution to be `node`.
+
 ## [9.77.0] - 2019-09-03
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.77.0",
+  "version": "9.77.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.77.0",
+  "version": "9.77.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -9,7 +9,8 @@
     "strict": false,
     "typeRoots": ["node_modules/@types"],
     "target": "esnext",
-    "declaration": true
+    "declaration": true,
+    "moduleResolution": "node"
   },
   "typeAcquisition": {
     "enable": false


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix tsconfig's module resolution, as we want it to catch the `index.tsx` files too.

#### What problem is this solving?

Was not able to find the `./components/Tooltip` module but there was a `./components/Tooltip/index.tsx` file.

#### How should this be manually tested?

Clone this branch and run `yarn && yarn type-check`

#### Screenshots or example usage

##### Classic

![image](https://user-images.githubusercontent.com/15948386/64181655-45bf4280-ce3d-11e9-9869-97dd6bfdafa2.png)

##### Node

![image](https://user-images.githubusercontent.com/15948386/64181714-66879800-ce3d-11e9-8359-e24c64959006.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
