### PR TITLE
Fix PropTypes for Input, TextArea and Toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.86.1] - 2019-10-03
+
 ### Fixed
 
 - Label PropTypes of `Input`, `TextArea` and `Toggle`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Label PropTypes of `Input`, `TextArea` and `Toggle`.
+- Value PropType of `Input`.
 - `Button` hover state in collapsed tertiary buttons
 
 ## [9.86.0] - 2019-10-03

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.86.0",
+  "version": "9.86.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.86.0",
+  "version": "9.86.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -283,7 +283,7 @@ Input.propTypes = {
   /** Input size */
   size: PropTypes.oneOf(['small', 'regular', 'large']),
   /** Label */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** Prefix */
   prefix: PropTypes.node,
   /** Spec attribute */
@@ -347,7 +347,7 @@ Input.propTypes = {
   /** Spec attribute */
   type: PropTypes.string,
   /** Spec attribute */
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** onChange event */
   onChange: PropTypes.func,
   /** onKeyDown event */

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -181,7 +181,7 @@ Textarea.propTypes = {
   /** Help text */
   helpText: PropTypes.node,
   /** Label */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** Spec attribute */
   autoComplete: PropTypes.string,
   /** Spec attribute */

--- a/react/components/Toggle/index.js
+++ b/react/components/Toggle/index.js
@@ -196,7 +196,7 @@ Toggle.propTypes = {
   semantic: PropTypes.bool,
   disabled: PropTypes.bool,
   id: PropTypes.string,
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   name: PropTypes.string,
   onChange: PropTypes.func,
   onClick: PropTypes.func,


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Allow the users to use the input properly and allow inputs which have tooltips.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[workspace](https://rerisson--storecomponents.myvtex.com/admin/brand/create/)
These inputs are from styleguide.

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
