### PR TITLE
Fix Tooltip popup's position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.87.1] - 2019-10-10
+
 ### Fixed
 
 - **Tooltip** popup's position.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tooltip** popup's position.
+
 ## [9.87.0] - 2019-10-10
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.87.0",
+  "version": "9.87.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.87.0",
+  "version": "9.87.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -189,8 +189,8 @@ const getPopupPositionRecursively = (
     Math.min(styles.left, horizontalMax - popupRect.width - 1)
   )
 
-  const transform = `translate3d(${Math.round(left)}px, -${Math.round(
-    document.body.offsetHeight - top
+  const transform = `translate3d(${Math.round(left)}px, ${Math.round(
+    top - document.body.offsetHeight
   )}px, 0)`
 
   return {


### PR DESCRIPTION
#### What is the purpose of this pull request?

The tooltip was getting positioned wrongly in the admin `brand` page. `document.body.offsetHeight - top` was negative so the `translate3d` didn't work properly.

#### What problem is this solving?

Tooltip wrongly positioned.

#### How should this be manually tested?

[Working workspace](https://categories--storecomponents.myvtex.com/admin/brand/2000000/)

#### Screenshots or example usage

##### Bug

![image](https://user-images.githubusercontent.com/15948386/66516834-586e0c80-eab8-11e9-9eb6-3d2ab13ac1e6.png)

##### Fixed

![image](https://user-images.githubusercontent.com/15948386/66516529-9585cf00-eab7-11e9-9792-fbe5ef30fa51.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
