### PR TITLE
Fix: EXPERIMENTAL_TableTree shows arrow with empty nodesKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.91.6] - 2019-11-06
+
 ### Fixed
 
 - `EXPERIMENTAL_TableTree` shows arrow with empty `nodesKey`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `EXPERIMENTAL_TableTree` shows arrow with empty `nodesKey`.
+
 ## [9.91.5] - 2019-11-06
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.91.5",
+  "version": "9.91.6",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "case-sensitive-paths-webpack-plugin": "^2.2.0",
     "focus-visible": "^4.1.5",
     "fromentries": "^1.1.0",
+    "lodash.isempty": "^4.4.0",
     "react-color": "^2.17.0",
     "react-datepicker": "^2.3.0",
     "react-docgen-displayname-handler": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "case-sensitive-paths-webpack-plugin": "^2.2.0",
     "focus-visible": "^4.1.5",
     "fromentries": "^1.1.0",
-    "lodash.isempty": "^4.4.0",
     "react-color": "^2.17.0",
     "react-datepicker": "^2.3.0",
     "react-docgen-displayname-handler": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.91.5",
+  "version": "9.91.6",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_TableTree/README.md
+++ b/react/components/EXPERIMENTAL_TableTree/README.md
@@ -91,6 +91,7 @@ const items = [
     email: 'kungfu.master@gmail.com',
     number: 39.09222,
     country: '🇨🇳China',
+    children: [],
   },
   {
     name: 'Natasha Romanoff',

--- a/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
 import uuid from 'uuid'
-import isEmpty from 'lodash.isempty'
+import isEmpty from 'lodash/isEmpty'
 
 import CellPrefix from './CellPrefix'
 import Row from '../../EXPERIMENTAL_Table/DataTable/Row'

--- a/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import uuid from 'uuid'
+import isEmpty from 'lodash.isempty'
 
 import CellPrefix from './CellPrefix'
 import Row from '../../EXPERIMENTAL_Table/DataTable/Row'
@@ -71,7 +72,7 @@ const Node: FC<NodeProps> = ({
     )
   }
 
-  return data[nodesKey] ? (
+  return data[nodesKey] && !isEmpty(data[nodesKey]) ? (
     <>
       {renderCells(true)}
       {isCollapsed(data) &&

--- a/react/components/EXPERIMENTAL_TableTree/hooks/useTableTreeCheckboxes.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/hooks/useTableTreeCheckboxes.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useCallback, useEffect, useReducer } from 'react'
-import isEmpty from 'lodash.isempty'
+import isEmpty from 'lodash/isEmpty'
 import { getFlat, getToggledState } from './checkboxesUtils'
 
 export default function useTableTreeCheckboxes({

--- a/react/components/EXPERIMENTAL_TableTree/hooks/useTableTreeCheckboxes.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/hooks/useTableTreeCheckboxes.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useCallback, useEffect, useReducer } from 'react'
+import isEmpty from 'lodash.isempty'
 import { getFlat, getToggledState } from './checkboxesUtils'
 
 export default function useTableTreeCheckboxes({
@@ -32,7 +33,7 @@ export default function useTableTreeCheckboxes({
     const shake = (tree: Item) => {
       const childNodes = tree[nodesKey] as Array<Item>
 
-      if (!childNodes) return
+      if (!childNodes || isEmpty(childNodes)) return
 
       const areChildsChecked = childNodes.every(child =>
         checkedItems.some(comparator(child))
@@ -56,7 +57,7 @@ export default function useTableTreeCheckboxes({
   const isChecked = useCallback(
     (item: Item) => {
       const childs = item[nodesKey] as Array<Item>
-      return childs
+      return childs && !isEmpty(childs)
         ? childs.every(child => checkedItems.some(comparator(child)))
         : checkedItems.some(comparator(item))
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6829,6 +6829,11 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash.isempty@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
+
 lodash.merge@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6829,11 +6829,6 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.isempty@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
-  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
-
 lodash.merge@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

The arrow must not be shown when nodesKey is an empty array.

#### How should this be manually tested?
Clone the repo and `cd styleguide && yarn && yarn start`

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
