### PR TITLE
Show EXPERIMENTAL_BulkActions even if no action is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Show `EXPERIMENTAL_BulkActions` even if no actions is setted.
+- Show `EXPERIMENTAL_BulkActions` even if no action is set.
 
 ## [9.96.7] - 2019-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Show `EXPERIMENTAL_BulkActions` even if no actions is setted.
+
 ## [9.96.7] - 2019-11-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.96.8] - 2019-11-19
+
 ### Changed
 
 - Show `EXPERIMENTAL_BulkActions` even if no action is set.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.96.7",
+  "version": "9.96.8",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.96.7",
+  "version": "9.96.8",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/BulkActions.tsx
+++ b/react/components/EXPERIMENTAL_Table/BulkActions.tsx
@@ -25,7 +25,6 @@ const BulkActions: FC<BulkActionsProps> = ({
     bulkState,
     selectAllRows,
     deselectAllRows,
-    hasBulkActions,
     hasPrimaryBulkAction,
     hasSecondaryBulkActions,
   } = data
@@ -51,30 +50,28 @@ const BulkActions: FC<BulkActionsProps> = ({
         overflow: hasRowsSelected ? 'auto' : 'hidden',
         transition: BULK_ACTIONS_TRANSITION,
       }}>
-      {hasBulkActions && (
-        <div className="flex flex-row">
-          {hasPrimaryBulkAction && (
-            <div className="mr4">
-              <Button
-                variation="secondary"
-                size="small"
-                onClick={() => main.onClick(bulkActionsReturnedParameters)}>
-                {main.label}
-              </Button>
-            </div>
-          )}
-          {hasSecondaryBulkActions && (
-            <ActionMenu
-              label={texts.secondaryActionsLabel}
-              buttonProps={{ variation: 'secondary', size: 'small' }}
-              options={others.map(el => ({
-                label: el.label,
-                onClick: () => el.onClick(bulkActionsReturnedParameters),
-              }))}
-            />
-          )}
-        </div>
-      )}
+      <div className="flex flex-row">
+        {hasPrimaryBulkAction && (
+          <div className="mr4">
+            <Button
+              variation="secondary"
+              size="small"
+              onClick={() => main.onClick(bulkActionsReturnedParameters)}>
+              {main.label}
+            </Button>
+          </div>
+        )}
+        {hasSecondaryBulkActions && (
+          <ActionMenu
+            label={texts.secondaryActionsLabel}
+            buttonProps={{ variation: 'secondary', size: 'small' }}
+            options={others.map(el => ({
+              label: el.label,
+              onClick: () => el.onClick(bulkActionsReturnedParameters),
+            }))}
+          />
+        )}
+      </div>
       <div className="tr flex flex-row items-center">
         {!bulkState.allLinesSelected && (
           <span className="mr4 c-muted-4">

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableBulkActions.tsx
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableBulkActions.tsx
@@ -31,8 +31,6 @@ export default function useTableBulkActions({
     [bulkActions]
   )
 
-  const hasBulkActions = hasPrimaryBulkAction || hasSecondaryBulkActions
-
   const bulkedColumns = useMemo<Array<Column>>(() => {
     const headerRenderer = () => {
       const selectedRowsLength = bulkState.selectedRows.length
@@ -60,17 +58,15 @@ export default function useTableBulkActions({
       />
     )
 
-    return hasBulkActions
-      ? [
-          {
-            vtexTableRoot: 'bulk',
-            width: 40,
-            headerRenderer,
-            cellRenderer,
-          },
-          ...columns,
-        ]
-      : columns
+    return [
+      {
+        vtexTableRoot: 'bulk',
+        width: 40,
+        headerRenderer,
+        cellRenderer,
+      },
+      ...columns,
+    ]
   }, [bulkState.selectedRows, bulkState.allLinesSelected])
 
   useEffect(() => {
@@ -138,7 +134,6 @@ export default function useTableBulkActions({
 
   return {
     /** constraints */
-    hasBulkActions,
     hasPrimaryBulkAction,
     hasSecondaryBulkActions,
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
In the `ProductsTable` of the `admin-collections` we need to use the bulkActions without set any action to it, according to the design as you can see bellow. For now, if the main and the other actions are not set, the component does not appear.
![image](https://user-images.githubusercontent.com/12852518/68704054-7cff4d80-056a-11ea-8d87-afc6c4905b73.png)

#### How should this be manually tested?
Run the following command and access the `http://localhost:6060/`:

```
yarn start
```

Or access the [workspace](https://waza--storecomponents.myvtex.com/admin/collections/1103/).

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
