### PR TITLE
Fix FilterBar statements defaultProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **FilterBar** `statement` must be an empty array in `defaultProps`.
+
 ## [9.88.1] - 2019-10-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.88.2] - 2019-10-16
+
 ### Fixed
 
 - **FilterBar** `statement` must be an empty array in `defaultProps`.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.88.1",
+  "version": "9.88.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.88.1",
+  "version": "9.88.2",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/FilterBar/index.js
+++ b/react/components/FilterBar/index.js
@@ -195,6 +195,7 @@ FilterBar.defaultProps = {
   subjectPlaceholder: 'Select a filter…',
   submitFilterLable: 'Apply',
   newFilterLable: 'New Filter',
+  statements: [],
 }
 
 export const filterBarPropTypes = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

It's not a required prop, so it needs a `defaultProp` or a safe usage. `defaultProps` are more elegant.

#### What problem is this solving?

When not passing the `statements` prop, the component breaks.

#### How should this be manually tested?

To see the problem:
- Access the [Styleguide](https://styleguide.vtex.com/#/Components/Display/FilterBar)
- Edit one of the examples and delete a `statements={something}` statement in the component declaration.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/66858913-a4a9c880-ef60-11e9-8b70-6d4fe39d0501.png)

![image](https://user-images.githubusercontent.com/15948386/66858943-b3907b00-ef60-11e9-8c13-f2f000446659.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
