### PR TITLE
Experimental Table: Handle items unicity using comparator function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `comparator` function to `EXPERIMENTAL_Table` and `EXPERIMENTAL_TableTree`.
 
+## [9.91.4] - 2019-11-05
+
 ### Added
 
 - isLoading prop to InputButton component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.91.5] - 2019-11-06
+
 ### Added
 
 - `comparator` function to `EXPERIMENTAL_Table` and `EXPERIMENTAL_TableTree`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `comparator` function to `EXPERIMENTAL_Table` and `EXPERIMENTAL_TableTree`.
+
+### Added
+
 - isLoading prop to InputButton component.
 
 ## [9.91.3] - 2019-10-31

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.91.3",
+  "version": "9.91.5",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.91.4",
+  "version": "9.91.5",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -677,8 +677,11 @@ function BulkExample() {
     ],
   }
 
+  const comparator = item => candidate => item.id === candidate.id
+
   const { bulkedColumns, isRowSelected, ...bulkData } = useTableBulkActions({
     columns,
+    comparator,
     items,
     bulkActions,
   })

--- a/react/components/EXPERIMENTAL_Table/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/index.tsx
@@ -61,10 +61,6 @@ const Table: FC<TableProps> & TableComposites = ({
   )
 }
 
-Table.defaultProps = {
-  unicityKey: 'id',
-}
-
 export const measuresPropTypes = {
   tableHeight: PropTypes.number,
   rowHeight: PropTypes.number,
@@ -75,7 +71,6 @@ export const measuresPropTypes = {
 export const tablePropTypes = {
   measures: PropTypes.shape(measuresPropTypes),
   containerHeight: PropTypes.number,
-  unicityKey: PropTypes.string,
   empty: PropTypes.bool,
   columns: PropTypes.arrayOf(
     PropTypes.shape({

--- a/react/components/EXPERIMENTAL_TableTree/README.md
+++ b/react/components/EXPERIMENTAL_TableTree/README.md
@@ -33,17 +33,117 @@ function ToolbarExample() {
     size: items.length,
   })
 
+  const comparator = item => candidate => {
+    return item.email === candidate.email
+  }
+
   return (
     <TableTree
+      comparator={comparator}
       measures={measures}
       columns={columns}
       items={items}
-      unicityKey="email"
       nodesKey="children"
     />
   )
 }
 ;<ToolbarExample />
+```
+
+#### Checkboxes
+
+```js
+const useTableMeasures = require('../EXPERIMENTAL_Table/hooks/useTableMeasures.tsx')
+  .default
+const sampleData = require('./sampleData.ts').default
+const useTableTreeCheckboxes = require('./hooks/useTableTreeCheckboxes.tsx')
+  .default
+
+// Define the columns
+const columns = [
+  {
+    id: 'name',
+    title: 'name',
+  },
+  {
+    id: 'email',
+    title: 'Email',
+  },
+  {
+    id: 'number',
+    title: 'Number',
+  },
+  {
+    id: 'country',
+    title: 'Country',
+  },
+]
+
+const items = [
+  {
+    name: "T'Chala",
+    email: 'black.panther@gmail.com',
+    number: 1.88191,
+    country: '🇰🇪Wakanda',
+  },
+  {
+    name: 'Shang-Chi',
+    email: 'kungfu.master@gmail.com',
+    number: 39.09222,
+    country: '🇨🇳China',
+  },
+  {
+    name: 'Natasha Romanoff',
+    email: 'black.widow@gmail.com',
+    number: 5.09291,
+    country: '🇷🇺Russia',
+  },
+  {
+    name: 'Peter Parker',
+    email: 'spider.man@gmail.com',
+    country: '🇺🇸USA',
+    children: [
+      {
+        name: 'Aunt May',
+        email: 'may.parker@gmail.com',
+        country: '🇺🇸USA',
+      },
+    ],
+  },
+]
+
+function Example() {
+  const [inputValue, setInputValue] = React.useState('')
+
+  const comparator = item => candidate => {
+    return item.email === candidate.email
+  }
+
+  const onToggle = ({ checkedItems }) => {
+    console.log(checkedItems)
+  }
+
+  const checkboxes = useTableTreeCheckboxes({
+    comparator,
+    items,
+    onToggle,
+  })
+
+  const measures = useTableMeasures({
+    size: items.length,
+  })
+
+  return (
+    <TableTree
+      comparator={comparator}
+      checkboxes={checkboxes}
+      columns={columns}
+      items={checkboxes.itemTree}
+      measures={measures}
+    />
+  )
+}
+;<Example />
 ```
 
 #### Full Example
@@ -108,9 +208,14 @@ function ToolbarExample() {
     console.log(checkedItems)
   }
 
+  const comparator = item => candidate => {
+    return item.email === candidate.email
+  }
+
   const checkboxes = useTableTreeCheckboxes({
     items,
     onToggle,
+    comparator,
     unicityKey: 'email',
     checked: [
       {
@@ -235,8 +340,8 @@ function ToolbarExample() {
 
   return (
     <TableTree
+      comparator={comparator}
       checkboxes={checkboxes}
-      unicityKey="email"
       columns={visibility.visibleColumns}
       items={checkboxes.itemTree}
       empty={empty}

--- a/react/components/EXPERIMENTAL_TableTree/README.md
+++ b/react/components/EXPERIMENTAL_TableTree/README.md
@@ -216,7 +216,6 @@ function ToolbarExample() {
     items,
     onToggle,
     comparator,
-    unicityKey: 'email',
     checked: [
       {
         name: "T'Chala",

--- a/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
@@ -3,13 +3,15 @@ import uuid from 'uuid'
 
 import CellPrefix from './CellPrefix'
 import Row from '../../EXPERIMENTAL_Table/DataTable/Row'
-import useTableTreeCheckboxes, { Item } from '../hooks/useTableTreeCheckboxes'
+import useTableTreeCheckboxes, {
+  Item,
+  comparatorCurry,
+} from '../hooks/useTableTreeCheckboxes'
 import { Column, Items } from '../../EXPERIMENTAL_Table'
 import { Density } from '../../EXPERIMENTAL_Table/hooks/useTableMeasures'
 
 const Node: FC<NodeProps> = ({
   columns,
-  unicityKey,
   rowHeight,
   nodesKey,
   checkboxes,
@@ -28,8 +30,8 @@ const Node: FC<NodeProps> = ({
     <CellPrefix depth={depth} hasCheckbox={!!checkboxes}>
       {hasChild && (
         <CellPrefix.CollapseToggle
-          collapsed={isCollapsed(data[unicityKey])}
-          onClick={() => toggleCollapsed(data[unicityKey])}
+          collapsed={isCollapsed(data)}
+          onClick={() => toggleCollapsed(data)}
         />
       )}
       {checkboxes && (
@@ -72,7 +74,7 @@ const Node: FC<NodeProps> = ({
   return data[nodesKey] ? (
     <>
       {renderCells(true)}
-      {isCollapsed(data[unicityKey]) &&
+      {isCollapsed(data) &&
         (data[nodesKey] as Array<Item>).map(data => (
           <Node
             selectedDensity={selectedDensity}
@@ -80,7 +82,6 @@ const Node: FC<NodeProps> = ({
             toggleCollapsed={toggleCollapsed}
             checkboxes={checkboxes}
             nodesKey={nodesKey}
-            unicityKey={unicityKey}
             rowHeight={rowHeight}
             columns={columns}
             key={`row-child-${uuid()}`}
@@ -94,21 +95,30 @@ const Node: FC<NodeProps> = ({
   )
 }
 
-const Tree: FC<TreeProps> = ({ checkboxes, items, ...nodeProps }) => {
-  const [collapsedItems, setCollapsedItems] = React.useState([])
+const Tree: FC<TreeProps> = ({
+  checkboxes,
+  items,
+  comparator,
+  ...nodeProps
+}) => {
+  const [collapsedItems, setCollapsedItems] = React.useState<Array<Item>>([])
 
   const listToRender = checkboxes ? items[nodeProps.nodesKey] : items
 
   const toggleCollapsed = React.useCallback(
-    (uniqueKey: unknown) => {
-      collapsedItems.includes(uniqueKey)
-        ? setCollapsedItems(collapsedItems.filter(key => key !== uniqueKey))
-        : setCollapsedItems([...collapsedItems, uniqueKey])
+    (item: Item) => {
+      isCollapsed(item)
+        ? setCollapsedItems(
+            collapsedItems.filter(
+              collapsedItem => !comparator(collapsedItem)(item)
+            )
+          )
+        : setCollapsedItems([...collapsedItems, item])
     },
     [collapsedItems]
   )
 
-  const isCollapsed = (uniqueKey: unknown) => collapsedItems.includes(uniqueKey)
+  const isCollapsed = (item: Item) => collapsedItems.some(comparator(item))
 
   return (
     <>
@@ -131,7 +141,7 @@ type TreeProps = {
   selectedDensity: Density
   nodesKey: string
   columns: Array<Column>
-  unicityKey: string
+  comparator: comparatorCurry
   rowHeight: number
   checkboxes?: Partial<ReturnType<typeof useTableTreeCheckboxes>>
 }
@@ -140,7 +150,6 @@ type NodeProps = {
   toggleCollapsed: (uniqueKey: unknown) => void
   isCollapsed: (uniqueKey: unknown) => boolean
   columns: Array<Column>
-  unicityKey: string
   selectedDensity: Density
   rowHeight: number
   nodesKey: string

--- a/react/components/EXPERIMENTAL_TableTree/hooks/__tests__/checkboxesUtils.test.ts
+++ b/react/components/EXPERIMENTAL_TableTree/hooks/__tests__/checkboxesUtils.test.ts
@@ -1,7 +1,7 @@
 import { getFlat, getToggledState } from '../checkboxesUtils'
 
 const props = ['children', 'related', 'friends']
-const unicityKey = 'name'
+const comparator = item => candidate => item.name === candidate.name
 
 props.forEach(prop => {
   test(`Tree is flattened correctly for prop ${prop}`, () => {
@@ -11,10 +11,10 @@ props.forEach(prop => {
   })
 
   test(`The state is toggled correctly on a item without childs on ${prop} prop`, () => {
-    expect(getToggledState([], { name: 'Alok' }, prop, unicityKey)).toEqual([
+    expect(getToggledState([], { name: 'Alok' }, prop, comparator)).toEqual([
       { name: 'Alok' },
     ])
-    expect(getToggledState([], { name: 'KVSH' }, prop, unicityKey)).toEqual([
+    expect(getToggledState([], { name: 'KVSH' }, prop, comparator)).toEqual([
       { name: 'KVSH' },
     ])
   })
@@ -34,7 +34,7 @@ props.forEach(prop => {
           ],
         },
         prop,
-        unicityKey
+        comparator
       )
     ).toEqual([
       {
@@ -59,7 +59,7 @@ props.forEach(prop => {
 
 function treeForProp(prop: string) {
   return {
-    [unicityKey]: 'root',
+    vtexTableTreeRoot: 'root',
     [prop]: [
       {
         name: 'Vintage Culture',
@@ -122,7 +122,7 @@ function flattenedTreeForProp(prop: string) {
           name: 'Metallica',
         },
       ],
-      [unicityKey]: 'root',
+      vtexTableTreeRoot: 'root',
     },
     {
       [prop]: [

--- a/react/components/EXPERIMENTAL_TableTree/hooks/checkboxesUtils.ts
+++ b/react/components/EXPERIMENTAL_TableTree/hooks/checkboxesUtils.ts
@@ -1,4 +1,4 @@
-import { Item } from './useTableTreeCheckboxes'
+import { Item, comparatorCurry } from './useTableTreeCheckboxes'
 
 /**
  * Return new state with items toggled
@@ -9,21 +9,19 @@ export function getToggledState(
   state: Array<Item>,
   item: Item,
   nodesKey: string = 'children',
-  unicityKey: string = 'id'
+  comparator: comparatorCurry
 ): Array<Item> {
-  const equalsKey = eqProp(unicityKey)
-
-  const stateIncludesItem = state.some(equalsKey(item))
+  const stateIncludesItem = state.some(comparator(item))
 
   const bulkFilter = (row: Item) =>
-    !getFlat(item, [], nodesKey).some(equalsKey(row))
+    !getFlat(item, [], nodesKey).some(comparator(row))
 
-  const filter = (row: Item) => row[unicityKey] !== item[unicityKey]
+  const filter = (row: Item) => !comparator(row)(item)
 
   const bulkCheck = (state: Array<Item>, item: Item): Array<Item> => {
     return [...state, ...getFlat(item, [], nodesKey)].reduce(
       (acc: Array<Item>, item: Item) =>
-        acc.some(equalsKey(item)) ? acc : [...acc, item],
+        acc.some(comparator(item)) ? acc : [...acc, item],
       []
     ) as Array<Item>
   }
@@ -50,8 +48,3 @@ export function getFlat(
     )
   return arr
 }
-
-/** Compares one prop of item and candidate  */
-export const eqProp = (prop: string) => (item: unknown) => (
-  candidate: unknown
-) => item[prop] === candidate[prop]

--- a/react/components/EXPERIMENTAL_TableTree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/index.tsx
@@ -9,6 +9,7 @@ import { InferProps } from 'prop-types'
 import TreeHeadings from './Tree/TreeHeadings'
 import Pagination from '../EXPERIMENTAL_Table/Pagination'
 import FilterBar from '../EXPERIMENTAL_Table/FilterBar'
+import { defaultComparatorCurry } from './hooks/useTableTreeCheckboxes'
 
 const TableTree: FC<Props> & TableComposites = ({
   children,
@@ -16,7 +17,7 @@ const TableTree: FC<Props> & TableComposites = ({
   items,
   checkboxes,
   nodesKey,
-  unicityKey,
+  comparator,
   measures,
   loading,
   empty,
@@ -50,7 +51,7 @@ const TableTree: FC<Props> & TableComposites = ({
               checkboxes={checkboxes}
               columns={columns}
               items={items}
-              unicityKey={unicityKey}
+              comparator={comparator}
               nodesKey={nodesKey}
               rowHeight={rowHeight}
             />
@@ -63,10 +64,12 @@ const TableTree: FC<Props> & TableComposites = ({
 
 TableTree.defaultProps = {
   nodesKey: 'children',
+  comparator: defaultComparatorCurry,
 }
 
 const treePropTypes = {
   nodesKey: PropTypes.string,
+  comparator: PropTypes.func,
 }
 
 const checkboxesPropTypes = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

➕Added `comparator` prop.
➖Remove `unicityKey` prop.

#### What problem is this solving?
Sometimes, items could not have a single prop that makes them unique. To solve the issues that may be caused by it, the prop `unicityKey` was deprecated in favor of a `comparator` function. 

This curry function should return true if the unique constraint is fulfilled, and its default value is:
`item => candidate => item.id && candidate.id && item.id === candidate.id` (items are equal if their id is the same).

#### How should this be manually tested?
Clone the repo and `yarn start`. [Running workspace](https://matheusps--storecomponents.myvtex.com/admin/collections/)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
