### PR TITLE
Fix readonly styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.79.2] - 2019-09-19
+
 ### Fixed
 
 - `readOnly` style of `Input`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `readOnly` style of `Input`.
+
 ## [9.79.1] - 2019-09-17
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.79.1",
+  "version": "9.79.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.79.1",
+  "version": "9.79.2",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -76,6 +76,8 @@ class Input extends Component {
       suffix: suffixProp,
       suffixIcon,
       groupBottom,
+      disabled,
+      readOnly,
     } = this.props
     const { active } = this.state
 
@@ -111,9 +113,11 @@ class Input extends Component {
       classes += 'code '
     }
 
-    if (this.props.disabled) {
-      classes += 'bg-transparent b--disabled c-disabled '
-      prefixSuffixGroupClasses += 'bg-disabled b--disabled c-disabled '
+    if (disabled || readOnly) {
+      classes += `bg-transparent b--disabled ${disabled ? 'c-disabled' : ''} `
+      prefixSuffixGroupClasses += `bg-disabled b--disabled ${
+        disabled ? 'c-disabled' : ''
+      } `
     } else {
       classes += 'bg-base c-on-base '
       prefixAndSuffixClasses += 'bg-base '
@@ -127,7 +131,7 @@ class Input extends Component {
       } else {
         classes += 'b--muted-4 '
         prefixSuffixGroupClasses += 'b--muted-4 '
-        if (!this.props.readOnly) {
+        if (!readOnly) {
           classes += 'hover-b--muted-3 '
           prefixSuffixGroupClasses += 'hover-b--muted-3 '
         }
@@ -196,7 +200,7 @@ class Input extends Component {
             onKeyDown={this.handleKeyDown}
             onKeyUp={this.handleKeyUp}
             className={classes}
-            disabled={this.props.disabled}
+            disabled={disabled}
             accept={this.props.accept}
             autoComplete={this.props.autoComplete}
             autoCorrect={this.props.autoCorrect}
@@ -213,7 +217,7 @@ class Input extends Component {
             name={this.props.name}
             pattern={this.props.pattern}
             placeholder={this.props.placeholder}
-            readOnly={this.props.readOnly}
+            readOnly={readOnly}
             required={this.props.required}
             spellCheck={this.props.spellCheck}
             src={this.props.src}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update readonly styles of input component.

#### What problem is this solving?
Wrong styles.

#### How should this be manually tested?
Checkout and `yarn styleguide`

#### Screenshots or example usage
Before:
<img width="375" alt="Screen Shot 2019-09-19 at 10 30 18" src="https://user-images.githubusercontent.com/2573602/65248665-ea41b580-dac8-11e9-93fa-0e95fe04d7c0.png">

After:
<img width="390" alt="Screen Shot 2019-09-19 at 10 29 57" src="https://user-images.githubusercontent.com/2573602/65248675-ee6dd300-dac8-11e9-9a6c-439a1ff5e0d4.png">


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
