### PR TITLE
Added loading to EXPERIMENTAL_TableV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `Loading` to `EXPERIMENTAL_TableV2`
+
 ## [9.78.1] - 2019-09-05
 
  - Redeploy to generate lib folder in npm package that broke on last deploy
@@ -33,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [9.77.4] - 2019-09-04
 
 ### Changed
+
 - Move `appearance: none` inline style to class in `Input` component.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.78.2] - 2019-09-05
+
 ### Added
 
 - `Loading` to `EXPERIMENTAL_TableV2`

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.78.1",
+  "version": "9.78.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.78.1",
+  "version": "9.78.2",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -128,6 +128,64 @@ function StateHookExample() {
 | selectedDensity    | Density         | Current selected density            |
 | setSelectedDensity | Function        | selectedDensity setter              |
 
+# Loading
+
+```js
+// Imports
+const useTableState = require('./hooks/useTableState.ts').default
+const Toggle = require('../Toggle/index.js').default
+
+const columns = [
+  {
+    id: 'name',
+    title: 'Name',
+  },
+  {
+    id: 'country',
+    title: 'Country',
+  },
+]
+
+const items = [
+  {
+    name: 'En Sabah Nuh',
+    country: '🇨🇺Cuba',
+  },
+  {
+    name: 'Abdul Qamar',
+    country: '🇸🇦Saudi Arabia',
+  },
+  {
+    name: 'Goose the Cat',
+    country: '🇺🇸USA',
+  },
+  {
+    name: 'Brian Braddock',
+    country: '🇬🇧Great Britain',
+  },
+]
+
+function LoadingExample() {
+  const [loading, setLoading] = React.useState(false)
+  const tableState = useTableState({
+    columns,
+    items,
+  })
+
+  return (
+    <div>
+      <Toggle
+        label="Toggle table loading"
+        checked={loading}
+        onChange={() => setLoading(!loading)}
+      />
+      <Table state={tableState} loading={loading} />
+    </div>
+  )
+}
+;<LoadingExample />
+```
+
 # Pagination
 
 ```js

--- a/react/components/EXPERIMENTAL_Table/SimpleTable/Loading.tsx
+++ b/react/components/EXPERIMENTAL_Table/SimpleTable/Loading.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import Spinner from '../../Spinner/index.js'
+import useTableContext from '../hooks/useTableContext'
+import { TABLE_HEADER_HEIGHT } from '../constants'
+
+const Loading = () => {
+  const { tableHeight } = useTableContext()
+  return (
+    <div
+      className="dtc v-mid tc"
+      style={{ height: tableHeight - TABLE_HEADER_HEIGHT }}>
+      <Spinner />
+    </div>
+  )
+}
+
+export default Loading

--- a/react/components/EXPERIMENTAL_Table/SimpleTable/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/SimpleTable/index.tsx
@@ -9,18 +9,16 @@ import Loading from './Loading'
 const SimpleTable: FC = () => {
   const { loading } = useTableContext()
   return (
-    <div id={NAMESPACES.TABLE} className="order-1 mw-100">
-      <div className="overflow-x-auto">
-        <div className="dt w-100" style={{ borderSpacing: 0 }}>
-          {loading ? (
-            <Loading />
-          ) : (
-            <>
-              <Header />
-              <Rows />
-            </>
-          )}
-        </div>
+    <div id={NAMESPACES.TABLE} className="order-1 mw-100 overflow-x-auto">
+      <div className="dt w-100" style={{ borderSpacing: 0 }}>
+        {loading ? (
+          <Loading />
+        ) : (
+          <>
+            <Header />
+            <Rows />
+          </>
+        )}
       </div>
     </div>
   )

--- a/react/components/EXPERIMENTAL_Table/SimpleTable/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/SimpleTable/index.tsx
@@ -3,14 +3,23 @@ import React, { FC, memo } from 'react'
 import Header from './Header'
 import Rows from './Rows'
 import { NAMESPACES } from '../constants'
+import useTableContext from '../hooks/useTableContext'
+import Loading from './Loading'
 
 const SimpleTable: FC = () => {
+  const { loading } = useTableContext()
   return (
     <div id={NAMESPACES.TABLE} className="order-1 mw-100">
       <div className="overflow-x-auto">
         <div className="dt w-100" style={{ borderSpacing: 0 }}>
-          <Header />
-          <Rows />
+          {loading ? (
+            <Loading />
+          ) : (
+            <>
+              <Header />
+              <Rows />
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/react/components/EXPERIMENTAL_Table/errors.ts
+++ b/react/components/EXPERIMENTAL_Table/errors.ts
@@ -1,0 +1,7 @@
+export const STATE_NOT_FOUND_ERROR = Error(
+  "😰 Ops! State is required\n 💡The useTableState hook can help you to control the EXPERIMENTAL_TableV2 states easily. Check the VTEX styleguide's docs for more info."
+)
+
+export const OUT_OF_SCOPE_COMPOSITES_ERROR = Error(
+  '⚠️ Table composites cannot be used outside of it'
+)

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableContext.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableContext.ts
@@ -1,11 +1,12 @@
 import { useContext } from 'react'
 
 import Context from '../context'
+import { OUT_OF_SCOPE_COMPOSITES_ERROR } from '../errors'
 
 const useTableContext = () => {
   const context = useContext(Context)
   if (!context) {
-    throw new Error('Ooops! Table composites cannot be used outside of it')
+    throw OUT_OF_SCOPE_COMPOSITES_ERROR
   }
   return context
 }

--- a/react/components/EXPERIMENTAL_Table/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/index.tsx
@@ -7,9 +7,12 @@ import { TableProvider } from './context'
 import Toolbar from './Toolbar/index'
 import { DENSITY_OPTIONS, NAMESPACES } from './constants'
 import Pagination, { PaginationProps } from './Pagination'
+import { STATE_NOT_FOUND_ERROR } from './errors'
 
 const propTypes = {
   nestedRows: PropTypes.bool,
+  loading: PropTypes.bool,
+  itemsSizeEstimate: PropTypes.number,
   state: PropTypes.shape({
     schema: PropTypes.shape({
       columns: PropTypes.objectOf(
@@ -37,6 +40,9 @@ interface Composites {
 }
 
 const Table: FC<Props> & Composites = ({ children, state, ...props }) => {
+  if (!state) {
+    throw STATE_NOT_FOUND_ERROR
+  }
   return (
     <TableProvider value={{ ...state, ...props }}>
       <div id={NAMESPACES.CONTAINER} className="flex flex-column">

--- a/react/components/EXPERIMENTAL_Table/typings.d.ts
+++ b/react/components/EXPERIMENTAL_Table/typings.d.ts
@@ -16,6 +16,7 @@ interface Column {
 
 interface TableProps {
   nestedRows?: boolean
+  loading?: boolean
 }
 
 interface TableState {


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
The `EXPERIMENTAL_TableV2` is now able to show a loading spinner.

#### How should this be manually tested?
`yarn start`

#### Screenshots or example usage
<img width="977" alt="Screen Shot 2019-09-05 at 15 10 40" src="https://user-images.githubusercontent.com/6964311/64367891-7515b100-cfef-11e9-8516-1b321949e05b.png">


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
