### PR TITLE
Add data-testid attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.85.0] - 2019-10-03
+
 ### Added
 
 - `data-testid` attribute for testing purposes on `Input`, `Dropdown`, `EmptyState`, `Button` & `PageBlock`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `data-testid` attribute for testing purposes on `Input`, `Dropdown`, `EmptyState`, `Button` & `PageBlock`
+
 ## [9.84.0] - 2019-10-01
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.84.0",
+  "version": "9.85.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.84.0",
+  "version": "9.85.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -207,6 +207,7 @@ class Button extends Component {
     return (
       <Element
         id={this.props.id}
+        data-testid={this.props.testId}
         autoFocus={iconOnly ? undefined : this.props.autoFocus}
         disabled={iconOnly ? undefined : this.props.disabled}
         name={iconOnly ? undefined : this.props.name}
@@ -286,6 +287,8 @@ Button.propTypes = {
   iconOnly: PropTypes.bool,
   /** (Button spec attribute) */
   id: PropTypes.string,
+  /** Data attribute */
+  testId: PropTypes.string,
   /** (Button spec attribute) */
   autoFocus: PropTypes.bool,
   /** (Button spec attribute) */

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -83,6 +83,7 @@ class Dropdown extends Component {
     const {
       label,
       id,
+      testId,
       value,
       size,
       disabled,
@@ -174,7 +175,8 @@ class Dropdown extends Component {
       <div
         className={`vtex-dropdown ${
           isInline ? 'vtex-dropdown--inline dib' : ''
-        }`}>
+        }`}
+        data-testid={testId}>
         <label>
           {label && <span className={labelClasses}>{label}</span>}
           <div className={containerClasses} style={containerStyle}>
@@ -277,6 +279,8 @@ Dropdown.propTypes = {
   preventTruncate: PropTypes.bool,
   /** Spec attribute */
   id: PropTypes.string,
+  /** Data attribute */
+  testId: PropTypes.string,
   /** Spec attribute */
   autoFocus: PropTypes.bool,
   /** Spec attribute */

--- a/react/components/EmptyState/index.js
+++ b/react/components/EmptyState/index.js
@@ -1,11 +1,14 @@
 import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
 
 class EmptyState extends PureComponent {
   render() {
-    const { title, children } = this.props
+    const { title, children, testId } = this.props
 
     return (
-      <div className="br3 flex c-muted-2 justify-center pv9 ph6 ph9-l tc">
+      <div
+        className="MAIN br3 flex c-muted-2 justify-center pv9 ph6 ph9-l tc"
+        data-testid={testId}>
         <div className="w-80 w-50-l">
           {title && <span className="t-heading-3 mt0 mt0">{title}</span>}
           {children && <div className="t-body lh-copy">{children}</div>}
@@ -32,6 +35,8 @@ EmptyState.propTypes = {
       )
     }
   },
+  /** Data attribute */
+  testId: PropTypes.string,
 }
 
 export default EmptyState

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -86,6 +86,7 @@ class Input extends Component {
       groupBottom,
       disabled,
       readOnly,
+      testId,
     } = this.props
     const { active } = this.state
 
@@ -190,7 +191,7 @@ class Input extends Component {
     }
 
     return (
-      <label className="vtex-input w-100">
+      <label className="vtex-input w-100" data-testid={testId}>
         {label && <span className={labelClasses}>{label}</span>}
         <div className={prefixSuffixGroupClasses}>
           {prefix && (
@@ -305,6 +306,8 @@ Input.propTypes = {
   groupBottom: PropTypes.bool,
   /** Spec attribute */
   id: PropTypes.string,
+  /** Data attribute */
+  testId: PropTypes.string,
   /** Spec attribute */
   inputMode: PropTypes.string,
   /** Spec attribute */

--- a/react/components/PageBlock/index.js
+++ b/react/components/PageBlock/index.js
@@ -6,7 +6,7 @@ import Box from '../Box/index'
 
 class PageBlock extends Component {
   render() {
-    const { title, subtitle, variation, titleAside } = this.props
+    const { title, subtitle, variation, titleAside, testId } = this.props
     const isAnnotated = variation === 'annotated'
 
     const headerClasses = classNames({
@@ -22,7 +22,8 @@ class PageBlock extends Component {
       <div
         className={`styleguide__pageBlock flex ${
           isAnnotated ? 'flex-row' : 'flex-column'
-        }`}>
+        }`}
+        data-testid={testId}>
         {/* Title, subtitle & aside */}
         {(title || subtitle) && (
           <div className={headerClasses}>
@@ -84,6 +85,8 @@ PageBlock.propTypes = {
   variation: PropTypes.oneOf(['full', 'half', 'annotated', 'aside']),
   /** Title for the block. */
   title: PropTypes.string,
+  /** Data attribute */
+  testId: PropTypes.string,
   /** Subtitle for the block. */
   subtitle: PropTypes.string,
   /** Content on the right side of the title. */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add simple data attribute `testid` to prevent developers from adding an extra html element around the element to be tested. Usually via e2e tests.

#### What problem is this solving?
Closes https://github.com/vtex/styleguide/issues/848

#### How should this be manually tested?
Checkout & add the attribute `testId` to one of the following components:
- `Input`
- `Dropdown`
- `EmptyState`
- `Button`
- `PageBlock`

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
