### PR TITLE
Provide updateCellMeasurements() method for cell height refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.96.0] - 2019-11-07
+
 ### Added
 
 - `updateCellMeasurements` function in **Table** to be used in `cellRenderer` in order to update cell size programatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- to **Table** a `updateCellMeasurements` function to be used in `cellRenderer` in order to update cell size programatically
+- `updateCellMeasurements` function in **Table** to be used in `cellRenderer` in order to update cell size programatically
 
 ## [9.95.0] - 2019-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- to **Table** a `updateCellMeasurements` function to be used in `cellRenderer` in order to update cell size programatically
+
 ## [9.95.0] - 2019-11-07
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.95.0",
+  "version": "9.96.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.95.0",
+  "version": "9.96.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -92,8 +92,9 @@ width: 350
 
 - Customize the render method of a single column cell.
 - It receives a function that returns a node (react component).
-- The function has the following params: ({ cellData, rowData })
+- The function has the following params: ({ cellData, rowData, updateCellMeasurements })
 - Default is render the value as a string.
+- If you use `dynamicRowHeights` option in your table, you may need to use `updateCellMeasurements` to update the cell measurement cache (e.g. in an `onLoad` prop for images).
 - If you have a custom cell component that has a click interaction and at the same time you use the onRowClick Table prop, you might stumble uppon the problem of both click actions being fired. We can work around that by doing a wrapper around cellRenderer to stop click event propagation, like so:
 
 ##### headerRight

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -352,6 +352,17 @@ class SimpleTable extends Component {
                         items[disableHeader ? rowIndex : rowIndex - 1]
                       const cellData = rowData[property]
 
+                      const cellClassNames = `flex items-center w-100 h-100 ph4 bb
+                                    b--muted-4 truncate ${
+                                      disableHeader && rowIndex === 0
+                                        ? 'bt'
+                                        : ''
+                                    } ${
+                        onRowClick && rowIndex === hoverRowIndex
+                          ? 'pointer bg-near-white c-link'
+                          : ''
+                      } ${columnIndex === 0 && fixFirstColumn ? 'br' : ''}`
+
                       return (
                         <CellMeasurer
                           cache={this._cache}
@@ -378,18 +389,7 @@ class SimpleTable extends Component {
                                   ? SELECTED_ROW_BACKGROUND
                                   : '',
                               }}
-                              className={`flex items-center w-100 h-100 ph4 bb
-                                    b--muted-4 truncate ${
-                                      disableHeader && rowIndex === 0
-                                        ? 'bt'
-                                        : ''
-                                    } ${
-                                onRowClick && rowIndex === hoverRowIndex
-                                  ? 'pointer bg-near-white c-link'
-                                  : ''
-                              } ${
-                                columnIndex === 0 && fixFirstColumn ? 'br' : ''
-                              }`}
+                              className={cellClassNames}
                               onClick={
                                 onRowClick &&
                                 property !== '_VTEX_Table_Internal_lineActions'

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -359,60 +359,67 @@ class SimpleTable extends Component {
                           key={key}
                           parent={parent}
                           rowIndex={rowIndex}>
-                          <div
-                            key={key}
-                            style={{
-                              ...style,
-                              height: this.calculateRowHeight(rowIndex),
-                              width: this.calculateColWidth(
-                                schema,
-                                properties,
-                                columnIndex,
-                                fullWidth,
-                                fullWidthColWidth
-                              ),
-                              backgroundColor: selectedRowsIndexes.includes(
-                                rowIndex - 1
-                              )
-                                ? SELECTED_ROW_BACKGROUND
-                                : '',
-                            }}
-                            className={`flex items-center w-100 h-100 ph4 bb
-                                b--muted-4 truncate ${
-                                  disableHeader && rowIndex === 0 ? 'bt' : ''
-                                } ${
-                              onRowClick && rowIndex === hoverRowIndex
-                                ? 'pointer bg-near-white c-link'
-                                : ''
-                            } ${
-                              columnIndex === 0 && fixFirstColumn ? 'br' : ''
-                            }`}
-                            onClick={
-                              onRowClick &&
-                              property !== '_VTEX_Table_Internal_lineActions'
-                                ? event =>
-                                    onRowClick({
-                                      event,
-                                      index: rowIndex,
-                                      rowData,
-                                    })
-                                : null
-                            }
-                            onMouseEnter={
-                              onRowClick
-                                ? () => this.handleRowHover(rowIndex)
-                                : null
-                            }
-                            onMouseLeave={
-                              onRowClick ? () => this.handleRowHover(-1) : null
-                            }>
-                            {cellRenderer
-                              ? cellRenderer({
-                                  cellData,
-                                  rowData,
-                                })
-                              : cellData}
-                          </div>
+                          {({ measure: updateCellMeasurements }) => (
+                            <div
+                              key={key}
+                              style={{
+                                ...style,
+                                height: this.calculateRowHeight(rowIndex),
+                                width: this.calculateColWidth(
+                                  schema,
+                                  properties,
+                                  columnIndex,
+                                  fullWidth,
+                                  fullWidthColWidth
+                                ),
+                                backgroundColor: selectedRowsIndexes.includes(
+                                  rowIndex - 1
+                                )
+                                  ? SELECTED_ROW_BACKGROUND
+                                  : '',
+                              }}
+                              className={`flex items-center w-100 h-100 ph4 bb
+                                    b--muted-4 truncate ${
+                                      disableHeader && rowIndex === 0
+                                        ? 'bt'
+                                        : ''
+                                    } ${
+                                onRowClick && rowIndex === hoverRowIndex
+                                  ? 'pointer bg-near-white c-link'
+                                  : ''
+                              } ${
+                                columnIndex === 0 && fixFirstColumn ? 'br' : ''
+                              }`}
+                              onClick={
+                                onRowClick &&
+                                property !== '_VTEX_Table_Internal_lineActions'
+                                  ? event =>
+                                      onRowClick({
+                                        event,
+                                        index: rowIndex,
+                                        rowData,
+                                      })
+                                  : null
+                              }
+                              onMouseEnter={
+                                onRowClick
+                                  ? () => this.handleRowHover(rowIndex)
+                                  : null
+                              }
+                              onMouseLeave={
+                                onRowClick
+                                  ? () => this.handleRowHover(-1)
+                                  : null
+                              }>
+                              {cellRenderer
+                                ? cellRenderer({
+                                    cellData,
+                                    rowData,
+                                    updateCellMeasurements,
+                                  })
+                                : cellData}
+                            </div>
+                          )}
                         </CellMeasurer>
                       )
                     }}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add an `updateCellMeasurements()` callback to the provided props in `skuCellRenderer`.

