### PR TITLE
Fix checkbox alignment when there is no arrow in the EXPERIMENTAL_TableTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.96.9] - 2019-11-20
+
 ### Fixed
 
 - `checkbox` was not vertically centered when there is no `arrow` in the `EXPERIMENTAL_TableTree`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `checkbox` was not vertically centered when there is no `arrow` in the `EXPERIMENTAL_TableTree`.
+
 ## [9.96.8] - 2019-11-19
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.96.8",
+  "version": "9.96.9",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.96.8",
+  "version": "9.96.9",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_TableTree/Tree/CellPrefix.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/CellPrefix.tsx
@@ -13,7 +13,7 @@ const CellPrefix: FC<CellPrefixProps> & CellPrefixComposites = ({
   return (
     <>
       <div className="dib" style={{ width }} />
-      <div className="dib pr3">
+      <div className="dib pr3 v-mid">
         <div className="flex w-100 items-center">{children}</div>
       </div>
     </>


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
[Running workspace](https://vitoria--storecomponents.myvtex.com/admin/collections/1094/)

#### How should this be manually tested?
Clone the repo and `yarn & yarn start`

#### Screenshots or example usage
Before
![image](https://user-images.githubusercontent.com/12852518/68330738-84c67a00-00b2-11ea-9015-6480f104a687.png)

After
![image](https://user-images.githubusercontent.com/12852518/68330984-ea1a6b00-00b2-11ea-93ff-a5fdcc6bc70f.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
