### PR TITLE
Fix withForwardedRef propType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `withForwardedRef` propType
+
 ## [9.80.3] - 2019-09-24
 
 - `LineActions` to `EXPERIMENTAL_TableV2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.80.4] - 2019-09-24
+
 ### Fixed
 
 - `withForwardedRef` propType

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.80.3",
+  "version": "9.80.4",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.80.3",
+  "version": "9.80.4",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/modules/withForwardedRef.js
+++ b/react/modules/withForwardedRef.js
@@ -10,7 +10,7 @@ const Element =
 export const refShape = PropTypes.oneOfType([
   PropTypes.func,
   PropTypes.shape({
-    current: PropTypes.instanceOf(Element).isRequired,
+    current: PropTypes.instanceOf(Element),
   }),
 ])
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says
<!--- Describe your changes in detail. -->
#### What problem is this solving?
The `current` value of the `ref` prop is always undefined. Its value is only set when the DOM loads, so it doesn't make sense to be required.

#### How should this be manually tested?
The input is used [here](https://addskuerrormodal--storecomponents.myvtex.com/admin/app/collections/create), the ref is used to set the focus to the input when save is pressed and the name is not filled.

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
