### PR TITLE
Feature/borderless radio group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **RadioGroup** `hideBorder` prop to hide group border.
+
 ## [9.79.0] - 2019-09-17
 
 ## [9.78.12] - 2019-09-17
+
 ### Added
+
 - Css class to the vtex toast container
 
 ## [9.78.11] - 2019-09-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.79.1] - 2019-09-17
+
 ### Added
 
 - **RadioGroup** `hideBorder` prop to hide group border.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.79.0",
+  "version": "9.79.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.79.0",
+  "version": "9.79.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/RadioGroup/README.md
+++ b/react/components/RadioGroup/README.md
@@ -131,3 +131,19 @@ Entire group disabled
   onChange={() => {}}
 />
 ```
+
+Hiding border
+
+```js
+<RadioGroup
+  name="radioGroupExample3"
+  hideBorder
+  options={[
+    { value: 'value1', label: 'Hue' },
+    { value: 'value2', label: 'Saturation' },
+    { value: 'value3', label: 'Value' },
+  ]}
+  value="value1"
+  onChange={() => {}}
+/>
+```

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -9,7 +9,7 @@ class RadioGroup extends React.Component {
   }
 
   render() {
-    const { options, value, name, disabled } = this.props
+    const { options, value, name, disabled, hideBorder } = this.props
 
     return (
       <div>
@@ -20,7 +20,9 @@ class RadioGroup extends React.Component {
           const id = `${name}-${i}`
           return (
             <label
-              className={`db pv2 ph4 ba b--muted-4 br3 ${classNames({
+              className={`db pv2 ph4 br3 ${classNames({
+                'b--muted-4': !hideBorder,
+                ba: !hideBorder,
                 pointer: !isDisabled,
               })}`}
               key={id}
@@ -72,10 +74,13 @@ RadioGroup.propTypes = {
   onChange: PropTypes.func.isRequired,
   /** Disable the entire group */
   disabled: PropTypes.bool,
+  /** Hide group border */
+  hideBorder: PropTypes.bool,
 }
 
 RadioGroup.defaultProps = {
   disabled: false,
+  hideBorder: false,
 }
 
 export default RadioGroup


### PR DESCRIPTION
#### What is the purpose of this pull request?

 - adds possibility to toggle RadioGroup component border.

#### What problem is this solving?

 - In the new `promotions-admin` layout reference (in figma) there are some radioGroups with no borders. (and its way better to use the RadioGroup instead of coordenating several Radios just because of a css border)

#### Screenshots or example usage
 - default case
<img width="708" alt="Screen Shot 2019-09-17 at 5 32 51 PM" src="https://user-images.githubusercontent.com/8530905/65077394-3d085980-d971-11e9-9729-a66db9651989.png">
 - borderless
<img width="696" alt="Screen Shot 2019-09-17 at 5 33 02 PM" src="https://user-images.githubusercontent.com/8530905/65077413-4265a400-d971-11e9-9a2a-3f3ef15671ef.png">

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
