### PR TITLE
Fix TableTree exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Export for `EXPERIMENTAL_useTableTreeCheckboxes`.
+
+### Changed
+
+- Allow `EXPERIMENTAL_TableTree` to use pagination.
+
 ## [9.86.3] - 2019-10-07
 
 ### Added

--- a/react/EXPERIMENTAL_Table.ts
+++ b/react/EXPERIMENTAL_Table.ts
@@ -1,3 +1,1 @@
-import Table from './components/EXPERIMENTAL_Table/index'
-
-export default Table
+export { default } from './components/EXPERIMENTAL_Table/index'

--- a/react/EXPERIMENTAL_TableTree.ts
+++ b/react/EXPERIMENTAL_TableTree.ts
@@ -1,3 +1,1 @@
-import Table from './components/EXPERIMENTAL_TableTree/index'
-
-export default Table
+export { default } from './components/EXPERIMENTAL_TableTree/index'

--- a/react/EXPERIMENTAL_useTableBulkActions.ts
+++ b/react/EXPERIMENTAL_useTableBulkActions.ts
@@ -1,3 +1,3 @@
-import useTableBulkActions from './components/EXPERIMENTAL_Table/hooks/useTableBulkActions'
-
-export default useTableBulkActions
+export {
+  default,
+} from './components/EXPERIMENTAL_Table/hooks/useTableBulkActions'

--- a/react/EXPERIMENTAL_useTableLineActions.ts
+++ b/react/EXPERIMENTAL_useTableLineActions.ts
@@ -1,3 +1,3 @@
-import useTableLineActions from './components/EXPERIMENTAL_Table/hooks/useTableLineActions'
-
-export default useTableLineActions
+export {
+  default,
+} from './components/EXPERIMENTAL_Table/hooks/useTableLineActions'

--- a/react/EXPERIMENTAL_useTableState.ts
+++ b/react/EXPERIMENTAL_useTableState.ts
@@ -1,3 +1,1 @@
-import useTableState from './components/EXPERIMENTAL_Table/hooks/useTableState'
-
-export default useTableState
+export { default } from './components/EXPERIMENTAL_Table/hooks/useTableState'

--- a/react/EXPERIMENTAL_useTableTreeCheckboxes.ts
+++ b/react/EXPERIMENTAL_useTableTreeCheckboxes.ts
@@ -1,0 +1,3 @@
+export {
+  default,
+} from './components/EXPERIMENTAL_TableTree/hooks/useTableTreeCheckboxes'

--- a/react/components/EXPERIMENTAL_Table/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/index.tsx
@@ -117,13 +117,11 @@ type Props = TableProps & InferProps<typeof bulkPropTypes>
 export type TableComposites = {
   Toolbar: FC
   Pagination?: FC<PaginationProps>
-  LineActions?: FC<LineActionProps>
   BulkActions?: FC
 }
 
 Table.Toolbar = Toolbar
 Table.Pagination = Pagination
-Table.LineActions = LineActions
 Table.propTypes = tablePropTypes
 Table.BulkActions = BulkActions
 

--- a/react/components/EXPERIMENTAL_TableTree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/index.tsx
@@ -10,6 +10,7 @@ import { TableContainer, Thead } from '../EXPERIMENTAL_Table/Styled'
 import { tablePropTypes, TableComposites } from '../EXPERIMENTAL_Table'
 import { InferProps } from 'prop-types'
 import TreeHeadings from './Tree/TreeHeadings'
+import Pagination from '../EXPERIMENTAL_Table/Pagination'
 
 const TableTree: FC<Props> & TableComposites = ({
   children,
@@ -71,6 +72,7 @@ const propTypes = {
 type Props = InferProps<typeof propTypes>
 
 TableTree.Toolbar = Toolbar
+TableTree.Pagination = Pagination
 TableTree.propTypes = propTypes
 
 export type TreeProps = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Export `useTableTreeCheckboxes` hook
Allow `EXPERIMENTAL_TableTree` to use `Pagination`
Use the shorter version of export in Table and TableTree components.

#### How should this be manually tested?
Clone the repo and `yarn && yarn start`

#### Screenshots or example usage
No need

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
