### PR TITLE
Update Line Chart Props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `hide` prop for allow hide a LineChart axis
+- `hide` prop to allow hiding a LineChart axis
 - `type` prop for allow different interpolations of the LineChart
 - `tick` prop for allow a customized label on LineChart
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `hide` prop to allow hiding a LineChart axis
-- `type` prop for allow different interpolations of the LineChart
+- `type` prop to allow different interpolations of the LineChart
 - `tick` prop for allow a customized label on LineChart
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `hide` prop to allow hiding a LineChart axis
 - `type` prop to allow different interpolations of the LineChart
-- `tick` prop for allow a customized label on LineChart
+- `tick` prop to allow a customized label on LineChart
 
 ### Changed
 - `axis` prop to `xAxis` and `yAxis` props on LineChart schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `axis` prop to `xAxis` and `yAxis` props on LineChart schema
 - default `container` prop to have a `width` and `height` dependent of the screen size
+- `schema` to `config` prop.
 
 ## [9.97.1] - 2019-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - `axis` prop to `xAxis` and `yAxis` props on LineChart schema
-- default `container` prop to have a `width` and `length` dependent of the screen size
+- default `container` prop to have a `width` and `height` dependent of the screen size
 
 ## [9.97.1] - 2019-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [9.97.2] - 2019-12-03
 ### Added
 - `hide` prop to allow hiding a LineChart axis
 - `type` prop to allow different interpolations of the LineChart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `hide` prop for allow hide a LineChart axis
+- `type` prop for allow different interpolations of the LineChart
+- `tick` prop for allow a customized label on LineChart
+
+### Changed
+- `axis` prop to `xAxis` and `yAxis` props on LineChart schema
 
 ## [9.97.1] - 2019-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - `axis` prop to `xAxis` and `yAxis` props on LineChart schema
+- default `container` prop to have a `width` and `length` dependent of the screen size
 
 ## [9.97.1] - 2019-12-03
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.97.1",
+  "version": "9.97.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.97.1",
+  "version": "9.97.2",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -1,15 +1,6 @@
 #### The line chart shows the data as a data points connected by a line. They are useful to analyze changes over the time, comparisons, and trends.
 
 ```js
-
-const CustomizedLabel = (props) => {
-  const {
-    x, y, fill, payload,
-  } = props
-  console.log('hello')
-  return (<text x={x} y={y} fill={fill} textAnchor="middle">{`h${payload.value}`}</text>)
-  
-}
   const sampleData = require('./sampleData').default;
   const keys = ['customers', 'orders', 'totalSpent'];
   const mapper = {
@@ -27,8 +18,7 @@ const CustomizedLabel = (props) => {
     data={sampleData}
     dataKeys={keys}
     xAxisKey='hour'
-    schema={{xAxis:{ tick: <CustomizedLabel />}}}
-    formatter={formatter}
+    tooltipFormatter={formatter}
   />
 ```
 
@@ -43,12 +33,12 @@ from the data to the axis.
 ```jsx noeditor
 const sampleData = require('./multilineSample').default;
 const keys = ['uv', 'pv', 'amt', 'gte', 'yaw'];
-const schema = {container: { height: 200, width: '40%'}};
+const customSchema = {container: { height: 200, width: '40%'}};
 <LineChart
   data={sampleData}
   dataKeys={keys}
-  schema={schema}
   xAxisKey='name'
+  schema={customSchema}
 />
 ```
 - Avoid to do grid competes visually with the data.
@@ -63,9 +53,15 @@ const schema = {
     height: 300,
     width: '100%'
   },
