### PR TITLE
Add preferential sort order option to table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.81.0] - 2019-09-25
+
 ### Added
 
 - Preferential sort order to a sortable table column, which can be used to set the first sort order when sorting is set. Defaults to `ASC`, which is the previous behaviour.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Preferential sort order to a sortable table column, which can be used to set the first sort order when sorting is set. Defaults to `ASC`, which is the previous behaviour.
+
 ## [9.80.4] - 2019-09-24
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.80.4",
+  "version": "9.81.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.80.4",
+  "version": "9.81.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -26,16 +26,18 @@ class SimpleTable extends Component {
 
   toggleSortType = key => {
     const {
-      sort: { sortOrder, sortedBy },
+      sort: { preferentialSortOrder = 'ASC', sortOrder, sortedBy },
     } = this.props
-    if (sortedBy !== key || (sortedBy === key && sortOrder !== 'ASC')) {
+
+    if (sortedBy !== key) {
       return {
-        sortOrder: 'ASC',
+        sortOrder: preferentialSortOrder,
         sortedBy: key,
       }
     }
+
     return {
-      sortOrder: 'DESC',
+      sortOrder: sortOrder === 'ASC' ? 'DESC' : 'ASC',
       sortedBy: key,
     }
   }
@@ -356,6 +358,7 @@ SimpleTable.propTypes = {
   sort: PropTypes.shape({
     sortOrder: PropTypes.oneOf(['ASC', 'DESC']),
     sortedBy: PropTypes.string,
+    preferentialSortOrder: PropTypes.oneOf(['ASC', 'DESC']),
   }),
   onSort: PropTypes.func,
   updateTableKey: PropTypes.string,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a `preferentialSortOrder` option, defaulted to `ASC` (the previous hardcoded behaviour), which can be used by the developer to set the first sort order in a column sort click.

#### What problem is this solving?
The Table component has a hardcoded preferential sort order set to `ASC`, i.e., on a sortable column header first click, the table order is automatically set to an ascending order.

However, in some applications, the most interesting numeric values in a sortable list are the larger ones, and in the current context, these are two clicks away from an unsorted state instead of one.

#### How should this be manually tested?
- Visit [this link](https://artur--sandboxintegracao.myvtex.com/admin/received-skus/approved/)
- Click in the `Price` or `Stock` column header. The first sort order will be descending, instead of the usual ascending. Further clicks in the same column header will make the sort order flip as usual.

#### Screenshots or example usage
![Ordering](https://user-images.githubusercontent.com/3827456/65622013-34300d00-df9b-11e9-9e43-46f007804011.gif)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
