### PR TITLE
Removes unnecessary margins and paddings from hideBorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.79.3] - 2019-09-19
+
 ### Fixed
 - **RadioGroup** remove unnecessary paddings and margins if `hideBorder` is ON.
 - **RadioGroup** updates examples in documentation to encourage usage without borders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- **RadioGroup** remove unnecessary paddings and margins if `hideBorder` is ON.
+- **RadioGroup** updates examples in documentation to encourage usage without borders.
+
 ## [9.79.2] - 2019-09-19
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.79.2",
+  "version": "9.79.3",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.79.2",
+  "version": "9.79.3",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/RadioGroup/README.md
+++ b/react/components/RadioGroup/README.md
@@ -20,50 +20,9 @@
 Default
 
 ```js
-const Radio = require('../Radio').default
-initialState = { checkedRadioValue: 'option-1' }
-;<div>
-  <Radio
-    checked={state.checkedRadioValue === 'option-0'}
-    id="radio-0"
-    label="Option 0"
-    name="radio-group"
-    onChange={e => setState({ checkedRadioValue: 'option-0' })}
-    value="option-0"
-  />
-  <Radio
-    checked={state.checkedRadioValue === 'option-1'}
-    id="radio-1"
-    label="Option 1"
-    name="radio-group"
-    onChange={e => setState({ checkedRadioValue: 'option-1' })}
-    value="option-1"
-  />
-  <Radio
-    checked={state.checkedRadioValue === 'option-2'}
-    id="radio-2"
-    label="Option 2"
-    name="radio-group"
-    onChange={e => setState({ checkedRadioValue: 'option-2' })}
-    value="option-2"
-  />
-  <Radio
-    checked={state.checkedRadioValue === 'option-3'}
-    disabled
-    id="radio-3"
-    label="Option 3"
-    name="radio-group"
-    onChange={e => setState({ checkedRadioValue: 'option-3' })}
-    value="option-3"
-  />
-</div>
-```
-
-RadioGroup
-
-```js
 initialState = { value: 'cyan' }
 ;<RadioGroup
+  hideBorder
   name="colors"
   options={[
     { value: 'cyan', label: 'Cyan' },
@@ -80,6 +39,7 @@ One option disabled
 
 ```js
 <RadioGroup
+  hideBorder
   name="radioGroupExample2"
   options={[
     {
@@ -120,6 +80,7 @@ Entire group disabled
 
 ```js
 <RadioGroup
+  hideBorder
   name="radioGroupExample3"
   disabled
   options={[
@@ -132,12 +93,11 @@ Entire group disabled
 />
 ```
 
-Hiding border
+With optional border
 
 ```js
 <RadioGroup
   name="radioGroupExample3"
-  hideBorder
   options={[
     { value: 'value1', label: 'Hue' },
     { value: 'value2', label: 'Saturation' },

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -22,7 +22,7 @@ class RadioGroup extends React.Component {
             <label
               className={`db br3 ${classNames({
                 'b--muted-4': !hideBorder,
-                ba: !hideBorder,
+                'b--muted-4 ba pv2 ph4': !hideBorder,
                 pv2: !hideBorder,
                 ph4: !hideBorder,
                 pointer: !isDisabled,

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -21,10 +21,7 @@ class RadioGroup extends React.Component {
           return (
             <label
               className={`db br3 ${classNames({
-                'b--muted-4': !hideBorder,
                 'b--muted-4 ba pv2 ph4': !hideBorder,
-                pv2: !hideBorder,
-                ph4: !hideBorder,
                 pointer: !isDisabled,
               })}`}
               key={id}

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -20,9 +20,11 @@ class RadioGroup extends React.Component {
           const id = `${name}-${i}`
           return (
             <label
-              className={`db pv2 ph4 br3 ${classNames({
+              className={`db br3 ${classNames({
                 'b--muted-4': !hideBorder,
                 ba: !hideBorder,
+                pv2: !hideBorder,
+                ph4: !hideBorder,
                 pointer: !isDisabled,
               })}`}
               key={id}
@@ -37,7 +39,7 @@ class RadioGroup extends React.Component {
                   borderBottomRightRadius: 0,
                 }),
               }}>
-              <div className="mt3">
+              <div className={classNames({ mt3: !hideBorder })}>
                 <Radio
                   id={id}
                   name={name}


### PR DESCRIPTION
Also, updates the examples in the documentation so as to encourage usage of the component with the `hideBorder` ON.

## Before

![image](https://user-images.githubusercontent.com/467471/65191831-9d6bc980-da4b-11e9-92d4-7375fe50723f.png)

## After

![image](https://user-images.githubusercontent.com/467471/65191819-91800780-da4b-11e9-8a87-0f30c6d00834.png)