#### What problem is this solving?
While the table height is being updated whenever there is a different *sum* of rows heights, sometimes the individual cell height is not being updated in the cell measurement cache, causing said sum to convey the wrong height measurement for the table.

Since this depends on some obscure logic for the CellMeasurer cache that maintains the cell previous measurements, one way of refreshing those measurements is to provide the `measure()` render prop provided by the `CellMeasurer`. That way one can programatically remeasure an individual cell and update the entire row.

This is similar to the `react-virtualized` recommended approach for cells that contain images, [which can be seen here](https://github.com/bvaughn/react-virtualized/blob/master/docs/CellMeasurer.md#using-cellmeasurer-with-images)

#### How should this be manually tested?
To see the problem:
1. [Visit this link](https://measuretest--partnerchallenge26.myvtex.com/admin/received-skus/pending)
2. Check a SKU
3. Click on the `Link to existing SKU` button
4. When the modal shows up, you'll see that there is an input.
5. Write an random string of letters only (e.g. `sdkfjas`)
6. Confirm by clicking on `Link to SKU`
7. You should see that there is an error message at the SKU line, but it touches the bottom line of the row (padding is hidden)

To see the working fix:
1. [Visit this link](https://artur--partnerchallenge26.myvtex.com/admin/received-skus/pending)
2. Check a SKU
3. Click on the `Link to existing SKU` button
4. When the modal shows up, you'll see that there is an input.
5. Write an random string of letters only (e.g. `sdkfjas`)
6. Confirm by clicking on `Link to SKU`
7. You should see that there is an error message at the SKU line, but now the padding is showing up

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/3827456/68003150-ecac3900-fc4a-11e9-8be4-0f3e8dfcab60.png)

After:
![image](https://user-images.githubusercontent.com/3827456/68003180-051c5380-fc4b-11e9-92bc-0f522da0baca.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
