### PR TITLE
Add optional onRowHover prop to table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.90.6] - 2019-10-29
+
 ### Added
 
 - **Table** `onRowHover` optional prop.
+
+### Fixed
+
+- **Table** selectAll and allRowsSelected required warnings. These props are actually optional.
 
 ## [9.90.5] - 2019-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Table** `onRowHover` optional prop.
+
 ## [9.90.5] - 2019-10-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [9.90.6] - 2019-10-29
+## [9.90.7] - 2019-10-29
 
 ### Added
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.90.5",
+  "version": "9.90.6",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.90.6",
+  "version": "9.90.7",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.90.5",
+  "version": "9.90.6",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.90.6",
+  "version": "9.90.7",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -56,7 +56,7 @@ class SimpleTable extends Component {
   }
 
   handleRowHover = rowIndex => {
-    const { onRowClick } = this.props
+    const { onRowClick, onRowHover } = this.props
     const { isLineActionsHovered } = this.state
     if (onRowClick && !isLineActionsHovered) {
       this.setState({
@@ -67,6 +67,8 @@ class SimpleTable extends Component {
         hoverRowIndex: -1,
       })
     }
+
+    onRowHover(rowIndex)
   }
 
   calculateColWidth = (
@@ -424,6 +426,7 @@ SimpleTable.defaultProps = {
   fullWidth: false,
   dynamicRowHeight: false,
   selectedRowsIndexes: [],
+  onRowHover: () => {},
 }
 
 SimpleTable.propTypes = {
@@ -434,6 +437,7 @@ SimpleTable.propTypes = {
   density: PropTypes.string,
   disableHeader: PropTypes.bool,
   onRowClick: PropTypes.func,
+  onRowHover: PropTypes.func,
   emptyStateLabel: PropTypes.string,
   emptyStateChildren: PropTypes.node,
   sort: PropTypes.shape({

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -149,6 +149,7 @@ class Table extends PureComponent {
       emptyStateChildren,
       fixFirstColumn,
       onRowClick,
+      onRowHover,
       sort,
       onSort,
       updateTableKey,
@@ -307,6 +308,7 @@ class Table extends PureComponent {
               emptyStateChildren={emptyStateChildren}
               dynamicRowHeight={dynamicRowHeight}
               onRowClick={onRowClick}
+              onRowHover={onRowHover}
               sort={sort}
               onSort={onSort}
               key={hiddenFields.toString()}
@@ -348,6 +350,8 @@ Table.propTypes = {
   fixFirstColumn: PropTypes.bool,
   /** Callback invoked when a user clicks on a table row. ({ event: Event, index: number, rowData: any }): void */
   onRowClick: PropTypes.func,
+  /** Callback invoked when a user hovers a table row. (rowIndex): void */
+  onRowHover: PropTypes.func,
   /** Sort order and which property (key in schema) is table data sorted by. */
   sort: PropTypes.shape({
     sortOrder: PropTypes.oneOf(['ASC', 'DESC']),
@@ -439,8 +443,8 @@ Table.propTypes = {
     texts: PropTypes.shape({
       secondaryActionsLabel: PropTypes.string.isRequired,
       rowsSelected: PropTypes.func.isRequired,
-      selectAll: PropTypes.string.isRequired,
-      allRowsSelected: PropTypes.func.isRequired,
+      selectAll: PropTypes.string,
+      allRowsSelected: PropTypes.func,
     }),
     totalItems: PropTypes.number,
     onChange: PropTypes.func,


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add an optional prop `onRowHover` to table

#### What problem is this solving?
To allow devs to take action when some line is hovered, like specific changes to some cells in the hovered row.

The motivation comes from our team designer wanting some buttons to pop up only when the row is hovered.

#### How should this be manually tested?
https://anita--partnerchallenge26.myvtex.com/admin/received-skus/pending/ has an example of a table using onRowHover
click on the "Approved" tab and see another table, this time without `onRowHover`, still working properly.

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
