### PR TITLE
[8.x] Fix SSR checking in Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.73.10] - 2019-10-21
+
 ### Fixed
 
 - **Table** SSR errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Table** SSR errors
+
 ## [8.73.9] - 2019-10-17
 
 - **Select** `defaultValue` warning when receiving an array of options.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "styleguide",
-  "version": "8.73.9",
+  "version": "8.73.10",
   "title": "VTEX Styleguide",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "8.73.9",
+  "version": "8.73.10",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -95,8 +95,11 @@ class Table extends PureComponent {
   }
 
   getScrollbarWidth = () => {
-    if (!window || !document || !document.documentElement)
+    const isSSR = typeof document === 'undefined'
+    if (isSSR) {
       return DEFAULT_SCROLLBAR_WIDTH
+    }
+
     const scrollbarWidth =
       window.innerWidth - document.documentElement.clientWidth
     return isNaN(scrollbarWidth) ? DEFAULT_SCROLLBAR_WIDTH : scrollbarWidth


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change condition for checking SSR condition in Table to `typeof document === 'undefined'` which is ReferenceError safe.

#### What problem is this solving?
_This should address issues #746 and #894 for Styleguide 8.x_

[Running workspace](https://artur--partnerchallenge26.myvtex.com/test) with a SSR-rendered table in Render 7.x

Current checking with `!document` yields a Reference Error in SSR, since this global variable is not defined outside the browser--no DOM references. Thus, a safer approach is to use `typeof`, which evaluates any symbol, even undeclared variables.

#### How should this be manually tested?
You can visit the link provided above

#### Screenshots or example usage
None

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
