### PR TITLE
Fix EXPERIMENTAL_Table's ButtonNewLine presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- `EXPERIMENTAL_Table`'s `ButtonNewLine` presentation.
+- `EXPERIMENTAL_Table`'s `ButtonNewLine` style.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `EXPERIMENTAL_Table`'s `ButtonNewLine` presentation.
+
 ### Changed
 
 - **Filters**: little style corrections and design improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.81.4] - 2019-09-26
+
 ### Fixed
 
 - `EXPERIMENTAL_Table`'s `ButtonNewLine` style.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.81.3",
+  "version": "9.81.4",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.81.3",
+  "version": "9.81.4",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/Toolbar/Button.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/Button.tsx
@@ -1,22 +1,9 @@
 import React, { forwardRef, ReactNode } from 'react'
+import csx from 'classnames'
 
 import ButtonWithIcon from '../../ButtonWithIcon/index.js'
 import { BUTTON } from '../constants'
 const ICON_OPTICAL_COMPENSATION = { marginTop: 1.5 }
-
-export type ButtonProps = {
-  id?: string
-  label?: string
-  onClick?: Function
-  isLoading?: boolean
-  disabled?: boolean
-  size?: Size
-  icon?: any
-  title?: string
-  variation?: Variation
-  isActiveOfGroup?: boolean
-  children?: ReactNode
-}
 
 type Ref = HTMLDivElement
 
@@ -33,13 +20,19 @@ const Button = forwardRef<Ref, ButtonProps>(
       label,
       variation,
       isActiveOfGroup,
+      isGrouped,
+      isFirstOfGroup,
       size,
     },
     ref
   ) => {
     const isTertiary = variation === BUTTON.VARIATION.TERTIARY
     return (
-      <div id={id} title={title} ref={ref} className="relative mh2">
+      <div
+        id={id}
+        title={title}
+        ref={ref}
+        className={csx('relative', { mh2: isTertiary })}>
         <ButtonWithIcon
           icon={
             <span
@@ -48,6 +41,8 @@ const Button = forwardRef<Ref, ButtonProps>(
               {icon}
             </span>
           }
+          isGrouped={isGrouped}
+          isFirstOfGroup={isFirstOfGroup}
           isActiveOfGroup={isActiveOfGroup}
           disabled={disabled}
           isLoading={isLoading}
@@ -64,9 +59,27 @@ const Button = forwardRef<Ref, ButtonProps>(
   }
 )
 
+export type ButtonProps = {
+  id?: string
+  label?: string
+  onClick?: Function
+  isLoading?: boolean
+  disabled?: boolean
+  size?: Size
+  icon?: any
+  title?: string
+  variation?: Variation
+  isActiveOfGroup?: boolean
+  isGrouped?: boolean
+  isFirstOfGroup?: boolean
+  children?: ReactNode
+}
+
 Button.defaultProps = {
   variation: BUTTON.VARIATION.TERTIARY,
   isActiveOfGroup: false,
+  isGrouped: false,
+  isFirstOfGroup: false,
   size: BUTTON.SIZE.SMALL,
 }
 

--- a/react/components/EXPERIMENTAL_Table/Toolbar/ButtonNewLine.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/ButtonNewLine.tsx
@@ -16,6 +16,8 @@ const ButtonNewLine: FC<ButtonNewLineProps> = ({ actions, ...buttonProps }) => {
           isActiveOfGroup
           id={namespace}
           key={namespace}
+          isGrouped
+          isFirstOfGroup
           variation={BUTTON.VARIATION.PRIMARY}
           icon={<IconPlus solid size={ICON_SIZE.LIGHT} />}
           {...buttonProps}


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
The button presentation should match the previous table.

#### How should this be manually tested?
`yarn start`

#### Screenshots or example usage
Before
<img width="166" alt="Screen Shot 2019-09-26 at 11 20 26" src="https://user-images.githubusercontent.com/6964311/65698939-afed9080-e053-11e9-81d7-f8d95b557c9f.png">
After
<img width="136" alt="Screen Shot 2019-09-26 at 11 41 43" src="https://user-images.githubusercontent.com/6964311/65698942-b24fea80-e053-11e9-8da6-df4b8f2eb4a2.png">
#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
