### PR TITLE
Add `fixed` option to make Bulk Actions bar sticky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `Fixed` option to bulk actions for a sticky behaviour
+
 ## [9.87.3] - 2019-10-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.88.0] - 2019-10-15
+
 ### Added
 
 - `Fixed` option to bulk actions for a sticky behaviour

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.87.3",
+  "version": "9.88.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.87.3",
+  "version": "9.88.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/BulkActions.js
+++ b/react/components/Table/BulkActions.js
@@ -11,6 +11,7 @@ import Close from '../icon/Close'
 import BulkActionsSelectedRows from './BulkActionsSelectedRows'
 import { TABLE_CONTENT_CLASS } from './SimpleTable'
 
+const DEFAULT_BAR_HEIGHT_PX = '56px'
 const close = <Close />
 
 class BulkActions extends PureComponent {
@@ -18,13 +19,13 @@ class BulkActions extends PureComponent {
     super(props)
 
     this.state = {
-      sticky: false,
+      isStickingToTop: false,
     }
   }
 
   handleStickyChange = status => {
     this.setState({
-      sticky: status.status === Sticky.STATUS_FIXED,
+      isStickingToTop: status.status === Sticky.STATUS_FIXED,
     })
   }
 
@@ -59,14 +60,14 @@ class BulkActions extends PureComponent {
           className={classNames(
             'flex flex-row justify-between bg-action-primary c-on-action-primary ph4',
             {
-              pv4: hasRowsSelected,
-              'shadow-4': hasRowsSelected && this.state.sticky,
-              'br3 br--top': !this.state.sticky,
+              'pv4 overflow-auto': hasRowsSelected,
+              'overflow-hidden': !hasRowsSelected,
+              'shadow-4': hasRowsSelected && this.state.isStickingToTop,
+              'br3 br--top': !this.state.isStickingToTop,
             }
           )}
           style={{
-            height: hasRowsSelected ? '56px' : 0,
-            overflow: hasRowsSelected ? 'auto' : 'hidden',
+            height: hasRowsSelected ? DEFAULT_BAR_HEIGHT_PX : 0,
             transition: 'height 0.2s ease-in-out, padding 0.2s ease-in-out',
           }}>
           {hasBulkActions && (

--- a/react/components/Table/BulkActions.js
+++ b/react/components/Table/BulkActions.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import Sticky from 'react-stickynode'
 
 import Button from '../Button'
 import ButtonWithIcon from '../ButtonWithIcon'
@@ -8,10 +9,25 @@ import ActionMenu from '../ActionMenu'
 import Close from '../icon/Close'
 
 import BulkActionsSelectedRows from './BulkActionsSelectedRows'
+import { TABLE_CONTENT_CLASS } from './SimpleTable'
 
 const close = <Close />
 
 class BulkActions extends PureComponent {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      sticky: false,
+    }
+  }
+
+  handleStickyChange = status => {
+    this.setState({
+      sticky: status.status === Sticky.STATUS_FIXED,
+    })
+  }
+
   render() {
     const {
       hasPrimaryBulkAction,
@@ -26,85 +42,95 @@ class BulkActions extends PureComponent {
     const hasBulkActions = hasPrimaryBulkAction || hasSecondaryBulkActions
     const selectedRowsLength = selectedRows.length
     const hasRowsSelected = selectedRowsLength > 0
+    const fixed = bulkActions && bulkActions.fixed
 
     const bulkActionsReturnedParameters = allLinesSelected
       ? { allLinesSelected: true }
       : { selectedRows }
 
     return (
-      <div
-        className={classNames(
-          'flex flex-row justify-between bg-action-primary c-on-action-primary br3 br--top ph4',
-          {
-            pv4: hasRowsSelected,
-          }
-        )}
-        style={{
-          height: hasRowsSelected ? '56px' : 0,
-          overflow: hasRowsSelected ? 'auto' : 'hidden',
-          transition: 'height 0.2s ease-in-out, padding 0.2s ease-in-out',
-        }}>
-        {hasBulkActions && (
-          <div className="flex flex-row">
-            {hasPrimaryBulkAction && (
-              <div className="mr4">
-                <Button
-                  variation="secondary"
-                  size="small"
-                  onClick={() =>
-                    bulkActions.main.handleCallback(
-                      bulkActionsReturnedParameters
-                    )
-                  }>
-                  {bulkActions.main.label}
-                </Button>
-              </div>
-            )}
-            {hasSecondaryBulkActions && (
-              <ActionMenu
-                label={bulkActions.texts.secondaryActionsLabel}
-                buttonProps={{ variation: 'secondary', size: 'small' }}
-                options={bulkActions.others.map(el => ({
-                  label: el.label,
-                  isDangerous: el.isDangerous,
-                  onClick: () =>
-                    el.handleCallback(bulkActionsReturnedParameters),
-                }))}
-              />
-            )}
-          </div>
-        )}
-        <div className="tr flex flex-row items-center">
-          {!allLinesSelected && bulkActions && bulkActions.texts && (
-            <span className="mr4 c-muted-4">
-              {bulkActions.texts.rowsSelected(
-                <BulkActionsSelectedRows
-                  selectedRowsLength={selectedRowsLength}
+      <Sticky
+        enabled={fixed && hasRowsSelected}
+        innerZ="1"
+        activeClass="shadow-4"
+        bottomBoundary={`.${TABLE_CONTENT_CLASS}`}
+        onStateChange={this.handleStickyChange}>
+        <div
+          className={classNames(
+            'flex flex-row justify-between bg-action-primary c-on-action-primary ph4',
+            {
+              pv4: hasRowsSelected,
+              'shadow-4': hasRowsSelected && this.state.sticky,
+              'br3 br--top': !this.state.sticky,
+            }
+          )}
+          style={{
+            height: hasRowsSelected ? '56px' : 0,
+            overflow: hasRowsSelected ? 'auto' : 'hidden',
+            transition: 'height 0.2s ease-in-out, padding 0.2s ease-in-out',
+          }}>
+          {hasBulkActions && (
+            <div className="flex flex-row">
+              {hasPrimaryBulkAction && (
+                <div className="mr4">
+                  <Button
+                    variation="secondary"
+                    size="small"
+                    onClick={() =>
+                      bulkActions.main.handleCallback(
+                        bulkActionsReturnedParameters
+                      )
+                    }>
+                    {bulkActions.main.label}
+                  </Button>
+                </div>
+              )}
+              {hasSecondaryBulkActions && (
+                <ActionMenu
+                  label={bulkActions.texts.secondaryActionsLabel}
+                  buttonProps={{ variation: 'secondary', size: 'small' }}
+                  options={bulkActions.others.map(el => ({
+                    label: el.label,
+                    isDangerous: el.isDangerous,
+                    onClick: () =>
+                      el.handleCallback(bulkActionsReturnedParameters),
+                  }))}
                 />
               )}
-            </span>
+            </div>
           )}
-          {bulkActions &&
-            bulkActions.texts &&
-            bulkActions.texts.selectAll &&
-            bulkActions.texts.allRowsSelected && (
-              <span className="mr2">
-                {allLinesSelected ? (
-                  bulkActions.texts.allRowsSelected(
-                    <span className="b">{bulkActions.totalItems}</span>
-                  )
-                ) : (
-                  <Button onClick={() => onSelectAllLines()}>
-                    <span className="ttu">
-                      {`${bulkActions.texts.selectAll} ${bulkActions.totalItems}`}
-                    </span>
-                  </Button>
+          <div className="tr flex flex-row items-center">
+            {!allLinesSelected && bulkActions && bulkActions.texts && (
+              <span className="mr4 c-muted-4">
+                {bulkActions.texts.rowsSelected(
+                  <BulkActionsSelectedRows
+                    selectedRowsLength={selectedRowsLength}
+                  />
                 )}
               </span>
             )}
-          <ButtonWithIcon icon={close} onClick={() => onDeselectAllLines()} />
+            {bulkActions &&
+              bulkActions.texts &&
+              bulkActions.texts.selectAll &&
+              bulkActions.texts.allRowsSelected && (
+                <span className="mr2">
+                  {allLinesSelected ? (
+                    bulkActions.texts.allRowsSelected(
+                      <span className="b">{bulkActions.totalItems}</span>
+                    )
+                  ) : (
+                    <Button onClick={() => onSelectAllLines()}>
+                      <span className="ttu">
+                        {`${bulkActions.texts.selectAll} ${bulkActions.totalItems}`}
+                      </span>
+                    </Button>
+                  )}
+                </span>
+              )}
+            <ButtonWithIcon icon={close} onClick={() => onDeselectAllLines()} />
+          </div>
         </div>
-      </div>
+      </Sticky>
     )
   }
 }

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -21,6 +21,7 @@ const NO_TITLE_COLUMN = ' '
 const SELECTED_ROW_BACKGROUND = '#dbe9fd'
 const DEFAULT_SCROLLBAR_WIDTH = 17
 const EMPTY_STATE_SIZE_IN_ROWS = 5
+export const TABLE_CONTENT_CLASS = 'vtex-table__content'
 
 class SimpleTable extends Component {
   constructor(props) {
@@ -187,7 +188,9 @@ class SimpleTable extends Component {
     const tableHeight = containerHeight || this.calculateContainerHeight()
 
     return (
-      <div className="vh-100 w-100 dt" style={{ height: tableHeight }}>
+      <div
+        className={`vh-100 w-100 dt ${TABLE_CONTENT_CLASS}`}
+        style={{ height: tableHeight }}>
         {loading ? (
           <div
             className="dtc v-mid tc"

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -453,6 +453,7 @@ Table.propTypes = {
         handleCallback: PropTypes.func.isRequired,
       })
     ),
+    fixed: PropTypes.bool,
   }),
   /** Totalizers property  */
   totalizers: PropTypes.array,

--- a/react/package.json
+++ b/react/package.json
@@ -11,6 +11,7 @@
     "react-overlays": "^1.1.2",
     "react-responsive-modal": "^3.1.0",
     "react-select": "^2.1.2",
+    "react-stickynode": "^2.1.1",
     "react-virtualized": "^9.19.1",
     "uuid": "^3.3.2",
     "vtex-tachyons": "^2.10.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -418,7 +418,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5, classnames@^2.2.6:
+classnames@^2.0.0, classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -663,6 +663,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+eventemitter3@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -1193,7 +1198,7 @@ linear-layout-vector@0.0.1:
   resolved "https://registry.yarnpkg.com/linear-layout-vector/-/linear-layout-vector-0.0.1.tgz#398114d7303b6ecc7fd6b273af7b8401d8ba9c70"
   integrity sha1-OYEU1zA7bsx/1rJzr3uEAdi6nHA=
 
-lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.13:
+lodash@^4.0.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -1601,7 +1606,7 @@ prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1,
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-raf@^3.4.0:
+raf@^3.0.0, raf@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -1763,6 +1768,16 @@ react-select@^2.1.2:
     raf "^3.4.0"
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
+
+react-stickynode@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-stickynode/-/react-stickynode-2.1.1.tgz#1d5160641c72b1a954c872b26130919cb1ce4a78"
+  integrity sha512-yzY1mE8QYCdrg4zpmHYfe5ZaE4VF63VpbgboLntdKnQG98bNlGDXDY9vpt/3O4uIEoddeL0zBtXU2I0LyLMzFw==
+  dependencies:
+    classnames "^2.0.0"
+    prop-types "^15.6.0"
+    shallowequal "^1.0.0"
+    subscribe-ui-event "^2.0.0"
 
 react-transition-group@^2.2.1, react-transition-group@^2.4.0:
   version "2.9.0"
@@ -1943,6 +1958,11 @@ setimmediate@^1.0.5:
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
+shallowequal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -2081,6 +2101,15 @@ stylis@^3.5.0:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
+
+subscribe-ui-event@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/subscribe-ui-event/-/subscribe-ui-event-2.0.5.tgz#f276d8eae3f82b640e69d7b9d55f7334f9ec67ec"
+  integrity sha512-1DasqBzDgTbkj2Yu0F8atPB6ouvvM5EdUm6zPONO8IZXVr97ommJFTp1yX/HMW5qYw/nc0huJ7r6VkeqixAdgA==
+  dependencies:
+    eventemitter3 "^3.0.0"
+    lodash "^4.17.10"
+    raf "^3.0.0"
 
 tabbable@^3.1.0:
   version "3.1.2"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add an option to make the Bulk Actions bar sticky, so that a long selection of rows can maintain the bulk actions visible while the user scrolls to the bottom of the table it is associated with.

#### What problem is this solving?
Long table lists tend to hide the bulk actions bar when the user is scrolling down.

#### How should this be manually tested?
You can check the proposed feature in this [running workspace](https://artur--partnerchallenge26.myvtex.com/admin/received-skus/pending). Or if you want to check this out manually, you may
1. Pull this branch and link the app.
2. Make a table with a considerable amount of lines and, in your `bulkActions` options, use `fixed: true`.

#### Screenshots or example usage
None

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
