### PR TITLE
Add loading status to InputButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- isLoading prop to InputButton component.
+
 ## [9.91.3] - 2019-10-31
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.91.3",
+  "version": "9.91.4",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -126,8 +126,10 @@ class Input extends Component {
       classes += 'code '
     }
 
-    if (disabled || readOnly) {
-      classes += `bg-transparent b--disabled ${disabled ? 'c-disabled' : ''} `
+    if (disabled || readOnly || isLoadingButton) {
+      classes += `bg-transparent b--disabled ${
+        disabled || isLoadingButton ? 'c-disabled' : ''
+      } `
       prefixSuffixGroupClasses += `bg-disabled b--disabled ${
         disabled ? 'c-disabled' : ''
       } `

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -86,6 +86,7 @@ class Input extends Component {
       suffix: suffixProp,
       suffixIcon,
       button,
+      isLoadingButton,
       groupBottom,
       disabled,
       readOnly,
@@ -214,7 +215,7 @@ class Input extends Component {
             onMouseEnter={this.handleMouseEnter}
             onMouseLeave={this.handleMouseLeave}
             className={classes}
-            disabled={disabled}
+            disabled={disabled || isLoadingButton}
             accept={this.props.accept}
             autoComplete={this.props.autoComplete}
             autoCorrect={this.props.autoCorrect}
@@ -249,7 +250,8 @@ class Input extends Component {
           {button && size !== 'small' && (
             <span className="flex items-center mr1">
               <Button
-                disabled={disabled}
+                disabled={disabled || isLoadingButton}
+                isLoading={isLoadingButton}
                 size={size === 'large' ? 'regular' : 'small'}
                 type="submit"
                 variation="secondary">
@@ -281,6 +283,7 @@ Input.defaultProps = {
   size: 'regular',
   prefix: '',
   type: 'text',
+  isLoadingButton: false,
 }
 
 Input.propTypes = {
@@ -327,6 +330,9 @@ Input.propTypes = {
   testId: PropTypes.string,
   /** Spec attribute */
   inputMode: PropTypes.string,
+  /** @ignore
+   * Loading state */
+  isLoadingButton: PropTypes.bool,
   /** Spec attribute */
   list: PropTypes.string,
   /** Spec attribute */

--- a/react/components/InputButton/README.md
+++ b/react/components/InputButton/README.md
@@ -32,6 +32,29 @@ With submit button
 </div>
 ```
 
+Loading state
+
+```js
+initialState = { isLoading: false };
+<form onSubmit={
+    (e) => {
+      e.preventDefault
+      setState({ isLoading: true })
+      setTimeout(() => { setState({ isLoading: false }) }, 1200)
+    }
+  }>
+  <div className="mb5">
+    <InputButton
+      placeholder="Placeholder"
+      size="regular"
+      label="Regular loading"
+      button="Submit"
+      isLoading={state.isLoading}
+    />
+  </div>
+</form>
+```
+
 Disabled
 
 ```js

--- a/react/components/InputButton/index.js
+++ b/react/components/InputButton/index.js
@@ -7,18 +7,25 @@ import { withForwardedRef } from '../../modules/withForwardedRef'
 
 class InputButton extends Component {
   render() {
-    const { button, ...props } = this.props
+    const { button, isLoading, ...props } = this.props
 
     return (
       <div>
-        <Input {...props} button={button} />
+        <Input {...props} button={button} isLoadingButton={isLoading} />
       </div>
     )
   }
 }
 
+InputButton.defaultProps = {
+  isLoading: false,
+}
+
 InputButton.propTypes = {
+  /** (InputButton spec attribute) */
   button: PropTypes.string,
+  /** Loading state */
+  isLoading: PropTypes.bool,
 }
 
 export default withForwardedRef(InputButton)


### PR DESCRIPTION
#### What is the purpose of this pull request?

To allow a loading status to `InputButton` component.

#### What problem is this solving?

`InputButton` don't have a way to give feedback when, after submitting the form, something needs to load and the user needs to wait.

#### How should this be manually tested?

http://localhost:6060/#/Components/Forms/InputButton

#### Screenshots or example usage

![loding](https://user-images.githubusercontent.com/1315451/68159892-6dac4e80-ff31-11e9-81c3-22e19d15a11b.gif)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
