### PR TITLE
Add staticHeight prop on Modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `staticHeight` prop on `Modal` component to allow selection of modal height and keep it static.
+
 ## [9.90.3] - 2019-10-25
 
 ### Fixed
@@ -24,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `w-100` style on `TopBar` title className from `Modal` component.
-- `arrowAlign` prop on `Collapsible` to allow icon position selection. 
+- `arrowAlign` prop on `Collapsible` to allow icon position selection.
 
 ## [9.90.0] - 2019-10-24
 

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -59,6 +59,7 @@ class Modal extends PureComponent {
       showBottomBarBorder,
       onCloseTransitionFinish,
       container,
+      staticHeight,
     } = this.props
     const { shadowBottom, shadowTop } = this.state
 
@@ -88,6 +89,8 @@ class Modal extends PureComponent {
           },
           modal: {
             padding: 0,
+            maxHeight: staticHeight,
+            minHeight: staticHeight,
           },
           closeIcon: {
             top: '8px',
@@ -169,6 +172,8 @@ Modal.propTypes = {
   showTopBar: PropTypes.bool,
   /** Event fired when the closing transition is finished */
   onCloseTransitionFinish: PropTypes.func,
+  /** Delimits modal height when a static height is needed */
+  staticHeight: PropTypes.string,
 }
 
 export default Modal

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -173,7 +173,7 @@ Modal.propTypes = {
   /** Event fired when the closing transition is finished */
   onCloseTransitionFinish: PropTypes.func,
   /** Delimits modal height when a static height is needed */
-  staticHeight: PropTypes.string,
+  staticHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 
 export default Modal


### PR DESCRIPTION
#### What is the purpose of this pull request?
as the title says. 
<!--- Describe your changes in detail. -->

#### What problem is this solving?
The modal height depends on modal content. 

![modalerrado](https://user-images.githubusercontent.com/20481790/67523641-7a08ef80-f685-11e9-8fb1-fbbcccc3d637.gif)

I needed to use a modal with a fix height. 

![modalcerto](https://user-images.githubusercontent.com/20481790/67523652-7d9c7680-f685-11e9-8abd-b42865df5aae.gif)

[Running workspace](https://minhawks--storecomponents.myvtex.com/admin/app/categories)

If you use the prop `staticHeight`, the max height and min height will be the same. 
And if you don't use the prop, the default behavior is the modal height depends on modal content. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Clone the repository, checkout to this branch and run yarn && yarn styleguide.

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
