### PR TITLE
Move ID attr from div to select element in Dropdown component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- ID now belongs to `<select>` element in Dropdown component.
+
 ## [9.88.5] - 2019-10-18
 
 ### Fixed

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -180,7 +180,7 @@ class Dropdown extends Component {
         <label>
           {label && <span className={labelClasses}>{label}</span>}
           <div className={containerClasses} style={containerStyle}>
-            <div id={id} className={`vtex-dropdown__button ${classes}`}>
+            <div className={`vtex-dropdown__button ${classes}`}>
               <div className={`flex ${isInline ? '' : 'h-100'}`}>
                 <div
                   className={`vtex-dropdown__caption flex-auto tl truncate ${
@@ -201,6 +201,7 @@ class Dropdown extends Component {
             </div>
 
             <select
+              id={id}
               disabled={disabled}
               className={selectClasses}
               onChange={this.handleChange}


### PR DESCRIPTION
#### What is the purpose of this pull request?

It moves `id` attribute from an component's `div` to the `select` element. 

#### What problem is this solving?

We use this attribute to improve test automation, checking the value of form's fields.

#### How should this be manually tested?

`yarn styleguide`

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
