### PR TITLE
Better table columns and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Names of `cellRender` and `headerRender` in favor of `cellRenderer` and `headerRenderer` on `EXPERIMENTAL_Table`.
+- Remove `hidden` prop from `Column`.
+
 ## [9.96.2] - 2019-11-11
 
 ### Changed
@@ -90,9 +93,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **Table** warning whenever some line's checkbox was selected
-
-### Added
-
 - `InputButton` component.
 
 ## [9.90.8] - 2019-10-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.96.3] - 2019-11-12
+
 - Names of `cellRender` and `headerRender` in favor of `cellRenderer` and `headerRenderer` on `EXPERIMENTAL_Table`.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 - Names of `cellRender` and `headerRender` in favor of `cellRenderer` and `headerRenderer` on `EXPERIMENTAL_Table`.
-- Remove `hidden` prop from `Column`.
+
+### Removed
+- `hidden` prop from `Column`.
 
 ## [9.96.2] - 2019-11-11
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.96.2",
+  "version": "9.96.3",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.96.2",
+  "version": "9.96.3",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
@@ -8,9 +8,9 @@ import { Column } from '../index'
 const Headings: FC<HeadingsProps> = ({ columns, cellProps, rowProps }) => {
   return (
     <Row {...rowProps} height={TABLE_HEADER_HEIGHT}>
-      {columns.map((headerData: Column) => {
-        const { headerRender, title, width } = headerData
-        const content = headerRender ? headerRender({ headerData }) : title
+      {columns.map((columnData: Column) => {
+        const { headerRenderer, title, width } = columnData
+        const content = headerRenderer ? headerRenderer({ columnData }) : title
         return (
           <Row.Cell
             {...cellProps}

--- a/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
@@ -30,10 +30,10 @@ const Rows: FC<RowsProps> = ({
         active={isRowActive && isRowActive(rowData)}
         key={`${NAMESPACES.ROW}-${uuid()}`}>
         {columns.map((column: Column) => {
-          const { cellRender, width } = column
+          const { cellRenderer, width } = column
           const cellData = rowData[column.id]
-          const content = cellRender
-            ? cellRender({ cellData, rowData, rowHeight, selectedDensity })
+          const content = cellRenderer
+            ? cellRenderer({ cellData, rowData, rowHeight, selectedDensity })
             : cellData
           return (
             <Row.Cell {...cellProps} key={`cel-${uuid()}`} width={width}>

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -24,7 +24,7 @@ type Column = {
 
 ##### title
 
-- Control the title which appears on the table Header.
+- Controls the title which appears on the table Header.
 - If you want to customize it with a component, you can use the `headerRenderer` prop.
 
 ##### width
@@ -105,9 +105,9 @@ const heroColumns: Array<Column> = [
     /** Custom renderer for email prop */
     headerRenderer: ({ columnData: { title } }) => {
       return (
-        <span>
+        <React.Fragment>
           <Emoji symbol="💌" label="mail" /> {title}
-        </span>
+        </React.Fragment>
       )
     },
   },
@@ -150,9 +150,9 @@ const heroColumns = [
     title: 'Email',
     headerRenderer: ({ columnData: { title } }) => {
       return (
-        <span>
+        <React.Fragment>
           <Emoji symbol="💌" label="mail" /> {title}
-        </span>
+        </React.Fragment>
       )
     },
   },
@@ -215,7 +215,7 @@ function SimpleExample() {
 
 ##### Toggle visibility
 
-It is possible to hide/show columns. This can be done using the `EXPERIMENTAL_useTableVisibility` hook and the `Columns` button (part of the `Toolbar`). Check the working example below:
+It is possible to show/hide columns. This can be done using the `EXPERIMENTAL_useTableVisibility` hook and the `Columns` button (part of the `Toolbar`). Check the working example below:
 
 ```js
 const useTableMeasures = require('./hooks/useTableMeasures.tsx').default

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -213,6 +213,111 @@ function SimpleExample() {
 ;<SimpleExample />
 ```
 
+##### Toggle visibility
+
+It is possible to hide/show columns. This can be done using the `EXPERIMENTAL_useTableVisibility` hook and the `Columns` button (part of the `Toolbar`). Check the working example below:
+
+```js
+const useTableMeasures = require('./hooks/useTableMeasures.tsx').default
+const useTableVisibility = require('./hooks/useTableVisibility.ts').default
+
+const Tag = require('../Tag/index.js').default
+
+const heroColumns = [
+  {
+    id: 'name',
+    title: 'Name',
+  },
+  {
+    id: 'email',
+    title: 'Email',
+    headerRenderer: ({ columnData: { title } }) => {
+      return (
+        <span>
+          <Emoji symbol="💌" label="mail" /> {title}
+        </span>
+      )
+    },
+  },
+  {
+    id: 'age',
+    title: 'Age',
+    cellRenderer: ({ cellData: age }) => {
+      const bgColor = age > 18 ? '#F71963' : '#134CD8'
+      return (
+        <Tag color="#FFFFFF" bgColor={bgColor}>
+          {age} years
+        </Tag>
+      )
+    },
+  },
+  {
+    id: 'country',
+    title: 'Nationality',
+  },
+]
+
+const heroes = [
+  {
+    name: "T'Chala",
+    email: 'black.panther@gmail.com',
+    age: 31,
+    country: '🇰🇪Wakanda',
+  },
+  {
+    name: 'Peter Parker',
+    email: 'spider.man@gmail.com',
+    age: 17,
+    country: '🇺🇸USA',
+  },
+  {
+    name: 'Natasha Romanoff',
+    email: 'black.widow@gmail.com',
+    age: 29,
+    country: '🇷🇺Russia',
+  },
+]
+
+function Emoji({ symbol, label = '' }) {
+  return (
+    <span role="img" arial-label={label} aria-hidden={label ? 'false' : 'true'}>
+      {symbol}
+    </span>
+  )
+}
+
+function ToggleColumnsExample() {
+  const visibility = useTableVisibility({
+    columns: heroColumns,
+  })
+
+  const measures = useTableMeasures({
+    size: heroes.length,
+  })
+
+  const buttonColumns = {
+    label: 'Toggle visible fields',
+    showAllLabel: 'Show All',
+    hideAllLabel: 'Hide All',
+    visibility,
+  }
+
+  return (
+    <Table
+      measures={measures}
+      items={heroes}
+      columns={visibility.visibleColumns}>
+      <Table.Toolbar>
+        <Table.Toolbar.ButtonGroup>
+          <Table.Toolbar.ButtonGroup.Columns {...buttonColumns} />
+        </Table.Toolbar.ButtonGroup>
+      </Table.Toolbar>
+    </Table>
+  )
+}
+;<ToggleColumnsExample />
+```
+
 # Features
 
 <div className="center mw7 pv6">

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -1,19 +1,20 @@
-# Table Columns
+## Columns
 
-The columns property is a LIST used to define the table columns and how they should behave visually. The Schema has properties and each one of them defines a column in the table.
-Example with simple structure:
+The `columns` property is an `Array` used to define the table columns and how they should behave visually. Each column describes each item field should be handled by the `Table`.
 
 ```ts
-;[
-  {
-    id: 'property',
-    title: 'Property',
-    cellRender: ({ cellData, rowData }) => {
-      return <span className="classname">{cellData}</span>
-    },
-  },
-  // ...
-]
+type Column = {
+  id?: string
+  title?: string
+  width?: number
+  cellRenderer?: ({
+    cellData: unknown
+    rowData: unknown
+    rowHeight: number
+    selectedDensity: 'low' | 'medium' | 'high'
+  }) => React.ReactNode
+  headerRenderer?: ({ columnData: Column }) => React.ReactNode
+}
 ```
 
 ##### id
@@ -23,44 +24,123 @@ Example with simple structure:
 
 ##### title
 
-- Control the title which appears on table Header.
-- It receives only strings.
-- If you want to customize it with a component, you can use the `headerRender` prop.
+- Control the title which appears on the table Header.
+- If you want to customize it with a component, you can use the `headerRenderer` prop.
 
-##### headerRender
+##### width
+
+- Defines a fixed width for the specific column.
+- By default, the column's width is defined to fit the available space without breaking the content.
+
+##### headerRenderer
 
 - Customize the render method of a single header column cell.
 - It receives a function that returns a node (react component).
-- The function has the following params: ({ headerData })
-- Default is render the value as a string.
-- If you have a custom cell component that has a click interaction and at the same time you use the onRowClick Table prop, you might stumble uppon the problem of both click actions being fired. We can work around that by doing a wrapper around cellRenderer to stop click event propagation.
+- The function has the following params: ({ columnData })
+- The default is rendering the value as a string.
 
-##### cellRender
+##### cellRenderer
 
 - Customize the render method of a single column cell.
 - It receives a function that returns a node (react component).
-- The function has the following params: ({ cellData, rowData })
-- Default is render the value as a string.
-- If you have a custom cell component that has a click interaction and at the same time you use the onRowClick Table prop, you might stumble uppon the problem of both click actions being fired. We can work around that by doing a wrapper around cellRenderer to stop click event propagation.
+- The function has the following params: ({ cellData, rowData, rowHeight, selectedDensity })
+  - cellData: the value of the current cell.
+  - rowData: the value of the current row.
+  - rowHeight: current height of the row.
+  - selectedDensity: current table density.
+- The default is rendering the value as a string.
 
-##### hidden
+To illustrate this info, let's suppose we have a list of heroes, each one with properties `name`, `email`, `age` and `country`:
 
-- Defines if a columns is initially hidden or not.
-- ⚠️ You should use the `Columns` button of the toolbar to enable toggle columns visibility.
+```ts
+type Hero = {
+  name: string
+  email: string
+  age: number
+  country: string
+}
 
-#### State Hook
+const heroes: Array<Hero> = [
+  {
+    name: "T'Chala",
+    email: 'black.panther@gmail.com',
+    age: 31,
+    country: '🇰🇪Wakanda',
+  },
+  {
+    name: 'Peter Parker',
+    email: 'spider.man@gmail.com',
+    age: 17,
+    country: '🇺🇸USA',
+  },
+  {
+    name: 'Natasha Romanoff',
+    email: 'black.widow@gmail.com',
+    age: 29,
+    country: '🇷🇺Russia',
+  },
+]
+```
 
-Different than the previous version the `Table v2` is completely stateless, meaning that the parent has full control of its states. This is made possible by the `useTableState` hook. Its input is an `List` containing `columns` (the columns definition), `items` (the actual items to show, which described by the columns) and `density` (density of the table rows).
+To allow us to see the `Column` features, let's imagine some specifications:
 
-### Example Of Usage
+- The `name` should be rendered as simple as possible
+- The `email` header should contain 💌 emoji
+- Age should be rendered inside of a `Tag` component with de `bgColor` blue for underage heroes and pink for the older age.
+- The header title for `country` prop should be 'Nationality'.
+
+Given these, the columns would be:
+
+```ts
+const heroColumns: Array<Column> = [
+  {
+    /** Definitions for the name prop */
+    id: 'name',
+    title: 'Name',
+  },
+  {
+    /** Definitions for the email prop */
+    id: 'email',
+    title: 'Email',
+    /** Custom renderer for email prop */
+    headerRenderer: ({ columnData: { title } }) => {
+      return (
+        <span>
+          <Emoji symbol="💌" label="mail" /> {title}
+        </span>
+      )
+    },
+  },
+  {
+    /** Definitions for the age prop */
+    id: 'age',
+    title: 'Age',
+    /** Custom renderer for age prop */
+    cellRenderer: ({ cellData: age }) => {
+      const bgColor = age > 18 ? '#F71963' : '#134CD8'
+      return (
+        <Tag color="#FFFFFF" bgColor={bgColor}>
+          {age} years
+        </Tag>
+      )
+    },
+  },
+  {
+    /** Definitions for the country prop */
+    id: 'country',
+    /** This means that the title shown for the country property will be Nationality */
+    title: 'Nationality',
+  },
+]
+```
+
+##### Working example:
 
 ```js
-// Imports
 const useTableMeasures = require('./hooks/useTableMeasures.tsx').default
 const Tag = require('../Tag/index.js').default
 
-// Define the columns
-const columns = [
+const heroColumns = [
   {
     id: 'name',
     title: 'Name',
@@ -68,77 +148,70 @@ const columns = [
   {
     id: 'email',
     title: 'Email',
+    headerRenderer: ({ columnData: { title } }) => {
+      return (
+        <span>
+          <Emoji symbol="💌" label="mail" /> {title}
+        </span>
+      )
+    },
   },
   {
-    id: 'number',
-    title: 'Number',
-    cellRender: ({ cellData }) => {
-      return <Tag>{cellData}</Tag>
+    id: 'age',
+    title: 'Age',
+    cellRenderer: ({ cellData: age }) => {
+      const bgColor = age > 18 ? '#F71963' : '#134CD8'
+      return (
+        <Tag color="#FFFFFF" bgColor={bgColor}>
+          {age} years
+        </Tag>
+      )
     },
   },
   {
     id: 'country',
-    title: 'Country',
+    title: 'Nationality',
   },
 ]
 
-// Define the items
-const items = [
+const heroes = [
   {
     name: "T'Chala",
     email: 'black.panther@gmail.com',
-    number: 1.88191,
+    age: 31,
     country: '🇰🇪Wakanda',
   },
   {
     name: 'Peter Parker',
     email: 'spider.man@gmail.com',
-    number: 3.09191,
+    age: 17,
     country: '🇺🇸USA',
-  },
-  {
-    name: 'Shang-Chi',
-    email: 'kungfu.master@gmail.com',
-    number: 39.09222,
-    country: '🇨🇳China',
   },
   {
     name: 'Natasha Romanoff',
     email: 'black.widow@gmail.com',
-    number: 5.09291,
+    age: 29,
     country: '🇷🇺Russia',
   },
 ]
 
-function StateHookExample() {
+function Emoji({ symbol, label = '' }) {
+  return (
+    <span role="img" arial-label={label} aria-hidden={label ? 'false' : 'true'}>
+      {symbol}
+    </span>
+  )
+}
+
+function SimpleExample() {
   const measures = useTableMeasures({
-    size: items.length,
+    size: heroes.length,
   })
 
-  return <Table measures={measures} columns={columns} items={items} />
+  return <Table measures={measures} columns={heroColumns} items={heroes} />
 }
-;<StateHookExample />
+;<SimpleExample />
 ```
-
-### Input Object
-
-| Property | Type                      | Description                         |
-| -------- | ------------------------- | ----------------------------------- |
-| columns  | List of Columns           | Definition of the table columns     |
-| items    | Array of Object           | The actual items that will be shown |
-| density  | 'low', 'medium' or 'high' | Density of table rows               |
-
-### Return Values
-
-| Property           | Type            | Description                         |
-| ------------------ | --------------- | ----------------------------------- |
-| columns            | List of Columns | Definition of the table columns     |
-| items              | Array of Object | The actual items that will be shown |
-| empty              | Boolean         | If there are items to show or not   |
-| tableHeight        | Number          | Table calculated height             |
-| rowHeight          | Number          | Table calculated row height         |
-| selectedDensity    | Density         | Current selected density            |
-| setSelectedDensity | Function        | selectedDensity setter              |
 
 # Features
 

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableBulkActions.tsx
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableBulkActions.tsx
@@ -34,7 +34,7 @@ export default function useTableBulkActions({
   const hasBulkActions = hasPrimaryBulkAction || hasSecondaryBulkActions
 
   const bulkedColumns = useMemo<Array<Column>>(() => {
-    const headerRender = () => {
+    const headerRenderer = () => {
       const selectedRowsLength = bulkState.selectedRows.length
       const itemsLength = items.length
       const isChecked = selectedRowsLength === itemsLength
@@ -51,7 +51,7 @@ export default function useTableBulkActions({
       )
     }
 
-    const cellRender = ({ rowData }) => (
+    const cellRenderer = ({ rowData }) => (
       <Checkbox
         checked={bulkState.selectedRows.some(comparator(rowData))}
         onClick={() => selectRow(rowData)}
@@ -65,8 +65,8 @@ export default function useTableBulkActions({
           {
             vtexTableRoot: 'bulk',
             width: 40,
-            headerRender,
-            cellRender,
+            headerRenderer,
+            cellRenderer,
           },
           ...columns,
         ]

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableVisibility.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableVisibility.ts
@@ -1,8 +1,11 @@
 import { useMemo, useState, useCallback } from 'react'
 import { Column } from '../index'
 
-export default function useTableVisibility({ columns }: VisibilityData) {
-  const [hiddenColumns, setHiddenColumns] = useState(getHiddenColumns(columns))
+export default function useTableVisibility({
+  columns,
+  hiddenColumns: initHiddenColumns = [],
+}: VisibilityData) {
+  const [hiddenColumns, setHiddenColumns] = useState(initHiddenColumns)
 
   const visibleColumns = useMemo(() => {
     const reducer = (acc: Array<Column>, col: Column) =>
@@ -40,12 +43,5 @@ export default function useTableVisibility({ columns }: VisibilityData) {
 
 export type VisibilityData = {
   columns: Array<Column>
-}
-
-interface Monad<T> extends Array<any> {
-  flatMap?(func: (x: T) => any): Array<any>
-}
-
-function getHiddenColumns(columns: Monad<Column>): Array<string> {
-  return columns.flatMap(col => (col.hidden ? [col.id] : []))
+  hiddenColumns?: Array<string>
 }

--- a/react/components/EXPERIMENTAL_Table/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/index.tsx
@@ -119,9 +119,8 @@ export type Column = {
   id?: string
   title?: string
   width?: number
-  cellRender?: (cellData: CellData) => React.ReactNode
-  headerRender?: ({ headerData: unknown }) => React.ReactNode
-  hidden?: boolean
+  cellRenderer?: (cellData: CellData) => React.ReactNode
+  headerRenderer?: ({ columnData: unknown }) => React.ReactNode
 }
 
 Table.Toolbar = Toolbar

--- a/react/components/EXPERIMENTAL_TableTree/README.md
+++ b/react/components/EXPERIMENTAL_TableTree/README.md
@@ -163,7 +163,7 @@ const columns = [
   {
     id: 'name',
     title: 'Description',
-    cellRender: ({ rowHeight, cellData }) => (
+    cellRenderer: ({ rowHeight, cellData }) => (
       <span>
         <Image size={rowHeight - 10} />
         <span className="ph4">{cellData}</span>

--- a/react/components/EXPERIMENTAL_TableTree/Tree/TreeHeadings.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/TreeHeadings.tsx
@@ -19,9 +19,9 @@ const TreeHeadings: FC<TreeHeadingsProps> = ({
 }) => {
   return (
     <Row {...rowProps} height={TABLE_HEADER_HEIGHT}>
-      {columns.map((headerData: Column, headerIndex: number) => {
-        const { headerRender, title, width } = headerData
-        const content = headerRender ? headerRender({ headerData }) : title
+      {columns.map((columnData: Column, headerIndex: number) => {
+        const { headerRenderer, title, width } = columnData
+        const content = headerRenderer ? headerRenderer({ columnData }) : title
         return (
           <Row.Cell
             {...cellProps}

--- a/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
@@ -51,10 +51,10 @@ const Node: FC<NodeProps> = ({
     return (
       <Row height={rowHeight} active={isRowSelected}>
         {columns.map((column: Column, cellIndex: number) => {
-          const { cellRender, width } = column
+          const { cellRenderer, width } = column
           const cellData = data[column.id]
-          const content = cellRender
-            ? cellRender({
+          const content = cellRenderer
+            ? cellRenderer({
                 cellData,
                 rowData: data,
                 rowHeight,


### PR DESCRIPTION
#### What is the purpose of this pull request?

🛠 Names of `cellRender` and `headerRender` in favor of `cellRenderer` and `headerRenderer` on `EXPERIMENTAL_Table`.
➖ Remove `hidden` prop from `Column`.

#### What problem is this solving?
The `columns` section needed better documentation and the `stateHook` is deprecated.

#### How should this be manually tested?
`yarn start`

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
