### PR TITLE
fix width of progress type line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.96.6] - 2019-11-13
+
 ### Fixed
 
 - `Progress` when line type, renders with width 100%, regardless of your parent's display.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Progress` when line type, renders with width 100%, regardless of your parent's display.
+
 ## [9.96.5] - 2019-11-13
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.96.5",
+  "version": "9.96.6",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.96.5",
+  "version": "9.96.6",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Progress/Line.tsx
+++ b/react/components/Progress/Line.tsx
@@ -12,7 +12,7 @@ export const ProgressLine: React.FC<
 > = props => {
   const barClasses = cn(
     styles.progressHeight,
-    'br4 overflow-hidden bg-light-silver'
+    'w-100 br4 overflow-hidden bg-light-silver'
   )
   const stepClasses = cn(styles.progressHeight, 'br4', {
     'bg-action-primary': props.percent !== 100,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix width of progress type line

<!--- Describe your changes in detail. -->

#### What problem is this solving?
Progress type line do not render if your parent is a flex element

#### How should this be manually tested?
Access the styleguide locally in Progress section

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
