### PR TITLE
Fix Tooltip offset size, default font size and shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.78.10] - 2019-09-10
+
 ### Fixed
 
 - **Tooltip** offset size, default font size and shadow css class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tooltip** offset size, default font size and shadow css class.
+
 ## [9.78.9] - 2019-09-09
 
 ## [9.78.8] - 2019-09-09

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.78.9",
+  "version": "9.78.10",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.78.9",
+  "version": "9.78.10",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -10,7 +10,7 @@ import style from './tooltip.css'
 export type Position = 'top' | 'right' | 'bottom' | 'left'
 export type Size = 'mini' | 'small'
 
-const OFFSET = 16
+const OFFSET = 8
 const hasComputedDimensions = rect => rect && rect.width && rect.height
 
 const propTypes = {
@@ -68,7 +68,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   }, [visible])
 
   const popupClasses = classNames(
-    'absolute pv3 ph4 bg-base--inverted c-on-base--inverted br2 shadow-1 mw5 overflow-hidden',
+    'absolute pv3 ph4 bg-base--inverted c-on-base--inverted br2 shadow-4 mw5 overflow-hidden',
     style.popup,
     {
       dn: (!visible && !showPopup) || !childRect || !popupRect,

--- a/react/components/Tooltip/index.tsx
+++ b/react/components/Tooltip/index.tsx
@@ -44,7 +44,7 @@ type Props = PropTypes.InferProps<typeof propTypes>
 const defaultProps: Props = {
   trigger: 'hover',
   position: 'top',
-  size: 'mini',
+  size: 'small',
   delay: 0,
   duration: 200,
   timmingFn: 'ease-in-out',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the required tooltip measures. Now:

1. The default font size is `small`;
2. The offset (distance between the element and the tooltip) is now 8px instead of 16px;
3. Shadow is `shadow-4` instead of `shadow-1`.

#### What problem is this solving?

Wrong measures.

#### How should this be manually tested?

Clone the repository, checkout to this branch and run `yarn && yarn styleguide`

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/64535963-9f68b680-d2ee-11e9-9aa7-e46647aa5e47.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
