### PR TITLE
Allow grouping conditions subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- **Conditions** `group` property to contract. This allows conditions subject to be grouped by the given string value.
+
 ## [9.89.0] - 2019-10-24
 
 ## [9.88.5] - 2019-10-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [9.89.0] - 2019-10-24
 
+### Added
+
+- vtex-tachyons mention in non-io docs
+
 ## [9.88.5] - 2019-10-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.90.0] - 2019-10-24
+
 - **Conditions** `group` property to contract. This allows conditions subject to be grouped by the given string value.
 - **Select** grouping options documentation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 - **Conditions** `group` property to contract. This allows conditions subject to be grouped by the given string value.
+- **Select** grouping options documentation.
 
 ## [9.89.0] - 2019-10-24
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.89.0",
+  "version": "9.90.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.89.0",
+  "version": "9.90.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Conditions/README.md
+++ b/react/components/Conditions/README.md
@@ -546,6 +546,90 @@ class ComplexConditionsCase extends React.Component {
 ;<ComplexConditionsCase />
 ```
 
+Grouped
+
+```js
+const Input = require('../Input').default
+
+function SimpleInputObject({ value, onChange }) {
+  return <Input value={value || ''} onChange={e => onChange(e.target.value)} />
+}
+
+class GroupedConditionsCase extends React.Component {
+  constructor() {
+    super()
+
+    this.state = {
+      simpleStatements: [],
+      operator: 'all',
+    }
+
+    this.handleToggleOperator = this.handleToggleOperator.bind(this)
+  }
+
+  handleToggleOperator(operator) {
+    this.setState({ operator: this.state.operator === 'all' ? 'any' : 'all' })
+  }
+
+  render() {
+    const options = {
+      name: {
+        label: 'User name',
+        group: 'Group 1',
+        unique: true,
+        verbs: [
+          {
+            label: 'is',
+            value: '=',
+            object: props => <SimpleInputObject {...props} />,
+          },
+        ],
+      },
+      lastname: {
+        label: 'Last name',
+        group: 'Group 1',
+        unique: true,
+        verbs: [
+          {
+            label: 'is',
+            value: '=',
+            object: props => <SimpleInputObject {...props} />,
+          },
+        ],
+      },
+      email: {
+        label: 'Email',
+        group: 'Group 2',
+        unique: true,
+        verbs: [
+          {
+            label: 'contains',
+            value: 'contains',
+            object: props => <SimpleInputObject {...props} />,
+          },
+        ],
+      },
+    }
+
+    return (
+      <Conditions
+        canDelete
+        onChangeOperator={this.handleToggleOperator}
+        onChangeStatements={statements => {
+          console.log('Changed statements to:', statements)
+          this.setState({ simpleStatements: statements })
+        }}
+        operator={this.state.operator}
+        options={options}
+        subjectPlaceholder="Select subject"
+        statements={this.state.simpleStatements}
+      />
+    )
+  }
+}
+;<GroupedConditionsCase />
+```
+
 RTL example
 
 ```js

--- a/react/components/Conditions/index.tsx
+++ b/react/components/Conditions/index.tsx
@@ -9,8 +9,9 @@ import Separator from './Separator'
 import StrategySelector from './StrategySelector'
 import Statement from '../Statement/index'
 
-import { Labels, Operator } from "./typings";
-import { DEFAULT_LABELS, MEDIUM_ICON_SIZE } from './constants';
+import { Labels, Operator } from './typings'
+import { DEFAULT_LABELS, MEDIUM_ICON_SIZE } from './constants'
+import { SubjectOptions } from '../Statement/Atoms/SubjectAtom'
 
 type Props = {
   canDelete?: boolean
@@ -20,7 +21,7 @@ type Props = {
   onChangeStatements: (statement: Props['statements']) => void
   onChangeOperator: (operator: Props['operator']) => void
   operator: Operator
-  options: object
+  options: SubjectOptions
   hideOperator?: boolean
   statements: {
     subject: string
@@ -83,11 +84,8 @@ const Conditions: React.FC<Props> = ({
   }
 
   const handleUpdatestatement = (newStatement, statementIndex) => {
-    const newStatements = statements.map(
-      (statement, idx) =>
-        idx === statementIndex
-          ? newStatement
-          : statement
+    const newStatements = statements.map((statement, idx) =>
+      idx === statementIndex ? newStatement : statement
     )
     onChangeStatements(newStatements)
   }
@@ -100,9 +98,7 @@ const Conditions: React.FC<Props> = ({
             isRtl={isRtl}
             operator={operator}
             labels={labels}
-            onChangeOperator={operator =>
-              onChangeOperator(operator)
-            }
+            onChangeOperator={operator => onChangeOperator(operator)}
           />
         </div>
       )}
@@ -113,7 +109,9 @@ const Conditions: React.FC<Props> = ({
             <Statement
               isRtl={isRtl}
               isFullWidth={isFullWidth}
-              onChangeStatement={newStatement => onChangeStatements([newStatement])}
+              onChangeStatement={newStatement =>
+                onChangeStatements([newStatement])
+              }
               options={options}
               subjectPlaceholder={subjectPlaceholder}
             />
@@ -153,13 +151,11 @@ const Conditions: React.FC<Props> = ({
                     statement={statement}
                   />
                 </div>,
-                (canDelete &&
+                canDelete &&
                   (!isFullWidth ? (
                     <div
                       className="ma3 c-muted-2 pointer hover-c-danger"
-                      onClick={() =>
-                        handleRemoveStatement(statementIndex)
-                      }>
+                      onClick={() => handleRemoveStatement(statementIndex)}>
                       <IconClose size={25} />
                     </div>
                   ) : (
@@ -169,14 +165,11 @@ const Conditions: React.FC<Props> = ({
                         collapseRight
                         size="small"
                         icon={<IconClose className="c-on-action-primary" />}
-                        onClick={() =>
-                          handleRemoveStatement(statementIndex)
-                        }>
-                          {labels.delete || DEFAULT_LABELS.delete}
+                        onClick={() => handleRemoveStatement(statementIndex)}>
+                        {labels.delete || DEFAULT_LABELS.delete}
                       </ButtonWithIcon>
                     </div>
-                  ))
-                ),
+                  )),
               ]
 
               return (
@@ -189,9 +182,7 @@ const Conditions: React.FC<Props> = ({
                         ? 'flex-column items-strech'
                         : 'flex-row items-center'
                     }`}>
-
                     {isRtl ? statementContent.reverse() : statementContent}
-
                   </div>
 
                   {statementIndex !== statements.length - 1 && (

--- a/react/components/Conditions/index.tsx
+++ b/react/components/Conditions/index.tsx
@@ -245,7 +245,7 @@ Conditions.propTypes = {
   /** Operator indicates whether all the statements should be met or any of them */
   operator: PropTypes.oneOf(['all', 'any']),
   /** Possible options and respective data types, verb options */
-  options: PropTypes.object.isRequired,
+  options: PropTypes.any.isRequired,
   /** Show or hide the header that selects the operator (any vs all) */
   hideOperator: PropTypes.bool,
   /** one statement = {subject: string, verb: string, object: unknown, error: string} */

--- a/react/components/EXPERIMENTAL_Select/README.md
+++ b/react/components/EXPERIMENTAL_Select/README.md
@@ -1,5 +1,21 @@
 #### A Select lets the user pick one or more options from a list.
 
+### Options
+
+The options prop accepts the following types:
+
+```ts
+type Options = {
+  label: string
+  value: string | {}
+}[]
+
+type GroupedOptions = {
+  label: string
+  options: Options
+}
+```
+
 ### 👍 Dos
 
 - Mind the order of the options, like putting the more probable one to be selected at the top. In doubt, sort them alphanumerically (from A to Z and from 0 to 9).

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -208,6 +208,13 @@ const OptionShape = PropTypes.shape({
 
 const OptionsShape = PropTypes.arrayOf(OptionShape)
 
+const GroupedOptionsShape = PropTypes.arrayOf(
+  PropTypes.shape({
+    label: PropTypes.string,
+    options: OptionsShape,
+  })
+)
+
 Select.propTypes = {
   /** @ignore Forwarded Ref */
   forwardedRef: refShape,
@@ -244,7 +251,7 @@ Select.propTypes = {
   /** Handle events on search input */
   onSearchInputChange: PropTypes.func,
   /** Array of options. Options have the shape { label, value }. */
-  options: OptionsShape,
+  options: PropTypes.oneOfType([OptionsShape, GroupedOptionsShape]),
   /** Text for the select value.  */
   placeholder: PropTypes.string,
   /** Select size */

--- a/react/components/Statement/Atoms/ObjectAtom.tsx
+++ b/react/components/Statement/Atoms/ObjectAtom.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import Input from '../../Input/index'
 
-export type RenderProps = {
+export type ObjectOption = (renderProps: RenderProps) => React.ReactElement
+
+type RenderProps = {
   error: Props['error']
   onChange: Props['onChange']
   value: Props['object']
@@ -18,7 +19,7 @@ type Props = {
   /** Object Value changed callback */
   onChange: (value: Props['object'], error?: Props['error']) => void
   /** Possible options and respective data types, verb options */
-  renderObject: (renderProps: RenderProps) => React.ReactElement
+  renderObject: ObjectOption
 }
 
 const EmptyObjectAtom = () => (

--- a/react/components/Statement/Atoms/VerbAtom.tsx
+++ b/react/components/Statement/Atoms/VerbAtom.tsx
@@ -1,28 +1,24 @@
 import React from 'react'
 import Select from '../../EXPERIMENTAL_Select/index'
-import PropTypes from 'prop-types'
-import { withForwardedRef, refShape } from '../../../modules/withForwardedRef'
 
-const propTypes = {
-  /** @ignore Forwarded Ref */
-  forwardedRef: refShape,
-  /** Select disabled state */
-  disabled: PropTypes.bool,
-  /** Stretch component to 100% of the width */
-  isFullWidth: PropTypes.bool,
-  /** Current selected verb for this Statement */
-  verb: PropTypes.string,
-  /** Possible options and respective data types, verb options */
-  verbOptions: PropTypes.array.isRequired,
-  /** Value changed callback */
-  onChange: PropTypes.func.isRequired,
+import { ObjectOption } from './ObjectAtom'
+
+export type VerbOption = {
+  label: string
+  value: string
+  object: ObjectOption
 }
 
-type Props = PropTypes.InferProps<typeof propTypes>
+type Props = {
+  disabled?: boolean
+  isFullWidth?: boolean
+  verb?: string
+  verbOptions: VerbOption[]
+  onChange: (string) => void
+}
 
 const VerbAtom: React.FC<Props> = ({
   disabled,
-  forwardedRef,
   isFullWidth,
   onChange,
   verb,
@@ -37,7 +33,6 @@ const VerbAtom: React.FC<Props> = ({
       {verbOptions.length !== 1 ? (
         <div className="flex-auto">
           <Select
-            ref={forwardedRef}
             clearable={false}
             disabled={disabled}
             multi={false}
@@ -54,4 +49,4 @@ const VerbAtom: React.FC<Props> = ({
   )
 }
 
-export default withForwardedRef(VerbAtom)
+export default VerbAtom

--- a/react/components/Statement/index.tsx
+++ b/react/components/Statement/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import SubjectAtom from './Atoms/SubjectAtom'
+import SubjectAtom, { SubjectOptions } from './Atoms/SubjectAtom'
 import VerbAtom from './Atoms/VerbAtom'
 import ObjectAtom from './Atoms/ObjectAtom'
 
@@ -10,7 +10,7 @@ type Props = {
   omitSubject?: boolean
   omitVerbs?: boolean
   onChangeStatement: (statement: Props['statement']) => void
-  options: object
+  options: SubjectOptions
   statement?: {
     subject: string
     verb: string
@@ -30,7 +30,6 @@ const Statement: React.FC<Props> = ({
   statement = { subject: '', verb: '', object: null, error: null },
   subjectPlaceholder,
 }) => {
-
   const statementAtoms = [
     !omitSubject && (
       <SubjectAtom
@@ -66,9 +65,7 @@ const Statement: React.FC<Props> = ({
           onChangeStatement(newStatement)
         }}
         verb={statement.verb}
-        verbOptions={
-          statement.subject ? options[statement.subject].verbs : []
-        }
+        verbOptions={statement.subject ? options[statement.subject].verbs : []}
       />
     ),
     <ObjectAtom
@@ -85,28 +82,27 @@ const Statement: React.FC<Props> = ({
         onChangeStatement(newStatement)
       }}
       renderObject={
-        statement.subject && options[statement.subject].verbs.find(
+        statement.subject &&
+        options[statement.subject].verbs.find(
           verb => verb.value === statement.verb
         ).object
       }
     />,
   ]
 
-    return (
-      <div className="flex-column w-100 mv3">
-        <div
-          className={`flex w-100 items-center ${
-            isFullWidth ? 'flex-column items-stretch' : ''
-          }`}>
-          {isRtl ? statementAtoms.reverse() : statementAtoms}
-        </div>
-        {statement.error && (
-          <div className="red t-small mh3 mt2 lh-title">
-            {statement.error}
-          </div>
-        )}
+  return (
+    <div className="flex-column w-100 mv3">
+      <div
+        className={`flex w-100 items-start ${
+          isFullWidth ? 'flex-column items-stretch' : ''
+        }`}>
+        {isRtl ? statementAtoms.reverse() : statementAtoms}
       </div>
-    )
+      {statement.error && (
+        <div className="red t-small mh3 mt2 lh-title">{statement.error}</div>
+      )}
+    </div>
+  )
 }
 
 export default Statement

--- a/react/components/Statement/typings.d.ts
+++ b/react/components/Statement/typings.d.ts
@@ -1,0 +1,18 @@
+export type SelectOption<T> = {
+  label: string
+  value: T
+}
+
+export type SelectOptionGroup = {
+  label: string
+  options: SelectOption[]
+}
+
+export type GroupedOptions = {
+  [group: string]: SelectOption[]
+}
+
+export type SelectedOption = {
+  group: SelectOptionGroup['label']
+  option: SelectOption
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow developers to group their conditions subjects.

#### What problem is this solving?
When we had too many subjects it was really hard to find the wanted option. Sometimes we had to use a part of the subject in the verb to overcome this problem (see the image below for an example).

![image](https://user-images.githubusercontent.com/5971264/66854113-141aba80-ef57-11e9-896a-5f736b6a135f.png)

#### How should this be manually tested?
[Running workspace](http://10.1.14.209:6060/)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5971264/66853871-a078ad80-ef56-11e9-9ee1-f48a2a86464b.png)

