### PR TITLE
Fix button label escaping button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Table** allow `isDangerous` style to bulk actions.
 
+## [9.77.3] - 2019-09-04
+
 ### Fixed
 
 - Fix `Button` label escaping loading button when the prop `block` exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Table** allow `isDangerous` style to bulk actions.
 
+### Fixed
+
+- Fix `Button` label escaping loading button when the prop `block` exists
+
 ## [9.77.2] - 2019-09-03
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.77.2",
+  "version": "9.77.3",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.77.2",
+  "version": "9.77.3",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -175,7 +175,7 @@ class Button extends Component {
 
     if (block) {
       classes += 'w-100 '
-      labelClasses += 'w-100 '
+      labelClasses += 'w-100 border-box '
     }
 
     if (href) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix a bug that breaks a loading button highlight

#### What problem is this solving?

When a button used the prop `block`, its loading state displayed a bad highlight when clicked.

![image](https://user-images.githubusercontent.com/22064061/64204761-d19c9300-ce6c-11e9-93cb-8742c715d540.png)

#### How should this be manually tested?

Click the loading button at:
https://rafaprtest--parceiro01.myvtex.com/_v/segment/admin-login/v1/login?returnUrl=%2Fadmin

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/22064061/64204916-217b5a00-ce6d-11e9-900c-32b69e869e75.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
