### PR TITLE
Fix Tooltip usage with SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.91.2] - 2019-10-31
+
 ### Fixed
 
 - `Tooltip` not working with SSR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Tooltip` not working with SSR
+
 ## [9.91.1] - 2019-10-31
 
 ### Fixed
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `InputButton` component.
+
 
 ## [9.90.8] - 2019-10-30
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.91.1",
+  "version": "9.91.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.91.1",
+  "version": "9.91.2",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -14,6 +14,13 @@ export type Size = 'mini' | 'small'
 const OFFSET = 8
 const hasComputedDimensions = rect => rect && rect.width && rect.height
 
+function getChildRefPropType() {
+  if (typeof HTMLElement !== 'undefined') {
+    return PropTypes.shape({ current: PropTypes.instanceOf(HTMLElement) })
+  }
+  return PropTypes.shape({ current: PropTypes.elementType })
+}
+
 const propTypes = {
   /** Tooltip content */
   label: PropTypes.node.isRequired,
@@ -37,9 +44,7 @@ const propTypes = {
   /** Tooltip timming function used to animate the tooltip */
   timmingFn: PropTypes.string,
   /** Child ref. Used to correctly position the tooltip */
-  childRef: PropTypes.shape({
-    current: PropTypes.instanceOf(HTMLElement),
-  }),
+  childRef: getChildRefPropType(),
 }
 
 const defaultProps = {

--- a/react/components/Tooltip/index.tsx
+++ b/react/components/Tooltip/index.tsx
@@ -1,14 +1,5 @@
-import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import get from 'lodash/get'
-import React, {
-  FC,
-  cloneElement,
-  Children,
-  useRef,
-  useEffect,
-  useState,
-} from 'react'
+import React, { FC, cloneElement, Children } from 'react'
 
 import TooltipPopup, { Position, Size } from './TooltipPopup'
 import { useTooltip, Trigger } from './hooks'


### PR DESCRIPTION
#### What is the purpose of this pull request?

Tooltip wasn't working with SSR because the constructor `HTMLElement` only exists in the browser.

#### What problem is this solving?
The page that use SSR and the `Tooltip` was crashing
[Running workspace](https://skuinitial--storecomponents.myvtex.com/classic-shoes/p)


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Access this [workspace](https://skuinitial--storecomponents.myvtex.com/classic-shoes/p) to see working
Go to [this one](https://crashingssr--storecomponents.myvtex.com/classic-shoes/p?) to see the error

#### Screenshots or example usage

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
