### PR TITLE
Update table height after rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Table** stale height on first render when using `dynamicRowHeight`.
+
 ## [9.93.0] - 2019-11-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.94.0] - 2019-11-07
+
 ### Fixed
 
 - **Table** stale height on first render when using `dynamicRowHeight`.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.93.0",
+  "version": "9.94.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.93.0",
+  "version": "9.94.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -38,6 +38,28 @@ class SimpleTable extends Component {
     })
   }
 
+  componentDidMount() {
+    this.setState({
+      tableHeight:
+        this.props.containerHeight || this.calculateContainerHeight(),
+    })
+  }
+
+  componentDidUpdate() {
+    if (!this.props.containerHeight) {
+      this.updateTableHeight()
+    }
+  }
+
+  updateTableHeight() {
+    const calculatedContainerHeight = this.calculateContainerHeight()
+    if (this.state.tableHeight !== calculatedContainerHeight) {
+      this.setState({
+        tableHeight: calculatedContainerHeight,
+      })
+    }
+  }
+
   toggleSortType = key => {
     const {
       sort: { preferentialSortOrder = 'ASC', sortOrder, sortedBy },
@@ -161,26 +183,6 @@ class SimpleTable extends Component {
     }
 
     return rawTableHeight + this.getScrollbarWidth()
-  }
-
-  componentDidMount() {
-    this.setState({
-      tableHeight:
-        this.props.containerHeight || this.calculateContainerHeight(),
-    })
-  }
-
-  componentDidUpdate() {
-    if (this.props.containerHeight) {
-      return
-    }
-
-    const calculatedContainerHeight = this.calculateContainerHeight()
-    if (this.state.tableHeight !== calculatedContainerHeight) {
-      this.setState({
-        tableHeight: calculatedContainerHeight,
-      })
-    }
   }
 
   render() {

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -28,6 +28,7 @@ class SimpleTable extends Component {
 
     this.state = {
       hoverRowIndex: -1,
+      tableHeight: 0,
     }
 
     this._cache = new CellMeasurerCache({
@@ -162,6 +163,26 @@ class SimpleTable extends Component {
     return rawTableHeight + this.getScrollbarWidth()
   }
 
+  componentDidMount() {
+    this.setState({
+      tableHeight:
+        this.props.containerHeight || this.calculateContainerHeight(),
+    })
+  }
+
+  componentDidUpdate() {
+    if (this.props.containerHeight) {
+      return
+    }
+
+    const calculatedContainerHeight = this.calculateContainerHeight()
+    if (this.state.tableHeight !== calculatedContainerHeight) {
+      this.setState({
+        tableHeight: calculatedContainerHeight,
+      })
+    }
+  }
+
   render() {
     const {
       schema,
@@ -172,7 +193,6 @@ class SimpleTable extends Component {
       emptyStateLabel,
       emptyStateChildren,
       onRowClick,
-      containerHeight,
       sort: { sortOrder, sortedBy },
       onSort,
       updateTableKey,
@@ -181,15 +201,13 @@ class SimpleTable extends Component {
       loading,
       selectedRowsIndexes,
     } = this.props
-    const { hoverRowIndex } = this.state
+    const { hoverRowIndex, tableHeight } = this.state
 
     if (lineActions)
       schema.properties = this.addLineActionsToSchema(schema, lineActions)
     const properties = Object.keys(schema.properties)
 
     const tableKey = `vtex-table--${updateTableKey}--${density}`
-
-    const tableHeight = containerHeight || this.calculateContainerHeight()
 
     return (
       <div className="vh-100 w-100 dt" style={{ height: tableHeight }}>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Recalculate table container height after cell rendering.

#### What problem is this solving?

On every first rendering of the **Table v1**, while using the `dynamicRowHeight` option, we encounter a bug in which the table's initial height is set to the default height set by its density, and then a forced update (like a user interaction with the table) is needed in order to make the table's height be the sum of the individual rows' heights.

This happens because, when using `SimpleTable`'s `calculateContainerHeight` on the render method, we failed to notice that in order to correctly calculate the height needed to fit the cell content into it, it was first necessary to let the rendering occurr, and then measure each individual cell height. Before that, the height needed for each cell is not even defined to begin with.

Therefore, we must let a first rendering occur with the default table height (`density's corresponding line height` x `#lines`) and then measure the needed line height for each cell. Since this should happen after each table update (because content can change), we place this in `componentDidUpdate` with a guard clause to prevent excessive re-rendering.

#### How should this be manually tested?
To see the problem:
1. [Visit this link](https://teste--partnerchallenge26.myvtex.com/admin/received-skus/pending)
2. Check the second option (_Meia Antiderrapante Baby Preta Florida com Laço - 9 a 12 meses_)
3. Click on the `Approve as New Product` button
4. When the modal shows up, you'll see that the rendered table has a side scrollbar. Notice that setting a `Category` or `Brand` fixes the problem.

To see the working fix:
1. [Visit this link](https://artur--partnerchallenge26.myvtex.com/admin/received-skus/pending)
2. Check the second option (_Meia Antiderrapante Baby Preta Florida com Laço - 9 a 12 meses_)
3. Click on the `Approve as New Product` button
4. When the modal shows up, you'll see that the table is now correctly rendered.

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/3827456/67814052-ddc65a80-fa81-11e9-9608-f20b63c701cd.png)

After:
![image](https://user-images.githubusercontent.com/3827456/67814024-c5564000-fa81-11e9-8f41-afcd5ee84f46.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
