### PR TITLE
Hotfix/page header height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PageHeader** `subtitle` was rendering even if there is no prop to render it.
+
 ## [9.78.4] - 2019-09-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.78.5] - 2019-09-06
+
 ### Fixed
 
 - **PageHeader** `subtitle` was rendering even if there is no prop to render it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-### Changed
-
--**Table** bulk actions doesn't show "Select all" button if the "selectAll" and "AllRowsSelected" parameters are not passed.
-
 ## [Unreleased]
 
 ## [9.78.4] - 2019-09-06
+
+### Changed
+
+- **Table** bulk actions doesn't show "Select all" button if the "selectAll" and "AllRowsSelected" parameters are not passed.
 
 ## [9.78.3] - 2019-09-05
 
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [9.78.1] - 2019-09-05
 
- - Redeploy to generate lib folder in npm package that broke on last deploy
+- Redeploy to generate lib folder in npm package that broke on last deploy
 
 ## [9.78.0] - 2019-09-05
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.78.4",
+  "version": "9.78.5",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.78.4",
+  "version": "9.78.5",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/PageHeader/index.js
+++ b/react/components/PageHeader/index.js
@@ -48,9 +48,11 @@ class PageHeader extends PureComponent {
             </div>
           )}
           <div className="w-100" style={{ height: 0 }} />
-          <div className="vtex-pageHeader__subtitle t-body lh-copy c-muted-1 mv5 order-1 order-0-ns">
-            {subtitle}
-          </div>
+          {subtitle && (
+            <div className="vtex-pageHeader__subtitle t-body lh-copy c-muted-1 mv5 order-1 order-0-ns">
+              {subtitle}
+            </div>
+          )}
         </div>
       </div>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?

 - fixes https://github.com/vtex/styleguide/issues/768

#### What problem is this solving?

 - PageHeader subtitle prop was rendering a subtitle (using up the space) even if there is no subtitle to render

#### How should this be manually tested?

#### Screenshots or example usage
 - before fix:
<img width="808" alt="Screen Shot 2019-08-22 at 12 09 32 PM" src="https://user-images.githubusercontent.com/8530905/64440620-ae5b2900-d0a2-11e9-97ba-cb50b62e39e2.png">

 - after fix
<img width="512" alt="Screen Shot 2019-08-22 at 12 10 07 PM" src="https://user-images.githubusercontent.com/8530905/64440656-ba46eb00-d0a2-11e9-8fe7-0b86e62076b0.png">


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
