### PR TITLE
Fix/prop name typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.90.2] - 2019-10-24
+
 ### Fixed
 
 - **FilterBar** `submitFilterLable` and `newFilterLable` prop names typos.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **FilterBar** `submitFilterLable` and `newFilterLable` prop names typos.
+
 ## [9.90.1] - 2019-10-24
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.90.1",
+  "version": "9.90.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.90.1",
+  "version": "9.90.2",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/FilterBar/FilterTag.js
+++ b/react/components/FilterBar/FilterTag.js
@@ -138,8 +138,8 @@ class FilterTag extends PureComponent {
       onClickClear,
       isMoreOptions,
       onSubmitFilterStatement,
-      submitFilterLable,
-      newFilterLable,
+      submitFilterLabel,
+      newFilterLabel,
     } = this.props
     const { isMenuOpen, virtualStatement } = this.state
 
@@ -234,7 +234,7 @@ class FilterTag extends PureComponent {
               <div
                 className={`flex flex-wrap ${isMoreOptions ? 'mb6' : 'mb3'}`}>
                 {isMoreOptions && (
-                  <span className="f4 mh3">{newFilterLable}</span>
+                  <span className="f4 mh3">{newFilterLabel}</span>
                 )}
                 <div className="flex flex-column">
                   {shouldOmitVerb && (
@@ -272,7 +272,7 @@ class FilterTag extends PureComponent {
                     this.resetVirtualStatement()
                     this.closeMenu()
                   }}>
-                  {submitFilterLable}
+                  {submitFilterLabel}
                 </Button>
               </div>
             </div>
@@ -297,7 +297,7 @@ FilterTag.defaultProps = {
   alwaysVisible: false,
   isMoreOptions: false,
   subjectPlaceholder: '…',
-  newFilterLable: '…',
+  newFilterLabel: 'New filter',
 }
 
 FilterTag.propTypes = {
@@ -310,8 +310,8 @@ FilterTag.propTypes = {
   onClickClear: PropTypes.func,
   isMoreOptions: PropTypes.bool,
   onSubmitFilterStatement: PropTypes.func.isRequired,
-  submitFilterLable: PropTypes.string.isRequired,
-  newFilterLable: PropTypes.string,
+  submitFilterLabel: PropTypes.string.isRequired,
+  newFilterLabel: PropTypes.string,
 }
 
 export default FilterTag

--- a/react/components/FilterBar/index.js
+++ b/react/components/FilterBar/index.js
@@ -225,6 +225,6 @@ FilterBar.propTypes = filterBarPropTypes
 export default deprecated({
   useNewProps: {
     submitFilterLable: 'submitFilterLabel',
-    newFilterLable: 'newFilterLabel'
-  }
+    newFilterLable: 'newFilterLabel',
+  },
 })(FilterBar)

--- a/react/components/FilterBar/index.js
+++ b/react/components/FilterBar/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import ButtonWithIcon from '../ButtonWithIcon'
 import IconClose from '../icon/Close'
+import deprecated from '../../modules/deprecated'
 
 import FilterTag from './FilterTag'
 
@@ -99,8 +100,8 @@ class FilterBar extends PureComponent {
       clearAllFiltersButtonLabel,
       statements,
       subjectPlaceholder,
-      submitFilterLable,
-      newFilterLable,
+      submitFilterLabel,
+      newFilterLabel,
     } = this.props
     const { visibleExtraOptions } = this.state
     const optionsKeys = Object.keys(options)
@@ -131,7 +132,7 @@ class FilterBar extends PureComponent {
                         '…'
                       )
                     }}
-                    submitFilterLable={submitFilterLable}
+                    submitFilterLabel={submitFilterLabel}
                     subject={subject}
                     options={options}
                     statements={statements}
@@ -148,8 +149,8 @@ class FilterBar extends PureComponent {
                 isMoreOptions
                 subjectPlaceholder={subjectPlaceholder}
                 getFilterLabel={() => moreOptionsLabel}
-                submitFilterLable={submitFilterLable}
-                newFilterLable={newFilterLable}
+                submitFilterLabel={submitFilterLabel}
+                newFilterLabel={newFilterLabel}
                 options={{
                   ...filterExtraOptions(
                     options,
@@ -193,8 +194,8 @@ FilterBar.defaultProps = {
   moreOptionsLabel: 'More',
   alwaysVisibleFilters: [],
   subjectPlaceholder: 'Select a filter…',
-  submitFilterLable: 'Apply',
-  newFilterLable: 'New Filter',
+  submitFilterLabel: 'Apply',
+  newFilterLabel: 'New Filter',
   statements: [],
 }
 
@@ -205,7 +206,7 @@ export const filterBarPropTypes = {
   statements: PropTypes.array,
   /** Filters change callback: returns array of statement definitions */
   onChangeStatements: PropTypes.func.isRequired,
-  /** lable for MORE options */
+  /** label for MORE options */
   moreOptionsLabel: PropTypes.string,
   /** filter options that are always visible outside MORE options */
   alwaysVisibleFilters: PropTypes.arrayOf(PropTypes.string),
@@ -213,12 +214,17 @@ export const filterBarPropTypes = {
   clearAllFiltersButtonLabel: PropTypes.string,
   /** Subject select placeholder inside 'More options' */
   subjectPlaceholder: PropTypes.string,
-  /** Submit button lable for statement inside FilterTag */
-  submitFilterLable: PropTypes.string,
-  /** New Filter title lable for inside the 'More options' menu */
-  newFilterLable: PropTypes.string,
+  /** Submit button label for statement inside FilterTag */
+  submitFilterLabel: PropTypes.string,
+  /** New Filter title label for inside the 'More options' menu */
+  newFilterLabel: PropTypes.string,
 }
 
 FilterBar.propTypes = filterBarPropTypes
 
-export default FilterBar
+export default deprecated({
+  useNewProps: {
+    submitFilterLable: 'submitFilterLabel',
+    newFilterLable: 'newFilterLabel'
+  }
+})(FilterBar)

--- a/react/modules/deprecated.js
+++ b/react/modules/deprecated.js
@@ -26,7 +26,9 @@ const getComponentName = target => {
 const mapNewProps = (propsMap, props) => {
   const newProps = {}
   Object.keys(propsMap).map(deprecatedProp => {
-    newProps[propsMap[deprecatedProp]] = props[deprecatedProp]
+    if (props[deprecatedProp]) {
+      newProps[propsMap[deprecatedProp]] = props[deprecatedProp]
+    }
   })
   return {
     ...props,


### PR DESCRIPTION
#### What is the purpose of this pull request?

 - Keeps backward compatibility while warning about deprecation of the props with the typo in the name.

#### What problem is this solving?
![image](https://user-images.githubusercontent.com/8530905/67522750-afacd900-f683-11e9-8975-1a47b9e00485.png)

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
