### PR TITLE
Fixed first column width of EXPRIMENTAL_TableTree docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.96.10] - 2019-11-21
+
 ### Fixed
 
 - First column width of `EXPERIMENTAL_TableTree` docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- First column width of `EXPERIMENTAL_TableTree` docs.
+
 ## [9.96.9] - 2019-11-20
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.96.9",
+  "version": "9.96.10",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.96.9",
+  "version": "9.96.10",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_TableTree/README.md
+++ b/react/components/EXPERIMENTAL_TableTree/README.md
@@ -170,7 +170,7 @@ const columns = [
   {
     id: 'name',
     title: 'Description',
-    width: 400,
+    width: 350,
     cellRenderer: ({ rowHeight, cellData }) => (
       <span>
         <Image size={rowHeight - 10} />

--- a/react/components/EXPERIMENTAL_TableTree/README.md
+++ b/react/components/EXPERIMENTAL_TableTree/README.md
@@ -10,6 +10,7 @@ const columns = [
   {
     id: 'name',
     title: 'Name',
+    width: 300,
   },
   {
     id: 'email',
@@ -69,6 +70,7 @@ const columns = [
   {
     id: 'name',
     title: 'name',
+    width: 300,
   },
   {
     id: 'email',
@@ -168,6 +170,7 @@ const columns = [
   {
     id: 'name',
     title: 'Description',
+    width: 400,
     cellRenderer: ({ rowHeight, cellData }) => (
       <span>
         <Image size={rowHeight - 10} />


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

This change is to avoid the other columns to "jump" when the first collapse.

#### How should this be manually tested?

Clone the repo and `yarn && yarn start`

#### Screenshots or example usage

Before:
<img width="834" alt="Screen Shot 2019-11-21 at 09 26 16" src="https://user-images.githubusercontent.com/6964311/69337992-fa008600-0c40-11ea-943f-236ec0076b60.png">

After:
<img width="834" alt="Screen Shot 2019-11-21 at 09 37 04" src="https://user-images.githubusercontent.com/6964311/69338684-7c3d7a00-0c42-11ea-814a-4e6167a84df6.png">


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
