### PR TITLE
Fix verb atom behavior when there's only one option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **FilterBar** `VerbAtom` behavior when there is only one verb option to show a `span` tag instead of a `Select`.
+
 ## [9.88.3] - 2019-10-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.88.4] - 2019-10-18
+
 ### Fixed
 
 - **FilterBar** `VerbAtom` behavior when there is only one verb option to show a `span` tag instead of a `Select`.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.88.3",
+  "version": "9.88.4",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.88.3",
+  "version": "9.88.4",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Statement/Atoms/ObjectAtom.tsx
+++ b/react/components/Statement/Atoms/ObjectAtom.tsx
@@ -22,7 +22,7 @@ type Props = {
 }
 
 const EmptyObjectAtom = () => (
-  <div className="flex-auto mh3 mb3">
+  <div className="flex-auto mh3">
     <Input disabled />
   </div>
 )

--- a/react/components/Statement/Atoms/VerbAtom.tsx
+++ b/react/components/Statement/Atoms/VerbAtom.tsx
@@ -30,7 +30,6 @@ const VerbAtom: React.FC<Props> = ({
 }) => {
   const value = verbOptions.find(option => option.value === verb)
 
-  console.log(value)
   return (
     <div
       className={`mh3 ${isFullWidth ? 'pb3' : ''} flex justify-center`}

--- a/react/components/Statement/Atoms/VerbAtom.tsx
+++ b/react/components/Statement/Atoms/VerbAtom.tsx
@@ -30,20 +30,27 @@ const VerbAtom: React.FC<Props> = ({
 }) => {
   const value = verbOptions.find(option => option.value === verb)
 
+  console.log(value)
   return (
     <div
-      className={`mh3 ${isFullWidth ? 'pb3' : ''}`}
+      className={`mh3 ${isFullWidth ? 'pb3' : ''} flex justify-center`}
       style={{ minWidth: '20%' }}>
-      <Select
-        ref={forwardedRef}
-        clearable={false}
-        disabled={disabled}
-        multi={false}
-        onChange={option => onChange(option && option.value)}
-        options={verbOptions}
-        placeholder=""
-        value={value}
-      />
+      {verbOptions.length !== 1 ? (
+        <div className="flex-auto">
+          <Select
+            ref={forwardedRef}
+            clearable={false}
+            disabled={disabled}
+            multi={false}
+            onChange={option => onChange(option && option.value)}
+            options={verbOptions}
+            placeholder=""
+            value={value}
+          />
+        </div>
+      ) : (
+        <span>{value.label}</span>
+      )}
     </div>
   )
 }

--- a/react/components/Statement/Atoms/VerbAtom.tsx
+++ b/react/components/Statement/Atoms/VerbAtom.tsx
@@ -32,8 +32,8 @@ const VerbAtom: React.FC<Props> = ({
 
   return (
     <div
-      className={`mh3 ${isFullWidth ? 'pb3' : ''} flex justify-center`}
-      style={{ minWidth: '20%' }}>
+      className={`mh3 ${isFullWidth ? 'pb3' : ''} flex items-center`}
+      style={verbOptions.length !== 1 ? { minWidth: '20%' } : {}}>
       {verbOptions.length !== 1 ? (
         <div className="flex-auto">
           <Select

--- a/react/components/Statement/index.tsx
+++ b/react/components/Statement/index.tsx
@@ -95,7 +95,7 @@ const Statement: React.FC<Props> = ({
     return (
       <div className="flex-column w-100 mv3">
         <div
-          className={`flex w-100 items-start ${
+          className={`flex w-100 items-center ${
             isFullWidth ? 'flex-column items-stretch' : ''
           }`}>
           {isRtl ? statementAtoms.reverse() : statementAtoms}


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says. When there is only one option, it should show a `span` tag instead of a `Select` option.

#### What problem is this solving?

![image](https://user-images.githubusercontent.com/15948386/67022745-16585280-f0d8-11e9-9ade-df9c57815e2f.png)


#### How should this be manually tested?

Clone the repository, checkout to this branch and run `yarn && yarn styleguide`.

#### Screenshots or example usage

##### Solution

![image](https://user-images.githubusercontent.com/15948386/67022765-22dcab00-f0d8-11e9-89fa-c8d920355e75.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
