### PR TITLE
Add width style on Modal TopBar title and fix arrow align on Collapsible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `w-100` style on `TopBar` title className from `Modal` component.
+
 ## [9.90.0] - 2019-10-24
 
 - **Conditions** `group` property to contract. This allows conditions subject to be grouped by the given string value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `w-100` style on `TopBar` title className from `Modal` component.
+- `arrowAlign` prop on `Collapsible` to allow icon position selection. 
 
 ## [9.90.0] - 2019-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.90.1] - 2019-10-24
+
 ### Added
 
 - `w-100` style on `TopBar` title className from `Modal` component.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.90.0",
+  "version": "9.90.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.90.0",
+  "version": "9.90.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Collapsible/index.js
+++ b/react/components/Collapsible/index.js
@@ -92,6 +92,7 @@ class Collapsible extends Component {
       muted,
       onClick: callback,
       isOpen,
+      arrowAlign,
     } = this.props
     let { caretColor } = this.props
     const { height } = this.state
@@ -120,7 +121,7 @@ class Collapsible extends Component {
           aria-expanded={isOpen}>
           {align === 'left' ? (
             <Fragment>
-              <div className={`${color} mr3 self-start mv4`}>
+              <div className={`${color} mr3 self-${arrowAlign}`}>
                 {isOpen ? <CaretUp /> : <CaretDown />}
               </div>
               <div className="flex-grow-1">{header}</div>
@@ -128,7 +129,7 @@ class Collapsible extends Component {
           ) : (
             <Fragment>
               <div className="flex-grow-1">{header}</div>
-              <div className={`${color} ml3 self-start mv4`}>
+              <div className={`${color} ml3  self-${arrowAlign}`}>
                 {isOpen ? <CaretUp /> : <CaretDown />}
               </div>
             </Fragment>
@@ -150,6 +151,7 @@ Collapsible.defaultProps = {
   align: 'left',
   isOpen: false,
   muted: false,
+  arrowAlign: 'center',
 }
 
 Collapsible.propTypes = {
@@ -170,6 +172,14 @@ Collapsible.propTypes = {
   onClick: PropTypes.func,
   /** Color or semantic to be applied to the Caret Icon in the Collapsible header.*/
   caretColor: PropTypes.oneOf(Object.keys(colorMap)),
+  /** Vertical position of arrow icon.*/
+  arrowAlign: PropTypes.oneOf([
+    'start',
+    'center',
+    'end',
+    'baseline',
+    'stretch',
+  ]),
 }
 
 export default Collapsible

--- a/react/components/Collapsible/index.js
+++ b/react/components/Collapsible/index.js
@@ -120,7 +120,7 @@ class Collapsible extends Component {
           aria-expanded={isOpen}>
           {align === 'left' ? (
             <Fragment>
-              <div className={`${color} mr3 self-center`}>
+              <div className={`${color} mr3 self-start mv4`}>
                 {isOpen ? <CaretUp /> : <CaretDown />}
               </div>
               <div className="flex-grow-1">{header}</div>
@@ -128,7 +128,7 @@ class Collapsible extends Component {
           ) : (
             <Fragment>
               <div className="flex-grow-1">{header}</div>
-              <div className={`${color} ml3 self-center`}>
+              <div className={`${color} ml3 self-start mv4`}>
                 {isOpen ? <CaretUp /> : <CaretDown />}
               </div>
             </Fragment>

--- a/react/components/Modal/TopBar.js
+++ b/react/components/Modal/TopBar.js
@@ -21,7 +21,7 @@ const TopBar = props => {
         ${styles.shadowTransition}
         ${showBottomShadow ? 'shadow-4' : ''}
       `}>
-      <span className="f3 c-on-base">
+      <span className="f3 c-on-base w-100">
         {title}
         {showBottomShadow}
       </span>


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
As the title says.

### TopBar
The prop `title` (`Modal` component) gets a node, usually it is only a short text, but can be a component. 
I needed to use the `InputSearch` component in Modal title 
![image](https://user-images.githubusercontent.com/20481790/67086833-0b54ff00-f178-11e9-9f6b-a657a35f7f3f.png)

but I couldn't expand input because of width from TopBar title. 

Adding width: 
![image](https://user-images.githubusercontent.com/20481790/67086807-f8dac580-f177-11e9-890f-71734cccb6dc.png)

### Collapsible
(look at  **Off-Road & All-Terrain Vehicle Protective Gear**)

When the text has a line break the arrow icon stay in the div center. 
![image](https://user-images.githubusercontent.com/20481790/67316054-28723080-f4de-11e9-8b9b-4ef4bb8dc2d3.png)


I needed to put the icon align with Radio and text. To be like that: 
![image](https://user-images.githubusercontent.com/20481790/67315904-e47f2b80-f4dd-11e9-9c57-7171c898ad39.png)

So, my idea was create a prop ( `arrowAlign`)  which allows you decide the icon position. 
The position could be `start`, `center`, `end`, `baseline` or `stretch`.  
And if you don't use the prop `arrowAlign`, the icon position will be `center`. 

#### How should this be manually tested?

Clone the repository, checkout to this branch and run yarn && yarn styleguide.

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
