### PR TITLE
Feature/new icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- **Icon** `SimpleBasket`.
+- **Icon** `Trophy`,`SimpleBasket`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- **Icon** `Trophy`,`SimpleBasket`.
+- **Icon** `Trophy`, `SimpleBasket`, `Ban`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix problem with responsive spaces on alert component
 
+### Added
+
+- **Icon** `Trophy`, `SimpleBasket`, `Ban`.
+
 ## [9.86.1] - 2019-10-03
 
 ### Fixed
@@ -65,10 +69,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New component to split elements.
 
 ## [9.81.4] - 2019-09-26
-
-### Added
-
-- **Icon** `Trophy`, `SimpleBasket`, `Ban`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [9.81.4] - 2019-09-26
 
+### Added
+
+- **Icon** `SimpleBasket`.
+
 ### Fixed
 
 - `EXPERIMENTAL_Table`'s `ButtonNewLine` style.

--- a/react/IconBan.js
+++ b/react/IconBan.js
@@ -1,0 +1,3 @@
+import Ban from './components/icon/Ban/index'
+
+export default Ban

--- a/react/IconSimpleBasket.js
+++ b/react/IconSimpleBasket.js
@@ -1,0 +1,3 @@
+import SimpleBasket from './components/icon/SimpleBasket/index'
+
+export default SimpleBasket

--- a/react/IconTrophy.js
+++ b/react/IconTrophy.js
@@ -1,0 +1,3 @@
+import IconTrophy from './components/icon/Trophy/index'
+
+export default IconTrophy

--- a/react/components/icon/Ban/index.js
+++ b/react/components/icon/Ban/index.js
@@ -1,0 +1,44 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { calcIconSize, baseClassname } from '../utils'
+
+const iconBase = {
+  width: 14,
+  height: 16,
+}
+
+class Ban extends PureComponent {
+  render() {
+    const { color, size, block } = this.props
+    const newSize = calcIconSize(iconBase, size)
+
+    return (
+      <svg
+        className={`${baseClassname('ban')} ${block ? 'db' : ''}`}
+        width={newSize.width}
+        height={newSize.height}
+        viewBox="0 0 64 64"
+        fill={color}
+        xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M32,2A30,30,0,1,0,62,32,30.034,30.034,0,0,0,32,2ZM8,32A23.98,23.98,0,0,1,46.705,13.053L13.053,46.705A23.871,23.871,0,0,1,8,32ZM32,56a23.871,23.871,0,0,1-14.7-5.053L50.947,17.3A23.98,23.98,0,0,1,32,56Z"
+          fill={color}
+        />
+      </svg>
+    )
+  }
+}
+
+Ban.defaultProps = {
+  color: 'currentColor',
+  size: 16,
+  block: false,
+}
+
+Ban.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.number,
+  block: PropTypes.bool,
+}
+
+export default Ban

--- a/react/components/icon/SimpleBasket/index.js
+++ b/react/components/icon/SimpleBasket/index.js
@@ -1,0 +1,47 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { calcIconSize, baseClassname } from '../utils'
+
+const iconBase = {
+  width: 18,
+  height: 12,
+}
+
+class SimpleBasket extends PureComponent {
+  render() {
+    const { color, size, block } = this.props
+    const newSize = calcIconSize(iconBase, size)
+
+    return (
+      <svg
+        className={`${baseClassname('simple-basket')} ${block ? 'db' : ''}`}
+        width={newSize.width}
+        height={newSize.height}
+        viewBox="0 0 64 64"
+        fill={color}
+        xmlns="http://www.w3.org/2000/svg">
+        <path
+          fill={color}
+          d="M7.384,31l6.642,28.229C14.133,59.681,14.536,60,15,60h34c0.464,0,0.867-0.319,0.974-0.771L56.616,31H7.384z " />
+        <path
+          data-color="color-2"
+          d="M62,21H50.535L38.832,3.445c-0.307-0.46-0.928-0.584-1.387-0.277 c-0.459,0.306-0.583,0.927-0.277,1.387L48.132,21H15.868L26.832,4.555c0.306-0.459,0.182-1.081-0.277-1.387 c-0.46-0.307-1.081-0.183-1.387,0.277L13.465,21H2c-0.552,0-1,0.448-1,1v6c0,0.552,0.448,1,1,1h60c0.552,0,1-0.448,1-1v-6 C63,21.448,62.552,21,62,21z" />
+      </svg>
+
+    )
+  }
+}
+
+SimpleBasket.defaultProps = {
+  color: 'currentColor',
+  size: 20,
+  block: false,
+}
+
+SimpleBasket.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.number,
+  block: PropTypes.bool,
+}
+
+export default SimpleBasket

--- a/react/components/icon/Trophy/index.js
+++ b/react/components/icon/Trophy/index.js
@@ -1,0 +1,46 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { calcIconSize, baseClassname } from '../utils'
+
+const iconBase = {
+  width: 18,
+  height: 12,
+}
+
+class Trophy extends PureComponent {
+  render() {
+    const { color, size, block } = this.props
+    const newSize = calcIconSize(iconBase, size)
+
+    return (
+      <svg
+        className={`${baseClassname('trophy')} ${block ? 'db' : ''}`}
+        width={newSize.width}
+        height={newSize.height}
+        viewBox="0 0 64 64"
+        fill={color}
+        xmlns="http://www.w3.org/2000/svg">
+        <path
+          fill={color}
+          d="M58.5,6H51V3a1,1,0,0,0-1-1H14a1,1,0,0,0-1,1V6H5.5A1.5,1.5,0,0,0,4,7.5v10c0,5.96,3.552,11.973,10.336,12.453a18.973,18.973,0,0,0,35.328,0C56.448,29.473,60,23.46,60,17.5V7.5A1.5,1.5,0,0,0,58.5,6ZM7,17.5V9h6V23a19.012,19.012,0,0,0,.384,3.805C9.015,25.864,7,21.549,7,17.5Zm50,0c0,4.049-2.015,8.364-6.384,9.305A19.012,19.012,0,0,0,51,23V9h6Z" />
+        <path
+          data-color="color-2"
+          d="M36,52H34V44H30v8H28c-10.207,0-11,6.889-11,9a1,1,0,0,0,1,1H46a1,1,0,0,0,1-1C47,58.889,46.207,52,36,52Z" />
+      </svg>
+    )
+  }
+}
+
+Trophy.defaultProps = {
+  color: 'currentColor',
+  size: 20,
+  block: false,
+}
+
+Trophy.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.number,
+  block: PropTypes.bool,
+}
+
+export default Trophy


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add new icons to the styleguide.

#### What problem is this solving?

Development of gocommerce admin panel, which needed icons that were still not available in vtex styleguide.

#### How should this be manually tested?

It should be tested like other icons.

#### Screenshots or example usage

Ban Icon
`<IconBan size={20} />`

![image](https://user-images.githubusercontent.com/27388955/66351236-95f55d00-e933-11e9-98e3-5f77fa207f27.png)

Trophy Icon
`<IconTrophy color="#ffb100" size={34} />`

![image](https://user-images.githubusercontent.com/27388955/66331420-e1dedc80-e908-11e9-8b05-9fee4ade8cbb.png)

Simple Basket Icon
`<IconSimpleBasket size={30} color="white" />`

![image](https://user-images.githubusercontent.com/27388955/66331466-ffac4180-e908-11e9-8cad-9959549edffc.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
