### PR TITLE
Fix/table scroll bar compensation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Table** height calculation now gets scrollbar hight compensation from `virtualized` callback.
+
 ### Changed
 
 - Default sized form elements text size to `t-body`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.103.6] - 2020-01-07
+
 ### Fixed
 
 - **Table** height calculation now gets scrollbar hight compensation from `virtualized` callback.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.103.5",
+  "version": "9.103.6",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.103.5",
+  "version": "9.103.6",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -19,7 +19,6 @@ const DEFAULT_COLUMN_WIDTH = 200
 const LINE_ACTIONS_COLUMN_WIDTH = 70
 const NO_TITLE_COLUMN = ' '
 const SELECTED_ROW_BACKGROUND = '#dbe9fd'
-const DEFAULT_SCROLLBAR_WIDTH = 17
 const EMPTY_STATE_SIZE_IN_ROWS = 5
 
 class SimpleTable extends Component {
@@ -29,6 +28,7 @@ class SimpleTable extends Component {
     this.state = {
       hoverRowIndex: -1,
       tableHeight: 0,
+      scrollbarWidth: 0,
     }
 
     this._cache = new CellMeasurerCache({
@@ -153,25 +153,19 @@ class SimpleTable extends Component {
     }
   }
 
-  getScrollbarWidth = () => {
-    const isSSR = typeof document === 'undefined'
-    if (isSSR) {
-      return DEFAULT_SCROLLBAR_WIDTH
+  handleScrollbarPresenceChange = ({ horizontal, size }) => {
+    if (horizontal) {
+      this.setState({ scrollbarWidth: size || 0 })
     }
-
-    const scrollbarWidth =
-      window.innerWidth - document.documentElement.clientWidth
-    return isNaN(scrollbarWidth) ? DEFAULT_SCROLLBAR_WIDTH : scrollbarWidth
   }
 
   calculateContainerHeight = () => {
     const { rowHeight, items, disableHeader } = this.props
+    const { scrollbarWidth } = this.state
 
     if (items.length === 0) {
       return (
-        HEADER_HEIGHT +
-        rowHeight * EMPTY_STATE_SIZE_IN_ROWS +
-        this.getScrollbarWidth()
+        HEADER_HEIGHT + rowHeight * EMPTY_STATE_SIZE_IN_ROWS + scrollbarWidth
       )
     }
 
@@ -182,7 +176,7 @@ class SimpleTable extends Component {
       rawTableHeight += this.calculateRowHeight(rowIndex)
     }
 
-    return rawTableHeight + this.getScrollbarWidth()
+    return rawTableHeight + scrollbarWidth
   }
 
   render() {
@@ -243,6 +237,9 @@ class SimpleTable extends Component {
 
                 return (
                   <MultiGrid
+                    onScrollbarPresenceChange={
+                      this.handleScrollbarPresenceChange
+                    }
                     height={tableHeight}
                     width={width}
                     deferredMeasurementCache={this._cache}


### PR DESCRIPTION
#### What is the purpose of this pull request?

 - Fix a table height calculation when there is no vertical scrollBar reference to calculate horizontal scrollBar height :developers:

#### What problem is this solving?
[Running workspace with bug](https://savio--vtexpages.myvtex.com/sfcourse)

 - notice the scrollbar in the bottom not being compensated in height calculation.

[Running workspace with fix](https://cafezinhi--pricingqa.myvtex.com/admin/app/example)

 - notice the scrollbar in the bottom being MAJESTICALLY compensated

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
