### PR TITLE
Add dynamic row heights to table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.84.0] - 2019-10-01
+
 ### Added
 
 - Option for dynamic row heights in table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Option for dynamic row heights in table.
+
 ## [9.83.1] - 2019-10-01
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.83.1",
+  "version": "9.84.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.83.1",
+  "version": "9.84.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -19,6 +19,8 @@ const DEFAULT_COLUMN_WIDTH = 200
 const LINE_ACTIONS_COLUMN_WIDTH = 70
 const NO_TITLE_COLUMN = ' '
 const SELECTED_ROW_BACKGROUND = '#dbe9fd'
+const DEFAULT_SCROLLBAR_WIDTH = 17
+const EMPTY_STATE_SIZE_IN_ROWS = 5
 
 class SimpleTable extends Component {
   constructor(props) {
@@ -126,17 +128,33 @@ class SimpleTable extends Component {
     }
   }
 
+  getScrollbarWidth = () => {
+    if (!window || !document || !document.documentElement)
+      return DEFAULT_SCROLLBAR_WIDTH
+    const scrollbarWidth =
+      window.innerWidth - document.documentElement.clientWidth
+    return isNaN(scrollbarWidth) ? DEFAULT_SCROLLBAR_WIDTH : scrollbarWidth
+  }
+
   calculateContainerHeight = () => {
-    const { disableHeader, items } = this.props
+    const { rowHeight, items, disableHeader } = this.props
+
+    if (items.length === 0) {
+      return (
+        HEADER_HEIGHT +
+        rowHeight * EMPTY_STATE_SIZE_IN_ROWS +
+        this.getScrollbarWidth()
+      )
+    }
 
     const rowCount = disableHeader ? items.length : items.length + 1
 
-    let containerHeight = 0
+    let rawTableHeight = 0
     for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-      containerHeight += this.calculateRowHeight(rowIndex)
+      rawTableHeight += this.calculateRowHeight(rowIndex)
     }
 
-    return containerHeight
+    return rawTableHeight + this.getScrollbarWidth()
   }
 
   render() {
@@ -149,6 +167,7 @@ class SimpleTable extends Component {
       emptyStateLabel,
       emptyStateChildren,
       onRowClick,
+      containerHeight,
       sort: { sortOrder, sortedBy },
       onSort,
       updateTableKey,
@@ -165,14 +184,14 @@ class SimpleTable extends Component {
 
     const tableKey = `vtex-table--${updateTableKey}--${density}`
 
-    const containerHeight = this.calculateContainerHeight()
+    const tableHeight = containerHeight || this.calculateContainerHeight()
 
     return (
-      <div className="vh-100 w-100 dt" style={{ height: containerHeight }}>
+      <div className="vh-100 w-100 dt" style={{ height: tableHeight }}>
         {loading ? (
           <div
             className="dtc v-mid tc"
-            style={{ height: containerHeight - HEADER_HEIGHT }}>
+            style={{ height: tableHeight - HEADER_HEIGHT }}>
             <Spinner />
           </div>
         ) : (

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -195,9 +195,9 @@ class SimpleTable extends Component {
             <Spinner />
           </div>
         ) : (
-          <div className="h-100">
+          <div>
             <AutoSizer key={tableKey}>
-              {({ width, height }) => {
+              {({ width }) => {
                 const colsWidth = Object.keys(schema.properties).reduce(
                   (acc, curr) => {
                     const col = schema.properties[curr]
@@ -218,7 +218,7 @@ class SimpleTable extends Component {
 
                 return (
                   <MultiGrid
-                    height={height}
+                    height={tableHeight}
                     width={width}
                     deferredMeasurementCache={this._cache}
                     tabIndex={null}
@@ -442,7 +442,7 @@ SimpleTable.propTypes = {
   updateTableKey: PropTypes.string,
   containerHeight: PropTypes.number,
   rowHeight: PropTypes.number.isRequired,
-  dynamicRowHeight: PropTypes.number,
+  dynamicRowHeight: PropTypes.bool,
   fullWidth: PropTypes.bool,
   lineActions: PropTypes.arrayOf(
     PropTypes.shape({

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -178,6 +178,7 @@ class Table extends PureComponent {
       toolbar,
       pagination,
       fullWidth,
+      dynamicRowHeight,
       lineActions,
       loading,
       bulkActions,
@@ -326,6 +327,7 @@ class Table extends PureComponent {
             disableHeader={disableHeader}
             emptyStateLabel={emptyStateLabel}
             emptyStateChildren={emptyStateChildren}
+            dynamicRowHeight={dynamicRowHeight}
             onRowClick={onRowClick}
             sort={sort}
             onSort={onSort}
@@ -388,6 +390,8 @@ Table.propTypes = {
   emptyStateChildren: PropTypes.node,
   /** Full width property  */
   fullWidth: PropTypes.bool,
+  /** Dynamic row height property */
+  dynamicRowHeight: PropTypes.bool,
   /** Line actions column */
   lineActions: PropTypes.arrayOf(
     PropTypes.shape({

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -14,8 +14,6 @@ import CheckboxContainer from './CheckboxContainer'
 import Totalizers from '../Totalizer'
 import BulkActions from './BulkActions'
 
-const TABLE_HEADER_HEIGHT = 36
-const EMPTY_STATE_SIZE_IN_ROWS = 5
 const DEFAULT_SCROLLBAR_WIDTH = 17
 
 class Table extends PureComponent {
@@ -100,17 +98,6 @@ class Table extends PureComponent {
     const scrollbarWidth =
       window.innerWidth - document.documentElement.clientWidth
     return isNaN(scrollbarWidth) ? DEFAULT_SCROLLBAR_WIDTH : scrollbarWidth
-  }
-
-  calculateTableHeight = totalItems => {
-    const { tableRowHeight } = this.state
-    const multiplicator =
-      totalItems !== 0 ? totalItems : EMPTY_STATE_SIZE_IN_ROWS
-    return (
-      TABLE_HEADER_HEIGHT +
-      tableRowHeight * multiplicator +
-      this.getScrollbarWidth()
-    )
   }
 
   handleSelectionChange = () => {
@@ -335,9 +322,7 @@ class Table extends PureComponent {
             updateTableKey={updateTableKey}
             lineActions={lineActions}
             loading={loading}
-            containerHeight={
-              containerHeight || this.calculateTableHeight(items.length)
-            }
+            containerHeight={containerHeight}
             selectedRowsIndexes={map(selectedRows, 'id')}
             density={selectedDensity}
           />

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -92,14 +92,6 @@ class Table extends PureComponent {
     this.setState({ hiddenFields: Object.keys(this.props.schema.properties) })
   }
 
-  getScrollbarWidth = () => {
-    if (!window || !document || !document.documentElement)
-      return DEFAULT_SCROLLBAR_WIDTH
-    const scrollbarWidth =
-      window.innerWidth - document.documentElement.clientWidth
-    return isNaN(scrollbarWidth) ? DEFAULT_SCROLLBAR_WIDTH : scrollbarWidth
-  }
-
   handleSelectionChange = () => {
     if (this.props.bulkActions && this.props.bulkActions.onChange) {
       const selectedParameters = this.state.allLinesSelected

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -14,8 +14,6 @@ import CheckboxContainer from './CheckboxContainer'
 import Totalizers from '../Totalizer'
 import BulkActions from './BulkActions'
 
-const DEFAULT_SCROLLBAR_WIDTH = 17
-
 class Table extends PureComponent {
   constructor(props) {
     super(props)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a `Dynamic Row Height` option to table v1.

#### What problem is this solving?
Some applications require that the table height have a little flexibility. For example, for a list of SKUs, on a column with SKU names, it is very important that the names endings (which usually contain specifications information), are displayed. However, if said names are too long, they can be cropped or hidden from view, as shown in Figure 1.

Thus, by enabling a dynamic row height, we can provide a little bit more of space to cells that are meant to contain highly flexible content, as shown in Figure 2.

#### How should this be manually tested?
You can go to [this link](https://artur--sandboxintegracao.myvtex.com/admin/received-skus/approved/?elements=15&from=0&to=15) to see the change in action. Alternatively, you can test this by:
1. Pulling this branch in your project that uses the Styleguide's table v1;
2. Linking this app in your test workspace;
3. Check if, by not setting the `dynamicRowHeight` option to `true`, your table still holds up;
4. Check if, by setting the `dynamicRowHeight` option to `true`, your table acquires a dynamic row height behaviour.

NOTE: the dynamic row height should never be *less* than the height correspondent to the chosen density.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3827456/65905943-ef8be380-e397-11e9-8c96-e333424354ab.png)
**Figure 1:** Table v1 without dynamic heights (using truncate for content)

![image](https://user-images.githubusercontent.com/3827456/65906199-72ad3980-e398-11e9-89e1-06e09208c5c6.png)
**Figure 2:** Table v1 with dynamic heights 

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
