### PR TITLE
Add vtex-tachyons mention in non-io docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.89.0] - 2019-10-24
+
 ## [9.88.5] - 2019-10-18
 
 ### Fixed

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -49,6 +49,16 @@ import Button from '@vtex/styleguide/lib/Button'
 
 And now, you can run your project like you always do.
 
+###### Styles
+
+When using the _Styleguide_ in project outside the _VTEX IO_ environment, you need to manually add the [vtex-tachyons](https://github.com/vtex/vtex-tachyons) to your project to get the components style as seen in the documentation. To do so, you can simply run the following install command:
+
+```shell noeditor static
+yarn add vtex-tachyons
+# or
+npm i vtex-tachyons --save
+```
+
 #### PRs and Code Review
 
 :loudspeaker: **Disclaimer:** In the course of this document we assume that you know how to use the basics of git as well like do a commit, rebase and merge. Before open a PR, read the [designing section](./designing.md) and take some minutes thinking if your change is appropriate to our styleguide.
@@ -127,11 +137,11 @@ import PropTypes from 'prop-types'
 
 const propTypes = {
   /** Optional message */
-  message: PropTypes.string
+  message: PropTypes.string,
 }
 
 const defaultProps = {
-  message: 'Hello world!'
+  message: 'Hello world!',
 }
 
 // This is the TypeScript "trick"
@@ -144,6 +154,7 @@ HelloWorld.defaultProps = defaultProps
 
 export default Hello
 ```
+
 After that, **for IO Apps**, you only need your component being imported and exported be at the `/react` folder in a `.ts` file (not `.tsx` yet, because we still have `.js` files) and the Builder Hub will generate the typings.
 
 With all this, you are ready to develop TypeScript components into our Styleguide :)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.88.5",
+  "version": "9.89.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.88.5",
+  "version": "9.89.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Mention that manually adding the `vtex-tachyons` dependency is required to get the styles of the components that are seen in the documentation.

#### What problem is this solving?
Closes #723.

#### How should this be manually tested?
[Running workspace](http://10.1.14.209:6060/#/Introduction/Developing)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5971264/66138625-50ecc600-e5d5-11e9-826f-adc63d8b2ccc.png)
