### PR TITLE
Make Select accept an array of options as the defaultValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.88.3] - 2019-10-17
+
 ### Fixed
 
 - **Select** `defaultValue` warning when receiving an array of options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Select** `defaultValue` warning when receiving an array of options.
+
 ## [9.88.2] - 2019-10-16
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.88.2",
+  "version": "9.88.3",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.88.2",
+  "version": "9.88.3",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -199,6 +199,15 @@ Select.defaultProps = {
   clearable: true,
 }
 
+const OptionShape = PropTypes.shape({
+  /** Text that gets rendered for the option. */
+  label: PropTypes.string.isRequired,
+  /** Underlying value, e.g., an id. */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+})
+
+const OptionsShape = PropTypes.arrayOf(OptionShape)
+
 Select.propTypes = {
   /** @ignore Forwarded Ref */
   forwardedRef: refShape,
@@ -209,7 +218,11 @@ Select.propTypes = {
   /** Creatable options. */
   creatable: PropTypes.bool,
   /** Default value */
-  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.string,
+    OptionShape,
+    OptionsShape,
+  ]),
   /** Disables Select */
   disabled: PropTypes.bool,
   /** Error message, e.g., validation error message. */
@@ -231,34 +244,13 @@ Select.propTypes = {
   /** Handle events on search input */
   onSearchInputChange: PropTypes.func,
   /** Array of options. Options have the shape { label, value }. */
-  options: PropTypes.arrayOf(
-    PropTypes.shape({
-      /** Text that gets rendered for the option. */
-      label: PropTypes.string.isRequired,
-      /** Underlying value, e.g., an id. */
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
-        .isRequired,
-    })
-  ),
+  options: OptionsShape,
   /** Text for the select value.  */
   placeholder: PropTypes.string,
   /** Select size */
   size: PropTypes.oneOf(['small', 'regular', 'large']),
   /** Value of the select. */
-  value: PropTypes.oneOfType([
-    PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
-        .isRequired,
-    }),
-    PropTypes.arrayOf(
-      PropTypes.shape({
-        label: PropTypes.string.isRequired,
-        value: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
-          .isRequired,
-      })
-    ),
-  ]),
+  value: PropTypes.oneOfType([OptionShape, OptionsShape]),
   /** Max height (in _px_) of the selected values container */
   valuesMaxHeight: PropTypes.number,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix a warning being shown when passing an array of options as the `defaultValue` of a `Select` component

#### What problem is this solving?
[Running workspace](http://link)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Testing on this [link](https://kiwi--recorrenciaqa.myvtex.com/admin/tracking-apps/vtex.totalexpress-tracking-integration/). Just click on `edit`.

#### Screenshots or example usage

Warning before:
![image](https://user-images.githubusercontent.com/12702016/67039716-4283cb80-f0f8-11e9-902f-889d557de10c.png)

Warning after:

~no image because there's no warning anymore 👀~

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
