### PR TITLE
Do not show column for showing/hiding when there is to text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.78.9] - 2019-09-09
+
 ## [9.78.8] - 2019-09-09
 
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.78.8",
+  "version": "9.78.9",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.78.8",
+  "version": "9.78.9",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -250,20 +250,25 @@ class Toolbar extends PureComponent {
                     <div
                       style={{ height: this.calculateFieldsBoxHeight() }}
                       className="overflow-auto">
-                      {Object.keys(schema.properties).map((field, index) => (
-                        <div
-                          key={index}
-                          className="flex justify-between ph6 pv3 pointer hover-bg-muted-5"
-                          onClick={() => onToggleColumn(field)}>
-                          <span className="w-70 truncate">
-                            {schema.properties[field].title || field}
-                          </span>
-                          <Toggle
-                            size="small"
-                            checked={!hiddenFields.includes(field)}
-                          />
-                        </div>
-                      ))}
+                      {Object.keys(schema.properties)
+                        .filter(
+                          field =>
+                            !!(schema.properties[field].title || field).trim()
+                        )
+                        .map((field, index) => (
+                          <div
+                            key={index}
+                            className="flex justify-between ph6 pv3 pointer hover-bg-muted-5"
+                            onClick={() => onToggleColumn(field)}>
+                            <span className="w-70 truncate">
+                              {schema.properties[field].title || field}
+                            </span>
+                            <Toggle
+                              size="small"
+                              checked={!hiddenFields.includes(field)}
+                            />
+                          </div>
+                        ))}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Do not show columns in the show/hide column list if there is no text (trimmed) for that column (title or field name).

#### What problem is this solving?
The following weird behavior:
![image](https://user-images.githubusercontent.com/5971264/64567236-27ba7c00-d32e-11e9-86ec-38e666b83ae4.png)


#### How should this be manually tested?

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5971264/64567097-ceeae380-d32d-11e9-9369-e6e895d904ec.png)
