### PR TITLE
Adding isDangerous style of line actions to bulk actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- isDangerous style to bulk actions.
+- **Table** allow `isDangerous` style to bulk actions.
 
 ## [9.77.1] - 2019-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- isDangerous style to bulk actions.
+
 ## [9.77.1] - 2019-09-03
 
 ### Fixed

--- a/react/components/Table/BulkActions.js
+++ b/react/components/Table/BulkActions.js
@@ -66,6 +66,7 @@ class BulkActions extends PureComponent {
                 buttonProps={{ variation: 'secondary', size: 'small' }}
                 options={bulkActions.others.map(el => ({
                   label: el.label,
+                  isDangerous: el.isDangerous,
                   onClick: () =>
                     el.handleCallback(bulkActionsReturnedParameters),
                 }))}

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -1369,6 +1369,11 @@ const defaultSchema = {
           label: 'Action 2',
           handleCallback: params => console.log(params),
         },
+        {
+          label: 'Dangerous action',
+          isDangerous: true,
+          handleCallback: params => console.log(params),
+        },
       ],
     }}
   />
@@ -1850,6 +1855,11 @@ class ResourceListExample extends React.Component {
             },
             {
               label: 'Action 2',
+              handleCallback: params => console.log(params),
+            },
+            {
+              label: 'Dangerous action',
+              isDangerous: true,
               handleCallback: params => console.log(params),
             },
           ],


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adding the isDangerous style of the line actions to the bulk actions.

#### What problem is this solving?
Sometimes the bulk actions options are the same as the line actions'. So it makes sense for bulk actions to have isDangerous style as well. An example of use case is the "Reject SKU" option.

#### How should this be manually tested?
Go to https://enzo--partnerchallenge29.myvtex.com/admin/suggestion/pending, select 2 or more SKUs, then go in "More" to see the isDangerous style.

#### Screenshots or example usage

isDangerous style (red) on line actions:
![Screen Shot 2019-09-03 at 15 33 59](https://user-images.githubusercontent.com/7076941/64203191-51286300-ce69-11e9-8144-aeb3c9950349.png)

Current state:
![Screen Shot 2019-09-03 at 15 31 32](https://user-images.githubusercontent.com/7076941/64203217-584f7100-ce69-11e9-9a84-0fbae76d66ff.png)

Proposed state:
![Screen Shot 2019-09-03 at 16 39 51](https://user-images.githubusercontent.com/7076941/64203302-7d43e400-ce69-11e9-9c1d-e60e74b9abf7.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
