### PR TITLE
Fix: Table tree not rendering if checkboxes are not allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.88.1] - 2019-10-16
+
 ### Fixed
 
 - Table tree not rendering if checkboxes are not allowed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Table tree not rendering if checkboxes are not allowed
+
 ## [9.88.0] - 2019-10-15
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.88.0",
+  "version": "9.88.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.88.0",
+  "version": "9.88.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/DataTable/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/index.tsx
@@ -1,10 +1,11 @@
 import React, { FC, Children } from 'react'
+import csx from 'classnames'
 
 import EmptyState from '../../EmptyState/index.js'
 
 import Headings from './Headings'
 import Rows from './Rows'
-import { NAMESPACES } from '../constants'
+import { NAMESPACES, ORDER_CLASSNAMES } from '../constants'
 import { useTableContext } from '../contexts'
 import Loading from './Loading'
 
@@ -23,7 +24,7 @@ const DataTableContainer: FC = ({ children }) => {
     <div
       id={NAMESPACES.TABLE}
       style={{ minHeight: height }}
-      className="order-1 mw-100 overflow-x-auto">
+      className={csx('order-1 mw-100 overflow-x-auto', ORDER_CLASSNAMES.TABLE)}>
       {children}
       {!isEmpty && loading && (
         <Loading>

--- a/react/components/EXPERIMENTAL_TableTree/README.md
+++ b/react/components/EXPERIMENTAL_TableTree/README.md
@@ -1,4 +1,45 @@
-#### Toolbar
+#### NodesKey Prop
+
+```js
+const useTableState = require('../EXPERIMENTAL_Table/hooks/useTableState.ts')
+  .default
+const sampleData = require('./sampleData.ts').default
+
+// Define the columns
+const columns = [
+  {
+    id: 'name',
+    title: 'Name',
+  },
+  {
+    id: 'email',
+    title: 'Email',
+  },
+  {
+    id: 'number',
+    title: 'Number',
+  },
+  {
+    id: 'country',
+    title: 'Country',
+  },
+]
+
+// Define the items
+const items = sampleData
+
+function ToolbarExample() {
+  const tableState = useTableState({
+    columns,
+    items,
+  })
+
+  return <TableTree unicityKey="email" nodesKey="children" state={tableState} />
+}
+;<ToolbarExample />
+```
+
+#### Full Example
 
 ```js
 const useTableState = require('../EXPERIMENTAL_Table/hooks/useTableState.ts')

--- a/react/components/EXPERIMENTAL_TableTree/Tree/CellPrefix.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/CellPrefix.tsx
@@ -1,16 +1,19 @@
-import React, { FC } from 'react'
+import React, { FC, Children } from 'react'
 
 import CollapseToggle, { CollapseToggleProps } from './CollapseToggle'
 import Checkbox, { CheckboxProps } from '../../EXPERIMENTAL_Table/Checkbox'
 
-const PREFIX_WIDTH = 64
+const PREFIX_WIDTH = 48
+const CHECKBOXES_WIDTH = 16
 
 const CellPrefix: FC<CellPrefixProps> & CellPrefixComposites = ({
   children,
+  hasCheckbox,
   depth,
 }) => {
+  const width = (PREFIX_WIDTH + (hasCheckbox ? CHECKBOXES_WIDTH : 0)) * depth
   return (
-    <span className="dib pr2" style={{ width: PREFIX_WIDTH * depth }}>
+    <span className="dib pr2" style={{ width }}>
       <span className="flex w-100 justify-end items-center">{children}</span>
     </span>
   )
@@ -18,6 +21,7 @@ const CellPrefix: FC<CellPrefixProps> & CellPrefixComposites = ({
 
 CellPrefix.defaultProps = {
   depth: 1,
+  hasCheckbox: false,
 }
 
 CellPrefix.CollapseToggle = CollapseToggle
@@ -30,6 +34,7 @@ export type CellPrefixComposites = {
 
 export type CellPrefixProps = {
   depth?: number
+  hasCheckbox?: boolean
 }
 
 export default CellPrefix

--- a/react/components/EXPERIMENTAL_TableTree/Tree/TreeHeadings.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/TreeHeadings.tsx
@@ -24,7 +24,7 @@ const TreeHeadings: FC<TreeHeadingsProps> = ({ cellProps, rowProps }) => {
             key={`heading-${uuid()}`}
             width={width}>
             {checkboxes && headerIndex === 0 && (
-              <CellPrefix>
+              <CellPrefix hasCheckbox={!!checkboxes}>
                 <span className="ph2">
                   <CellPrefix.Checkbox
                     checked={checkboxes.isChecked(items)}

--- a/react/components/EXPERIMENTAL_TableTree/Tree/TreeHeadings.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/TreeHeadings.tsx
@@ -3,18 +3,14 @@ import uuid from 'uuid'
 
 import { TABLE_HEADER_HEIGHT } from '../../EXPERIMENTAL_Table/constants'
 import { useTableContext } from '../../EXPERIMENTAL_Table/contexts'
-import { useCheckboxesContext } from '../contexts'
+import { useCheckboxesContext, useTreeContext } from '../contexts'
 import { Row, CellProps, RowProps } from '../../EXPERIMENTAL_Table/Styled'
 import CellPrefix from './CellPrefix'
 
 const TreeHeadings: FC<TreeHeadingsProps> = ({ cellProps, rowProps }) => {
   const { visibleColumns } = useTableContext()
-  const {
-    toggle,
-    itemTree,
-    isChecked,
-    isPartiallyChecked,
-  } = useCheckboxesContext()
+  const { items } = useTableContext()
+  const checkboxes = useCheckboxesContext()
 
   return (
     <Row {...rowProps} height={TABLE_HEADER_HEIGHT}>
@@ -27,13 +23,13 @@ const TreeHeadings: FC<TreeHeadingsProps> = ({ cellProps, rowProps }) => {
             className="bt"
             key={`heading-${uuid()}`}
             width={width}>
-            {headerIndex === 0 && (
+            {checkboxes && headerIndex === 0 && (
               <CellPrefix>
                 <span className="ph2">
                   <CellPrefix.Checkbox
-                    checked={isChecked(itemTree)}
-                    partial={isPartiallyChecked(itemTree)}
-                    onClick={() => toggle(itemTree)}
+                    checked={checkboxes.isChecked(items)}
+                    partial={checkboxes.isPartiallyChecked(items)}
+                    onClick={() => checkboxes.toggle(items)}
                   />
                 </span>
               </CellPrefix>

--- a/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  FC,
-  useState,
-  useContext,
-  createContext,
-  useCallback,
-} from 'react'
+import React, { FC } from 'react'
 import uuid from 'uuid'
 
 import CellPrefix from './CellPrefix'
@@ -15,11 +9,12 @@ import { Item } from '../hooks/useTableTreeCheckboxes'
 
 const Node: FC<NodeProps> = ({ data, depth }) => {
   const { visibleColumns, unicityKey, rowHeight } = useTableContext()
-  const { toggle, isChecked, isPartiallyChecked } = useCheckboxesContext()
+  const checkboxes = useCheckboxesContext()
   const { toggleCollapsed, isCollapsed, nodesKey } = useTreeContext()
 
-  const isRowChecked = isChecked(data)
-  const isRowPartiallyChecked = isPartiallyChecked(data)
+  const isRowChecked = checkboxes && checkboxes.isChecked(data)
+  const isRowPartiallyChecked =
+    checkboxes && checkboxes.isPartiallyChecked(data)
   const isRowSelected = isRowChecked || isRowPartiallyChecked
 
   const renderPrefix = (hasChild?: boolean) => (
@@ -30,13 +25,15 @@ const Node: FC<NodeProps> = ({ data, depth }) => {
           onClick={() => toggleCollapsed(data[unicityKey])}
         />
       )}
-      <span className="ph2">
-        <CellPrefix.Checkbox
-          checked={isRowChecked}
-          partial={isRowPartiallyChecked}
-          onClick={() => toggle(data)}
-        />
-      </span>
+      {checkboxes && (
+        <span className="ph2">
+          <CellPrefix.Checkbox
+            checked={isRowChecked}
+            partial={isRowPartiallyChecked}
+            onClick={() => checkboxes.toggle(data)}
+          />
+        </span>
+      )}
     </CellPrefix>
   )
 
@@ -75,9 +72,12 @@ const Node: FC<NodeProps> = ({ data, depth }) => {
 
 const Tree: FC = () => {
   const { items } = useTableContext()
+  const { nodesKey } = useTreeContext()
+  const checkboxes = useCheckboxesContext()
+  const listToRender = checkboxes ? items[nodesKey] : items
   return (
     <>
-      {items.children.map(data => (
+      {listToRender.map(data => (
         <Node key={`row-${uuid()}`} data={data} />
       ))}
     </>

--- a/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
@@ -18,7 +18,7 @@ const Node: FC<NodeProps> = ({ data, depth }) => {
   const isRowSelected = isRowChecked || isRowPartiallyChecked
 
   const renderPrefix = (hasChild?: boolean) => (
-    <CellPrefix depth={depth}>
+    <CellPrefix depth={depth} hasCheckbox={!!checkboxes}>
       {hasChild && (
         <CellPrefix.CollapseToggle
           collapsed={isCollapsed(data[unicityKey])}

--- a/react/components/EXPERIMENTAL_TableTree/contexts.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/contexts.tsx
@@ -3,9 +3,7 @@ import { checkboxesHookReturn } from './hooks/useTableTreeCheckboxes'
 import { TreeProps, TreeState } from './index'
 import useTreeState from './hooks/useTreeState'
 
-export const CheckboxesContext = createContext<Partial<checkboxesHookReturn>>(
-  {}
-)
+export const CheckboxesContext = createContext<checkboxesHookReturn>(null)
 
 export const TreeContext = createContext<Partial<TreeProps & TreeState>>({})
 

--- a/react/components/EXPERIMENTAL_TableTree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/index.tsx
@@ -12,6 +12,7 @@ import { InferProps } from 'prop-types'
 import TreeHeadings from './Tree/TreeHeadings'
 import Pagination from '../EXPERIMENTAL_Table/Pagination'
 import FilterBar from '../EXPERIMENTAL_Table/FilterBar'
+import { checkboxesHookReturn } from './hooks/useTableTreeCheckboxes'
 
 const TableTree: FC<Props> & TableComposites = ({
   children,
@@ -23,7 +24,8 @@ const TableTree: FC<Props> & TableComposites = ({
   return (
     <TableContext.Provider value={{ ...state, ...props }}>
       <TreeProvider nodesKey={nodesKey}>
-        <CheckboxesContext.Provider value={{ ...checkboxes }}>
+        <CheckboxesContext.Provider
+          value={checkboxes ? { ...checkboxes } : null}>
           <TableContainer>
             {children}
             <DataTable>
@@ -70,6 +72,7 @@ const propTypes = {
   ...tablePropTypes,
   ...checkboxesPropTypes,
 }
+
 type Props = InferProps<typeof propTypes>
 
 TableTree.Toolbar = Toolbar
@@ -79,6 +82,7 @@ TableTree.propTypes = propTypes
 
 export type TreeProps = {
   nodesKey?: string
+  checkboxes?: checkboxesHookReturn
 }
 
 export type TreeState = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

The `TableTree` may work without checkboxes.

#### How should this be manually tested?
Clone the repo and: `yarn && yarn start`

#### Screenshots or example usage
WIP

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