-  axis: {
+  xAxis: {
     axisLine: false,
-    tickLine: false
+    tickLine: false,
+    hide: false
+  },
+  yAxis: {
+    axisLine: false,
+    tickLine: false,
+    hide: false
   },
   grid: {
     horizontal: false,
@@ -75,11 +71,36 @@ const schema = {
 
 ```
 
-#### axis
-The axis property is responsible to change visual appearence of the axis in the chart.
+#### xAxis or yAxis
+This axis property are responsible to change visual appearence of the axis in the chart.
 
 - `tickLine`: If set true, axis tick lines will be drawn.
 - `axisLine`: If set true, axis line will be drawn.
+- `hide`: If set true, axis tick lines will be drawn.
+- `tick`: Takes a component instance which will be used to render the axis label. Your component instance will receive
+the props needed to render the label, like the `x` and `y` position of the tick in the line axis, the `payload` which represents the data
+and the `fill` the label color. As you can see below:
+
+```js
+const sampleData = require('./sampleData').default;
+const keys = ['customers', 'orders', 'totalSpent'];
+const CustomizedLabel = (props) => {
+  console.log(props)
+  const {
+    x, y, fill, payload,
+  } = props
+
+  return (<text x={x} y={y} fill={fill} textAnchor="middle">{`t-${payload.value}`}</text>)
+}
+
+<LineChart
+  data={sampleData}
+  dataKeys={keys}
+  xAxisKey='hour'
+  schema={{container: {height: 200, width: '40%'}, xAxis: {tick: <CustomizedLabel/>}}}
+/>
+```
+
 
 #### container
 The container property is responsible to define the size of box that will render the chart.
@@ -91,7 +112,8 @@ The container property is responsible to define the size of box that will render
 The grid property is responsible to show a grid inside the chart.
 
 - `horizontal`: If set true, horizontal grid lines will be drawn.
-- `vertical`: If set true, vertical grid lines will be drawn. 
+- `vertical`: If set true, vertical grid lines will be drawn.
+ 
 
 ### Formatting values on the tooltip
 

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -90,14 +90,15 @@ const CustomizedLabel = (props) => {
     x, y, fill, payload,
   } = props
 
-  return (<text x={x} y={y} fill={fill} textAnchor="middle">{`t-${payload.value}`}</text>)
-}
+  return (<text x={x} y={y} fill={fill} textAnchor="middle">{`h-${payload.value}`}</text>)
+};
+const customSchema = {container: {height: 200, width: '40%'}, xAxis: {tick: <CustomizedLabel/>}};
 
 <LineChart
   data={sampleData}
   dataKeys={keys}
   xAxisKey='hour'
-  schema={{container: {height: 200, width: '40%'}, xAxis: {tick: <CustomizedLabel/>}}}
+  schema={customSchema}
 />
 ```
 
@@ -111,11 +112,12 @@ The container property is responsible to define the size of box that will render
 ```js
 const sampleData = require('./sampleData').default;
 const keys = ['customers', 'orders', 'totalSpent'];
+const containerSchema = {container: {height: 100, width: '40%'}};
 <LineChart
   data={sampleData}
   dataKeys={keys}
   xAxisKey='hour'
-  schema={{yAxis:{tickLine: false}}}
+  schema={containerSchema}
 />
 ```
 
@@ -128,12 +130,13 @@ The grid property is responsible to show a grid inside the chart.
 ```js
 const sampleData = require('./sampleData').default;
 const keys = ['customers', 'orders', 'totalSpent'];
+const gridSchema = {grid: {vertical: true}};
 
 <LineChart
   data={sampleData}
   dataKeys={keys}
   xAxisKey='hour'
-  schema={{grid: {vertical: true}}}
+  schema={gridSchema}
 />
 ```
 

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -77,7 +77,7 @@ This axis property is responsible to change the visual appearance of the axis in
 
 - `tickLine`: If set true, axis tick lines will be drawn.
 - `axisLine`: If set true, axis line will be drawn.
-- `hide`: If set true, the axis do not display in the chart..
+- `hide`: If set true, the axis does not display in the chart.
 - `tick`: Renders a label of the axis. If you pass your component instance, it will receive
 the props needed to render the label, like the `x` and `y` position of the tick in the line axis, the `payload` which represents the data
 and the `fill` the label color. As you can see below:

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -113,7 +113,11 @@ The grid property is responsible to show a grid inside the chart.
 
 - `horizontal`: If set true, horizontal grid lines will be drawn.
 - `vertical`: If set true, vertical grid lines will be drawn.
- 
+
+### Line props
+
+- `type`: The interpolation type of line.
+
 
 ### Formatting values on the tooltip
 

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -108,11 +108,34 @@ The container property is responsible to define the size of box that will render
 - `height`: The percentage value of the chart's width or a fixed width.
 - `width`: The percentage value of the chart's width or a fixed height.
 
+```js
+const sampleData = require('./sampleData').default;
+const keys = ['customers', 'orders', 'totalSpent'];
+<LineChart
+  data={sampleData}
+  dataKeys={keys}
+  xAxisKey='hour'
+  schema={{yAxis:{tickLine: false}}}
+/>
+```
+
 #### grid
 The grid property is responsible to show a grid inside the chart.
 
 - `horizontal`: If set true, horizontal grid lines will be drawn.
 - `vertical`: If set true, vertical grid lines will be drawn.
+
+```js
+const sampleData = require('./sampleData').default;
+const keys = ['customers', 'orders', 'totalSpent'];
+
+<LineChart
+  data={sampleData}
+  dataKeys={keys}
+  xAxisKey='hour'
+  schema={{grid: {vertical: true}}}
+/>
+```
 
 ### Line props
 

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -41,7 +41,7 @@ const customConfig = {container: { height: '40%', width: '40%'}};
   config={customConfig}
 />
 ```
-- Avoid makes grid competes visually with the data.
+- Avoid the grid from visually competing with the data.
 
 
 # Line chart Config
@@ -229,4 +229,3 @@ const formatter2 = (value, name) => {
   return mapper[name]
 }
 ```
-

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -33,7 +33,7 @@ from the data to the axis.
 ```jsx noeditor
 const sampleData = require('./multilineSample').default;
 const keys = ['uv', 'pv', 'amt', 'gte', 'yaw'];
-const customConfig = {container: { height: '100%', width: '60%'}};
+const customConfig = {container: { height: '40%', width: '40%'}};
 <LineChart
   data={sampleData}
   dataKeys={keys}

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -78,7 +78,7 @@ This axis property are responsible to change visual appearence of the axis in th
 - `tickLine`: If set true, axis tick lines will be drawn.
 - `axisLine`: If set true, axis line will be drawn.
 - `hide`: If set true, the axis do not display in the chart..
-- `tick`: Takes a component instance which will be used to render the axis label. Your component instance will receive
+- `tick`: Renders a label of the axis. If you pass your component instance, it will receive
 the props needed to render the label, like the `x` and `y` position of the tick in the line axis, the `payload` which represents the data
 and the `fill` the label color. As you can see below:
 

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -1,6 +1,15 @@
 #### The line chart shows the data as a data points connected by a line. They are useful to analyze changes over the time, comparisons, and trends.
 
 ```js
+
+const CustomizedLabel = (props) => {
+  const {
+    x, y, fill, payload,
+  } = props
+  console.log('hello')
+  return (<text x={x} y={y} fill={fill} textAnchor="middle">{`h${payload.value}`}</text>)
+  
+}
   const sampleData = require('./sampleData').default;
   const keys = ['customers', 'orders', 'totalSpent'];
   const mapper = {
@@ -18,6 +27,7 @@
     data={sampleData}
     dataKeys={keys}
     xAxisKey='hour'
+    schema={{xAxis:{tick: <CustomizedLabel />}}}
     formatter={formatter}
   />
 ```

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -109,7 +109,7 @@ const keys = ['customers'];
 The grid property is responsible to show a grid inside the chart.
 
 - `horizontal`: If set to `true`, horizontal grid lines will be drawn.
-- `vertical`: If set true, vertical grid lines will be drawn.
+- `vertical`: If set to `true`, vertical grid lines will be drawn.
 
 ```js
 const sampleData = require('./sampleData').default;

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -77,7 +77,7 @@ This axis property are responsible to change visual appearence of the axis in th
 
 - `tickLine`: If set true, axis tick lines will be drawn.
 - `axisLine`: If set true, axis line will be drawn.
-- `hide`: If set true, axis tick lines will be drawn.
+- `hide`: If set true, the axis do not display in the chart..
 - `tick`: Takes a component instance which will be used to render the axis label. Your component instance will receive
 the props needed to render the label, like the `x` and `y` position of the tick in the line axis, the `payload` which represents the data
 and the `fill` the label color. As you can see below:
@@ -88,7 +88,7 @@ const CustomizedLabel = (props) => {
     x, y, fill, payload,
   } = props
 
-  return (<text x={x} y={y} fill={fill} textAnchor="middle">{`${payload.value}🕐`}</text>)
+  return (<text x={x} y={y} fill={fill} textAnchor="middle">{`${payload.value.toUpperCase()}`}</text>)
 };
 
 const sampleData = require('./sampleData').default;
@@ -98,7 +98,10 @@ const keys = ['customers'];
   data={sampleData}
   dataKeys={keys}
   xAxisKey='hour'
-  schema={{container: {height: 300, width: '100%'}, xAxis:{tick: <CustomizedLabel />}}}
+  schema={{
+    container: {height: 300, width: '100%'}, 
+    xAxis:{tick: <CustomizedLabel />}
+  }}
 />
 ```
 
@@ -109,16 +112,20 @@ The grid property is responsible to show a grid inside the chart.
 - `vertical`: If set true, vertical grid lines will be drawn.
 
 ```js
-const sampleData = require('./multilineSample').default;
-const keys = ['uv', 'pv'];
+const sampleData = require('./sampleData').default;
+const keys = ['customers'];
 
 <LineChart
   data={sampleData}
   dataKeys={keys}
-  xAxisKey='name'
-  schema={{grid: {vertical: true, horizontal: true}}}
+  xAxisKey='hour'
+  schema={{ 
+    xAxis:{tick: true},
+    grid: {vertical: true, horizontal: true}
+  }}
 />
 ```
+
 
 #### container
 The container property is responsible to define the size of box that will render the chart.
@@ -134,7 +141,11 @@ const keys = ['customers'];
   data={sampleData}
   dataKeys={keys}
   xAxisKey='hour'
-  schema={{container: {height: 200, width: '100%'}}}
+  schema={{
+    container: {height: 150, width: '80%'}, 
+    xAxis: {tick: true}, 
+    grid: {vertical: false, horizontal: false}
+  }}
 />
 ```
 

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -73,7 +73,7 @@ const schema = {
 
 
 #### xAxis or yAxis
-This axis property are responsible to change visual appearence of the axis in the chart.
+This axis property is responsible to change the visual appearance of the axis in the chart.
 
 - `tickLine`: If set true, axis tick lines will be drawn.
 - `axisLine`: If set true, axis line will be drawn.

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -33,7 +33,7 @@ from the data to the axis.
 ```jsx noeditor
 const sampleData = require('./multilineSample').default;
 const keys = ['uv', 'pv', 'amt', 'gte', 'yaw'];
-const customSchema = {container: { height: 200, width: '40%'}};
+const customSchema = {container: { height: '100%', width: '60%'}};
 <LineChart
   data={sampleData}
   dataKeys={keys}
@@ -99,7 +99,6 @@ const keys = ['customers'];
   dataKeys={keys}
   xAxisKey='hour'
   schema={{
-    container: {height: 300, width: '100%'}, 
     xAxis:{tick: <CustomizedLabel />}
   }}
 />
@@ -142,7 +141,6 @@ const keys = ['customers'];
   dataKeys={keys}
   xAxisKey='hour'
   schema={{
-    container: {height: 150, width: '80%'}, 
     xAxis: {tick: true}, 
     grid: {vertical: false, horizontal: false}
   }}

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -41,7 +41,7 @@ const customConfig = {container: { height: '100%', width: '60%'}};
   config={customConfig}
 />
 ```
-- Avoid to do grid competes visually with the data.
+- Avoid makes grid competes visually with the data.
 
 
 # Line chart Config

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -128,7 +128,7 @@ const keys = ['customers'];
 
 
 #### container
-The container property is responsible to define the size of box that will render the chart.
+The container property is responsible to define the size of the box that will render the chart.
 
 - `height`: The percentage value of the chart's width or a fixed width.
 - `width`: The percentage value of the chart's width or a fixed height.

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -27,7 +27,7 @@ const CustomizedLabel = (props) => {
     data={sampleData}
     dataKeys={keys}
     xAxisKey='hour'
-    schema={{xAxis:{tick: <CustomizedLabel />}}}
+    schema={{xAxis:{ tick: <CustomizedLabel />}}}
     formatter={formatter}
   />
 ```

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -108,7 +108,7 @@ const keys = ['customers'];
 #### grid
 The grid property is responsible to show a grid inside the chart.
 
-- `horizontal`: If set true, horizontal grid lines will be drawn.
+- `horizontal`: If set to `true`, horizontal grid lines will be drawn.
 - `vertical`: If set true, vertical grid lines will be drawn.
 
 ```js

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -33,22 +33,22 @@ from the data to the axis.
 ```jsx noeditor
 const sampleData = require('./multilineSample').default;
 const keys = ['uv', 'pv', 'amt', 'gte', 'yaw'];
-const customSchema = {container: { height: '100%', width: '60%'}};
+const customConfig = {container: { height: '100%', width: '60%'}};
 <LineChart
   data={sampleData}
   dataKeys={keys}
   xAxisKey='name'
-  schema={customSchema}
+  config={customConfig}
 />
 ```
 - Avoid to do grid competes visually with the data.
 
 
-# Line chart schema
-The schema prop defines the style of the chart. This should be given as an object with styles defined for `axis`, `grid`, `container`, according to your needs.  
+# Line chart Config
+The config prop defines the style of the chart. This should be given as an object with styles defined for `axis`, `grid`, `container`, according to your needs.  
 
 ```js noeditor static
-const schema = {
+const config = {
   container:{
     height: 300,
     width: '100%'
@@ -98,7 +98,7 @@ const keys = ['customers'];
   data={sampleData}
   dataKeys={keys}
   xAxisKey='hour'
-  schema={{
+  config={{
     xAxis:{tick: <CustomizedLabel />}
   }}
 />
@@ -118,7 +118,7 @@ const keys = ['customers'];
   data={sampleData}
   dataKeys={keys}
   xAxisKey='hour'
-  schema={{ 
+  config={{ 
     xAxis:{tick: true},
     grid: {vertical: true, horizontal: true}
   }}
@@ -140,7 +140,7 @@ const keys = ['customers'];
   data={sampleData}
   dataKeys={keys}
   xAxisKey='hour'
-  schema={{
+  config={{
     xAxis: {tick: true}, 
     grid: {vertical: false, horizontal: false}
   }}

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -68,9 +68,7 @@ const config = {
     vertical: false,
   }
 };
-
 ```
-
 
 #### xAxis or yAxis
 This axis property is responsible to change the visual appearance of the axis in the chart.
@@ -150,7 +148,64 @@ const keys = ['customers'];
 
 ### Line props
 
-- `type`: The interpolation type of line. For more details, check the [recharts types](http://recharts.org/en-US/api/Line#type)
+- `type`: The interpolation type of line.
+```js
+const sampleData = require('./sampleData').default;
+const keys = ['customers'];
+
+const Dropdown = require('../../Dropdown/index.js').default;
+const options = [
+  { value: 'basis', label: 'Basis' },
+  { value: 'basisClosed', label: 'Basis Closed' },
+  { value: 'basisOpen', label: 'Basis Open' },
+  { value: 'linear', label: 'Linear' },
+  { value: 'linearClosed', label: 'Linear Closed' },
+  { value: 'natural', label: 'Natural' },
+  { value: 'monotoneX', label: 'MonotoneX' },
+  { value: 'monotoneY', label: 'MonotoneY' },
+  { value: 'monotone', label: 'Monotone' },
+  { value: 'step', label: 'Step' },
+  { value: 'stepBefore', label: 'Step Before' },
+  { value: 'stepAfter', label: 'Step After' },
+]
+
+class InterpolationExample extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      interpolation: "monotone",
+    };
+  }
+  render() {
+    return (
+      <div>
+        <Dropdown
+          label="Interpolation"
+          size="small"
+          options={options}
+          value={this.state.interpolation}
+          onChange={(event) => {
+            this.setState({interpolation: event.target.value})
+          }}
+        />
+        <br/> <br/>
+        <LineChart
+          data={sampleData}
+          dataKeys={keys}
+          xAxisKey='hour'
+          config={{
+            xAxis: {tick: true}, 
+            grid: {vertical: false, horizontal: false}
+          }}
+          lineProps={{type: this.state.interpolation}}
+        />
+      </div>
+    )
+  }
+}
+
+<InterpolationExample/>
+```
 
 
 ### Formatting values on the tooltip

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -71,6 +71,7 @@ const schema = {
 
 ```
 
+
 #### xAxis or yAxis
 This axis property are responsible to change visual appearence of the axis in the chart.
 
@@ -82,42 +83,22 @@ the props needed to render the label, like the `x` and `y` position of the tick 
 and the `fill` the label color. As you can see below:
 
 ```js
-const sampleData = require('./sampleData').default;
-const keys = ['customers', 'orders', 'totalSpent'];
 const CustomizedLabel = (props) => {
-  console.log(props)
   const {
     x, y, fill, payload,
   } = props
 
-  return (<text x={x} y={y} fill={fill} textAnchor="middle">{`h-${payload.value}`}</text>)
+  return (<text x={x} y={y} fill={fill} textAnchor="middle">{`${payload.value}🕐`}</text>)
 };
-const customSchema = {container: {height: 200, width: '40%'}, xAxis: {tick: <CustomizedLabel/>}};
 
-<LineChart
-  data={sampleData}
-  dataKeys={keys}
-  xAxisKey='hour'
-  schema={customSchema}
-/>
-```
-
-
-#### container
-The container property is responsible to define the size of box that will render the chart.
-
-- `height`: The percentage value of the chart's width or a fixed width.
-- `width`: The percentage value of the chart's width or a fixed height.
-
-```js
 const sampleData = require('./sampleData').default;
-const keys = ['customers', 'orders', 'totalSpent'];
-const containerSchema = {container: {height: 100, width: '40%'}};
+const keys = ['customers'];
+
 <LineChart
   data={sampleData}
   dataKeys={keys}
   xAxisKey='hour'
-  schema={containerSchema}
+  schema={{container: {height: 300, width: '100%'}, xAxis:{tick: <CustomizedLabel />}}}
 />
 ```
 
@@ -128,21 +109,39 @@ The grid property is responsible to show a grid inside the chart.
 - `vertical`: If set true, vertical grid lines will be drawn.
 
 ```js
+const sampleData = require('./multilineSample').default;
+const keys = ['uv', 'pv'];
+
+<LineChart
+  data={sampleData}
+  dataKeys={keys}
+  xAxisKey='name'
+  schema={{grid: {vertical: true, horizontal: true}}}
+/>
+```
+
+#### container
+The container property is responsible to define the size of box that will render the chart.
+
+- `height`: The percentage value of the chart's width or a fixed width.
+- `width`: The percentage value of the chart's width or a fixed height.
+
+```js
 const sampleData = require('./sampleData').default;
-const keys = ['customers', 'orders', 'totalSpent'];
-const gridSchema = {grid: {vertical: true}};
+const keys = ['customers'];
 
 <LineChart
   data={sampleData}
   dataKeys={keys}
   xAxisKey='hour'
-  schema={gridSchema}
+  schema={{container: {height: 200, width: '100%'}}}
 />
 ```
 
+
 ### Line props
 
-- `type`: The interpolation type of line.
+- `type`: The interpolation type of line. For more details, check the [recharts types](http://recharts.org/en-US/api/Line#type)
 
 
 ### Formatting values on the tooltip

--- a/react/components/EXPERIMENTAL_Charts/LineChart/constants.ts
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/constants.ts
@@ -8,14 +8,11 @@ export const colors = [
   '#0000FF'
 ]
 
-
 export const defaultProps: DefaultLineProps = {
   type: 'monotone',
   strokeWidth: 3,
   dot: false,
 }
-
-
 
 export const tooltipProps = {
   cursor: false,

--- a/react/components/EXPERIMENTAL_Charts/LineChart/constants.ts
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/constants.ts
@@ -8,7 +8,7 @@ export const colors = [
   '#0000FF'
 ]
 
-type DefaultLineProps = Pick<LineProps, 'type' | 'strokeWidth' | 'dot'>
+
 export const defaultProps: DefaultLineProps = {
   type: 'monotone',
   strokeWidth: 3,

--- a/react/components/EXPERIMENTAL_Charts/LineChart/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/helpers.ts
@@ -1,0 +1,9 @@
+import { defaultProps } from './constants'
+
+const getLineDefaultProps = (userProps: LineProps)  => {
+    const lineConfigs = {...defaultProps, ...userProps}
+    return { lineConfigs }
+}
+
+
+export default getLineDefaultProps

--- a/react/components/EXPERIMENTAL_Charts/LineChart/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/helpers.ts
@@ -1,9 +1,0 @@
-import { defaultProps } from './constants'
-
-const getLineDefaultProps = (userProps: LineProps)  => {
-    const lineConfigs = {...defaultProps, ...userProps}
-    return { lineConfigs }
-}
-
-
-export default getLineDefaultProps

--- a/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
@@ -19,7 +19,7 @@ interface Props {
   data: any,
   dataKeys: string[],
   xAxisKey: string,
-  schema: ChartProps,
+  config: ChartProps,
   tooltipFormatter: TooltipFormatter,
   lineProps: LineProps,
 }
@@ -38,11 +38,11 @@ const LineChart: FC<Props> = ({
   data,
   dataKeys,
   xAxisKey,
-  schema,
+  config,
   tooltipFormatter,
   lineProps
 }) => {
-  const { configs } = getChartDefaultProps(schema); 
+  const { configs } = getChartDefaultProps(config); 
   const { lineConfigs } = getLineDefaultProps(lineProps)
 
   return (
@@ -72,7 +72,7 @@ LineChart.propTypes = {
   tooltipFormatter: PropTypes.func,
   
   /** The schema prop changes some styles of the chart. This prop should be given as an object.*/
-  schema: PropTypes.object,
+  config: PropTypes.object,
 
   /** The interpolation defines how data points should be connected when creating a path.*/
   lineProps: PropTypes.object,

--- a/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
@@ -42,7 +42,8 @@ const LineChart: FC<Props> = ({
   tooltipFormatter,
   lineProps
 }) => {
-  const { configs } = getChartDefaultProps(schema);  
+  const { configs } = getChartDefaultProps(schema); 
+  console.log(configs.xAxis.padding)
   const { lineConfigs } = getLineDefaultProps(lineProps)
 
   return (

--- a/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
@@ -72,7 +72,32 @@ LineChart.propTypes = {
   tooltipFormatter: PropTypes.func,
   
   /** The schema prop changes some styles of the chart. This prop should be given as an object.*/
-  config: PropTypes.object,
+  config: PropTypes.shape({
+    xAxis: PropTypes.shape({
+      axisLine: PropTypes.bool,
+      tickLine: PropTypes.bool,
+      tick: PropTypes.bool,
+      hide: PropTypes.bool
+    }),
+    yAxis: PropTypes.shape({
+      axisLine: PropTypes.bool,
+      tickLine: PropTypes.bool,
+      tick: PropTypes.bool,
+      hide: PropTypes.bool
+    }), 
+    container: PropTypes.shape({
+      height: PropTypes.oneOfType(
+        [PropTypes.string, PropTypes.number]
+      ),
+      width: PropTypes.oneOfType(
+        [PropTypes.string, PropTypes.number]
+      ),
+    }),
+    grid: PropTypes.shape({
+      horizontal: PropTypes.bool,
+      vertical: PropTypes.bool,
+    })
+  }),
 
   /** The interpolation defines how data points should be connected when creating a path.*/
   lineProps: PropTypes.object,

--- a/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
@@ -43,18 +43,14 @@ const LineChart: FC<Props> = ({
   lineProps
 }) => {
   const { configs } = getChartDefaultProps(schema); 
-  console.log(configs.xAxis.padding)
   const { lineConfigs } = getLineDefaultProps(lineProps)
 
   return (
     <ResponsiveContainer {...configs.container}>
       <LineChartBase data={data}>
-        <XAxis dataKey={xAxisKey} {...configs.xAxis} />
-        <YAxis {...configs.yAxis}/>
-        <CartesianGrid
-          horizontal={configs.grid.horizontal}
-          vertical={configs.grid.vertical}
-        />
+        <CartesianGrid {...configs.grid}/>
+        <XAxis dataKey={xAxisKey} {...configs.xAxis}/>
+        <YAxis  {...configs.yAxis} />
         <Tooltip formatter={tooltipFormatter} {...tooltipProps}/>
         {zipWith(dataKeys, colors, curry(renderLine)(lineConfigs))}
       </LineChartBase>

--- a/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
@@ -12,8 +12,7 @@ import {
 } from 'recharts'
 import PropTypes from 'prop-types'
 import { colors, tooltipProps } from './constants'
-import getChartDefaultProps from '../helpers'
-import getLineDefaultProps from './helpers';
+import { getChartDefaultProps, getLineDefaultProps }from '../helpers'
 
 interface Props {
   data: any,

--- a/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, PureComponent } from 'react'
 import { zipWith, curry } from 'lodash'
 import {
   Line,
@@ -9,7 +9,8 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   TooltipFormatter,
-  LineType,
+  XAxisProps,
+  TickFormatterFunction,
 } from 'recharts'
 import PropTypes from 'prop-types'
 import { colors, tooltipProps } from './constants'
@@ -33,6 +34,7 @@ const renderLine = (lineConfigs, key, color) =>(
     {...lineConfigs}
   />
 )
+
 
 const LineChart: FC<Props> = ({
   data,

--- a/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PureComponent } from 'react'
+import React, { FC } from 'react'
 import { zipWith, curry } from 'lodash'
 import {
   Line,
@@ -20,7 +20,7 @@ interface Props {
   dataKeys: string[],
   xAxisKey: string,
   schema: ChartProps,
-  formatter: TooltipFormatter,
+  tooltipFormatter: TooltipFormatter,
   lineProps: LineProps,
 }
 
@@ -39,7 +39,7 @@ const LineChart: FC<Props> = ({
   dataKeys,
   xAxisKey,
   schema,
-  formatter,
+  tooltipFormatter,
   lineProps
 }) => {
   const { configs } = getChartDefaultProps(schema);  
@@ -54,7 +54,7 @@ const LineChart: FC<Props> = ({
           horizontal={configs.grid.horizontal}
           vertical={configs.grid.vertical}
         />
-        <Tooltip formatter={formatter} {...tooltipProps}/>
+        <Tooltip formatter={tooltipFormatter} {...tooltipProps}/>
         {zipWith(dataKeys, colors, curry(renderLine)(lineConfigs))}
       </LineChartBase>
     </ResponsiveContainer>
@@ -72,7 +72,7 @@ LineChart.propTypes = {
   xAxisKey: PropTypes.string.isRequired,
   
   /** The formatter function of value in tooltip. If you return an array, the first entry will be the formatted "value", and the second entry will be the formatted "key" */
-  formatter: PropTypes.func,
+  tooltipFormatter: PropTypes.func,
   
   /** The schema prop changes some styles of the chart. This prop should be given as an object.*/
   schema: PropTypes.object,

--- a/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { zipWith } from 'lodash'
+import { zipWith, curry } from 'lodash'
 import {
   Line,
   LineChart as LineChartBase,
@@ -9,25 +9,28 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   TooltipFormatter,
+  LineType,
 } from 'recharts'
 import PropTypes from 'prop-types'
-import { colors, defaultProps, tooltipProps } from './constants'
-import getDefaultProps from '../helpers'
+import { colors, tooltipProps } from './constants'
+import getChartDefaultProps from '../helpers'
+import getLineDefaultProps from './helpers';
 
 interface Props {
   data: any,
   dataKeys: string[],
   xAxisKey: string,
   schema: ChartProps,
-  formatter: TooltipFormatter
+  formatter: TooltipFormatter,
+  lineProps: LineProps,
 }
 
-const renderLine = (key, color) => (
+const renderLine = (lineConfigs, key, color) =>(
   <Line
     key={key}
     dataKey={key}
     stroke={color}
-    {...defaultProps}
+    {...lineConfigs}
   />
 )
 
@@ -36,21 +39,23 @@ const LineChart: FC<Props> = ({
   dataKeys,
   xAxisKey,
   schema,
-  formatter
+  formatter,
+  lineProps
 }) => {
-  const { configs } = getDefaultProps(schema); 
+  const { configs } = getChartDefaultProps(schema);  
+  const { lineConfigs } = getLineDefaultProps(lineProps)
 
   return (
     <ResponsiveContainer {...configs.container}>
       <LineChartBase data={data}>
-        <XAxis dataKey={xAxisKey} {...configs.axis} />
-        <YAxis {...configs.axis}/>
+        <XAxis dataKey={xAxisKey} {...configs.xAxis} />
+        <YAxis {...configs.yAxis}/>
         <CartesianGrid
           horizontal={configs.grid.horizontal}
           vertical={configs.grid.vertical}
         />
         <Tooltip formatter={formatter} {...tooltipProps}/>
-        {zipWith(dataKeys, colors, renderLine)}
+        {zipWith(dataKeys, colors, curry(renderLine)(lineConfigs))}
       </LineChartBase>
     </ResponsiveContainer>
   )
@@ -71,6 +76,9 @@ LineChart.propTypes = {
   
   /** The schema prop changes some styles of the chart. This prop should be given as an object.*/
   schema: PropTypes.object,
+
+  /** The interpolation defines how data points should be connected when creating a path.*/
+  lineProps: PropTypes.object,
 }
   
 export default LineChart

--- a/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/index.tsx
@@ -9,8 +9,6 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   TooltipFormatter,
-  XAxisProps,
-  TickFormatterFunction,
 } from 'recharts'
 import PropTypes from 'prop-types'
 import { colors, tooltipProps } from './constants'

--- a/react/components/EXPERIMENTAL_Charts/LineChart/multilineSample.js
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/multilineSample.js
@@ -1,6 +1,6 @@
 const data = [
   {
-    name: 'Page A',
+    name: 'a',
     uv: 4000,
     pv: 2400,
     amt: 2400,
@@ -8,7 +8,7 @@ const data = [
     yaw: 8000,
   },
   {
-    name: 'Page B',
+    name: 'b',
     uv: 3000,
     pv: 1398,
     amt: 2210,
@@ -16,7 +16,7 @@ const data = [
     yaw: 1200,
   },
   {
-    name: 'Page C',
+    name: 'c',
     uv: 2000,
     pv: 9800,
     amt: 2290,
@@ -24,7 +24,7 @@ const data = [
     yaw: 3500,
   },
   {
-    name: 'Page D',
+    name: 'd',
     uv: 2780,
     pv: 3908,
     amt: 2000,
@@ -32,7 +32,7 @@ const data = [
     yaw: 7000,
   },
   {
-    name: 'Page E',
+    name: 'e',
     uv: 1890,
     pv: 4800,
     amt: 2181,
@@ -40,15 +40,7 @@ const data = [
     yaw: 8456,
   },
   {
-    name: 'Page F',
-    uv: 2390,
-    pv: 3800,
-    amt: 2500,
-    gte: 1890,
-    yaw: 3000,
-  },
-  {
-    name: 'Page G',
+    name: 'g',
     uv: 3490,
     pv: 4300,
     amt: 2100,

--- a/react/components/EXPERIMENTAL_Charts/commonProps.ts
+++ b/react/components/EXPERIMENTAL_Charts/commonProps.ts
@@ -6,14 +6,14 @@ export const commonDefaultProps = {
   xAxis: {
     axisLine: false,
     tickLine: false,
-    padding: { left: 10, right: 10 },
+    padding: { left: 20, right: 20 },
     tick: undefined,
     hide: false
   },
   yAxis: {
     axisLine: false,
     tickLine: false,
-    padding: { top: 10, bottom: 10 },
+    padding: { top: 20, bottom: 10 },
     tick: undefined,
     hide: false
   },

--- a/react/components/EXPERIMENTAL_Charts/commonProps.ts
+++ b/react/components/EXPERIMENTAL_Charts/commonProps.ts
@@ -6,12 +6,14 @@ export const commonDefaultProps = {
   xAxis: {
     axisLine: false,
     tickLine: false,
-    padding: { left: 10, right: 10 }
+    padding: { left: 10, right: 10 },
+    tick: undefined,
   },
   yAxis: {
     axisLine: false,
     tickLine: false,
-    padding: { left: 10, right: 10 }
+    padding: { top: 10, bottom: 10 },
+    tick: undefined,
   },
   grid: {
     horizontal: false,

--- a/react/components/EXPERIMENTAL_Charts/commonProps.ts
+++ b/react/components/EXPERIMENTAL_Charts/commonProps.ts
@@ -8,12 +8,14 @@ export const commonDefaultProps = {
     tickLine: false,
     padding: { left: 10, right: 10 },
     tick: undefined,
+    hide: false
   },
   yAxis: {
     axisLine: false,
     tickLine: false,
     padding: { top: 10, bottom: 10 },
     tick: undefined,
+    hide: false
   },
   grid: {
     horizontal: false,

--- a/react/components/EXPERIMENTAL_Charts/commonProps.ts
+++ b/react/components/EXPERIMENTAL_Charts/commonProps.ts
@@ -1,7 +1,8 @@
 export const commonDefaultProps = {
   container:{
-    height: 300,
-    width: '100%'
+    height: '99%',
+    width: '100%',
+    aspect: 4.0/3.0
   },
   xAxis: {
     axisLine: false,

--- a/react/components/EXPERIMENTAL_Charts/commonProps.ts
+++ b/react/components/EXPERIMENTAL_Charts/commonProps.ts
@@ -1,6 +1,6 @@
 export const commonDefaultProps = {
   container:{
-    height: '99%',
+    height: '100%',
     width: '100%',
     aspect: 4.0/3.0
   },

--- a/react/components/EXPERIMENTAL_Charts/commonProps.ts
+++ b/react/components/EXPERIMENTAL_Charts/commonProps.ts
@@ -6,15 +6,15 @@ export const commonDefaultProps = {
   xAxis: {
     axisLine: false,
     tickLine: false,
-    padding: { left: 20, right: 20 },
-    tick: undefined,
+    tick: true,
+    tickMargin: 15,
     hide: false
   },
   yAxis: {
     axisLine: false,
     tickLine: false,
-    padding: { top: 20, bottom: 10 },
-    tick: undefined,
+    tick: true,
+    tickMargin: 10,
     hide: false
   },
   grid: {

--- a/react/components/EXPERIMENTAL_Charts/commonProps.ts
+++ b/react/components/EXPERIMENTAL_Charts/commonProps.ts
@@ -3,7 +3,12 @@ export const commonDefaultProps = {
     height: 300,
     width: '100%'
   },
-  axis: {
+  xAxis: {
+    axisLine: false,
+    tickLine: false,
+    padding: { left: 10, right: 10 }
+  },
+  yAxis: {
     axisLine: false,
     tickLine: false,
     padding: { left: 10, right: 10 }

--- a/react/components/EXPERIMENTAL_Charts/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/helpers.ts
@@ -7,7 +7,7 @@ const getDefaultProps = (userProps: ChartProps)  => {
     props[key] = merge(props[key], userProps[key])
   ))
   
-  return { configs: props}
+  return { configs: props }
 }
 
 

--- a/react/components/EXPERIMENTAL_Charts/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/helpers.ts
@@ -1,10 +1,13 @@
+import { merge } from 'lodash'
 import { commonDefaultProps } from './commonProps'
 
 const getDefaultProps = (userProps: ChartProps)  => {
-    const alteredKeys = Object.keys(userProps);
-    const props = commonDefaultProps
-    alteredKeys.map(key => props[key] = {...commonDefaultProps[key], ...userProps[key]})
-    return { configs: props}
+  const props = commonDefaultProps
+  Object.keys(userProps).forEach(key => (
+    props[key] = merge(props[key], userProps[key])
+  ))
+  
+  return { configs: props}
 }
 
 

--- a/react/components/EXPERIMENTAL_Charts/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/helpers.ts
@@ -4,7 +4,7 @@ import { commonDefaultProps } from './commonProps'
 const getDefaultProps = (userProps: ChartProps)  => {
   const props = commonDefaultProps
   userProps && Object.keys(userProps).forEach(key => (
-    props[key] = merge(props[key], userProps[key])
+    props[key] = {...props[key], ...userProps[key]}
   ))
   
   return { configs: props}

--- a/react/components/EXPERIMENTAL_Charts/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/helpers.ts
@@ -5,4 +5,5 @@ const getDefaultProps = (userProps: ChartProps)  => {
     return { configs }
 }
 
+
 export default getDefaultProps

--- a/react/components/EXPERIMENTAL_Charts/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/helpers.ts
@@ -1,8 +1,10 @@
 import { commonDefaultProps } from './commonProps'
 
 const getDefaultProps = (userProps: ChartProps)  => {
-    const configs: ChartProps = {...commonDefaultProps, ...userProps}
-    return { configs }
+    const alteredKeys = Object.keys(userProps);
+    const props = commonDefaultProps
+    alteredKeys.map(key => props[key] = {...commonDefaultProps[key], ...userProps[key]})
+    return { configs: props}
 }
 
 

--- a/react/components/EXPERIMENTAL_Charts/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/helpers.ts
@@ -3,7 +3,8 @@ import { commonDefaultProps } from './commonProps'
 
 const getDefaultProps = (userProps: ChartProps)  => {
   const props = commonDefaultProps
-  Object.keys(userProps).forEach(key => (
+  console.log(props.container)
+  userProps && Object.keys(userProps).forEach(key => (
     props[key] = merge(props[key], userProps[key])
   ))
   

--- a/react/components/EXPERIMENTAL_Charts/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/helpers.ts
@@ -4,7 +4,7 @@ import { commonDefaultProps } from './commonProps'
 const getDefaultProps = (userProps: ChartProps)  => {
   const props = commonDefaultProps
   userProps && Object.keys(userProps).forEach(key => (
-    props[key] = {...props[key], ...userProps[key]}
+    props[key] = merge(props[key], userProps[key])
   ))
   
   return { configs: props}

--- a/react/components/EXPERIMENTAL_Charts/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/helpers.ts
@@ -3,7 +3,6 @@ import { commonDefaultProps } from './commonProps'
 
 const getDefaultProps = (userProps: ChartProps)  => {
   const props = commonDefaultProps
-  console.log(props.container)
   userProps && Object.keys(userProps).forEach(key => (
     props[key] = merge(props[key], userProps[key])
   ))

--- a/react/components/EXPERIMENTAL_Charts/helpers.ts
+++ b/react/components/EXPERIMENTAL_Charts/helpers.ts
@@ -1,7 +1,8 @@
 import { merge } from 'lodash'
 import { commonDefaultProps } from './commonProps'
+import { defaultProps } from './LineChart/constants'
 
-const getDefaultProps = (userProps: ChartProps)  => {
+const getChartDefaultProps = (userProps: ChartProps)  => {
   const props = commonDefaultProps
   userProps && Object.keys(userProps).forEach(key => (
     props[key] = merge(props[key], userProps[key])
@@ -10,5 +11,12 @@ const getDefaultProps = (userProps: ChartProps)  => {
   return { configs: props }
 }
 
+const getLineDefaultProps = (userProps: LineProps)  => {
+    const lineConfigs = {...defaultProps, ...userProps}
+    return { lineConfigs }
+}
 
-export default getDefaultProps
+export {
+  getChartDefaultProps,
+  getLineDefaultProps
+}

--- a/react/components/EXPERIMENTAL_Charts/typings.d.ts
+++ b/react/components/EXPERIMENTAL_Charts/typings.d.ts
@@ -1,9 +1,15 @@
 type BaseGridProps = Pick<CartesianGridProps, 'vertical' | 'horizontal'>
 type BaseAxisProps = Pick<XAxisProps, 'axisLine' | 'tickLine', 'padding'>
 type BaseContainerProps = Pick<ResponsiveContainerProps, 'height' | 'width'>
+type DefaultLineProps = Pick<LineProps, 'type' | 'strokeWidth' | 'dot'>
 
 type ChartProps = {
-  axis?: BaseAxisProps,
+  xAxis?: BaseAxisProps,
+  yAxis?: BaseAxisProps, 
   container?: BaseContainerProps,
   grid?: BaseGridProps
+}
+
+type LineProps = {
+  type?: LineType
 }

--- a/react/components/EXPERIMENTAL_Charts/typings.d.ts
+++ b/react/components/EXPERIMENTAL_Charts/typings.d.ts
@@ -1,6 +1,6 @@
 type BaseGridProps = Pick<CartesianGridProps, 'vertical' | 'horizontal'>
-type BaseXAxisProps = Pick<XAxisProps, 'axisLine' | 'tickLine' | 'padding' | 'tick'>
-type BaseYAxisProps = Pick<YAxisProps, 'axisLine' | 'tickLine' | 'padding' | 'tick'>
+type BaseXAxisProps = Pick<XAxisProps, 'axisLine' | 'tickLine' | 'padding' | 'tick' | 'hide'>
+type BaseYAxisProps = Pick<YAxisProps, 'axisLine' | 'tickLine' | 'padding' | 'tick' | 'hide'>
 type BaseContainerProps = Pick<ResponsiveContainerProps, 'height' | 'width'>
 type DefaultLineProps = Pick<LineProps, 'type' | 'strokeWidth' | 'dot'>
 

--- a/react/components/EXPERIMENTAL_Charts/typings.d.ts
+++ b/react/components/EXPERIMENTAL_Charts/typings.d.ts
@@ -1,11 +1,12 @@
 type BaseGridProps = Pick<CartesianGridProps, 'vertical' | 'horizontal'>
-type BaseAxisProps = Pick<XAxisProps, 'axisLine' | 'tickLine', 'padding'>
+type BaseXAxisProps = Pick<XAxisProps, 'axisLine' | 'tickLine' | 'padding' | 'tick'>
+type BaseYAxisProps = Pick<YAxisProps, 'axisLine' | 'tickLine' | 'padding' | 'tick'>
 type BaseContainerProps = Pick<ResponsiveContainerProps, 'height' | 'width'>
 type DefaultLineProps = Pick<LineProps, 'type' | 'strokeWidth' | 'dot'>
 
 type ChartProps = {
-  xAxis?: BaseAxisProps,
-  yAxis?: BaseAxisProps, 
+  xAxis?: BaseXAxisProps,
+  yAxis?: BaseYAxisProps, 
   container?: BaseContainerProps,
   grid?: BaseGridProps
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
as the title says.

#### What problem is this solving?
- Allows hide the chart axis
- Allows different configs for the `xAxis` and `yAxis`
- Allows different interpolations of the chart
- Allows that the axis label would be changed
- Improve the docs, to include charts for show how can we change the atributtes
- Make Line Chart Responsible, now the container, for default, auto-adjust for the size of the screen :tada: 
- Change `schema` to `config` prop

#### How should this be manually tested?
`yarn install` && `yarn start`

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Requires change to documentation, which has been updated accordingly.
