### PR TITLE
Add option to not show select all button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.78.4] - 2019-09-06
+
 ## [9.78.3] - 2019-09-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+-**Table** bulk actions doesn't show "Select all" button if the "selectAll" and "AllRowsSelected" parameters are not passed.
+
 ## [Unreleased]
 
 ## [9.78.3] - 2019-09-05

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.78.3",
+  "version": "9.78.4",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.78.3",
+  "version": "9.78.4",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/BulkActions.js
+++ b/react/components/Table/BulkActions.js
@@ -84,24 +84,24 @@ class BulkActions extends PureComponent {
               )}
             </span>
           )}
-          <span className="mr2">
-            {allLinesSelected ? (
-              bulkActions &&
-              bulkActions.texts &&
-              bulkActions.texts.allRowsSelected(
-                <span className="b">{bulkActions.totalItems}</span>
-              )
-            ) : (
-              <Button onClick={() => onSelectAllLines()}>
-                <span className="ttu">
-                  {bulkActions &&
-                    `${bulkActions.texts && bulkActions.texts.selectAll} ${
-                      bulkActions.totalItems
-                    }`}
-                </span>
-              </Button>
+          {bulkActions &&
+            bulkActions.texts &&
+            bulkActions.texts.selectAll &&
+            bulkActions.texts.allRowsSelected && (
+              <span className="mr2">
+                {allLinesSelected ? (
+                  bulkActions.texts.allRowsSelected(
+                    <span className="b">{bulkActions.totalItems}</span>
+                  )
+                ) : (
+                  <Button onClick={() => onSelectAllLines()}>
+                    <span className="ttu">
+                      {`${bulkActions.texts.selectAll} ${bulkActions.totalItems}`}
+                    </span>
+                  </Button>
+                )}
+              </span>
             )}
-          </span>
           <ButtonWithIcon icon={close} onClick={() => onDeselectAllLines()} />
         </div>
       </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add the option to now show select all button on table's bulk actions.

#### What problem is this solving?

Our API doesn't suport actions on all elements, so showing a "select all" button to the client is confusing. Also today then the bulk actions component doesn't receive some props it renders "undefined" on the action bar.

#### How should this be manually tested?
This link shows the table with no select all button
https://anita--basedevmkp.myvtex.com/admin/received-skus/pending

This link shows the button still working, also linked in this branch
https://anita2--basedevmkp.myvtex.com/admin/received-skus/pending

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8623116/64375696-ced0a800-cffc-11e9-9eae-fb10344a805f.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
