### PR TITLE
Add page top indicator option to Pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.97.0] - 2019-12-02
+
 ### Added
 
 - Page top indicator option to the `Pagination` component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Page top indicator option to the `Pagination` component
+
 ## [9.96.11] - 2019-12-02
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.96.11",
+  "version": "9.97.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.96.11",
+  "version": "9.97.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Pagination/PageIndicator.js
+++ b/react/components/Pagination/PageIndicator.js
@@ -4,18 +4,17 @@ import PropTypes from 'prop-types'
 function PageIndicator({ currentItemFrom, itemTo, textOf, totalItems }) {
   return (
     <div className="c-muted-2 t-small">
-      {currentItemFrom}
-      {' - '}
-      {itemTo} {textOf} {totalItems}
+      {`${currentItemFrom} - ${itemTo} `}
+      {textOf} {totalItems}
     </div>
   )
 }
 
 PageIndicator.propTypes = {
-  currentItemFrom: PropTypes.number,
-  itemTo: PropTypes.number,
-  textOf: PropTypes.string,
-  totalItems: PropTypes.number,
+  currentItemFrom: PropTypes.number.isRequired,
+  itemTo: PropTypes.number.isRequired,
+  textOf: PropTypes.string.isRequired,
+  totalItems: PropTypes.number.isRequired,
 }
 
 export default PageIndicator

--- a/react/components/Pagination/PageIndicator.js
+++ b/react/components/Pagination/PageIndicator.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+function PageIndicator({ currentItemFrom, itemTo, textOf, totalItems }) {
+  return (
+    <div className="c-muted-2 t-small">
+      {currentItemFrom}
+      {' - '}
+      {itemTo} {textOf} {totalItems}
+    </div>
+  )
+}
+
+PageIndicator.propTypes = {
+  currentItemFrom: PropTypes.number,
+  itemTo: PropTypes.number,
+  textOf: PropTypes.string,
+  totalItems: PropTypes.number,
+}
+
+export default PageIndicator

--- a/react/components/Pagination/PageIndicator.js
+++ b/react/components/Pagination/PageIndicator.js
@@ -1,20 +1,31 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-function PageIndicator({ currentItemFrom, itemTo, textOf, totalItems }) {
+function PageIndicator({
+  currentItemFrom,
+  itemTo,
+  textOf,
+  totalItems,
+  itemLabel,
+}) {
   return (
     <div className="c-muted-2 t-small">
       {`${currentItemFrom} - ${itemTo} `}
-      {textOf} {totalItems}
+      {textOf} {totalItems} {itemLabel}
     </div>
   )
+}
+
+PageIndicator.defaultProps = {
+  itemLabel: '',
 }
 
 PageIndicator.propTypes = {
   currentItemFrom: PropTypes.number.isRequired,
   itemTo: PropTypes.number.isRequired,
   textOf: PropTypes.string.isRequired,
-  totalItems: PropTypes.number.isRequired,
+  totalItems: PropTypes.node.isRequired,
+  itemLabel: PropTypes.node,
 }
 
 export default PageIndicator

--- a/react/components/Pagination/index.js
+++ b/react/components/Pagination/index.js
@@ -5,6 +5,8 @@ import CaretRight from '../icon/CaretRight'
 import ButtonWithIcon from '../ButtonWithIcon'
 import Dropdown from '../Dropdown'
 
+import PageIndicator from './PageIndicator'
+
 const caretLeft = <CaretLeft />
 const caretRight = <CaretRight />
 
@@ -49,6 +51,7 @@ class Pagination extends PureComponent {
       textOf,
       textShowRows,
       selectedOption,
+      hasPageTopIndicator,
     } = this.props
     const { selectedRowsOptionIndex } = this.state
 
@@ -60,49 +63,64 @@ class Pagination extends PureComponent {
     const itemTo = currentItemTo > totalItems ? totalItems : currentItemTo
 
     return (
-      <div
-        className={`flex flex-row items-center ${
-          rowsOptions ? 'justify-between' : 'justify-end'
-        }`}>
-        {dropdownOptions && (
-          <div className="flex flex-row pt5 items-baseline">
-            <span className="mr4 c-muted-2 t-small self-center">
-              {textShowRows}
-            </span>
-            <Dropdown
-              size="small"
-              options={dropdownOptions}
-              value={
-                selectedOption || dropdownOptions[selectedRowsOptionIndex].label
-              }
-              onChange={this.handleRowsChange}
+      <div className="flex flex-column">
+        {hasPageTopIndicator && (
+          <div className="mt2 mb5">
+            <PageIndicator
+              currentItemFrom={currentItemFrom}
+              itemTo={itemTo}
+              textOf={textOf}
+              totalItems={totalItems}
             />
           </div>
         )}
+        {this.props.children}
+        <div
+          className={`flex flex-row items-center ${
+            rowsOptions ? 'justify-between' : 'justify-end'
+          }`}>
+          {dropdownOptions && (
+            <div className="flex flex-row pt5 items-baseline">
+              <span className="mr4 c-muted-2 t-small self-center">
+                {textShowRows}
+              </span>
+              <Dropdown
+                size="small"
+                options={dropdownOptions}
+                value={
+                  selectedOption ||
+                  dropdownOptions[selectedRowsOptionIndex].label
+                }
+                onChange={this.handleRowsChange}
+              />
+            </div>
+          )}
 
-        <div className="flex flex-row pt5 items-center">
-          <div className="c-muted-2 t-small">
-            {currentItemFrom}
-            {' - '}
-            {itemTo} {textOf} {totalItems}
-          </div>
-          <div className="ml4">
-            <ButtonWithIcon
-              icon={caretLeft}
-              variation="secondary"
-              size="small"
-              disabled={isPrevDisabled}
-              onClick={this.handlePrevPage}
+          <div className="flex flex-row pt5 items-center">
+            <PageIndicator
+              currentItemFrom={currentItemFrom}
+              itemTo={itemTo}
+              textOf={textOf}
+              totalItems={totalItems}
             />
-          </div>
-          <div className="ml2">
-            <ButtonWithIcon
-              icon={caretRight}
-              variation="secondary"
-              size="small"
-              disabled={isNextDisabled}
-              onClick={this.handleNextPage}
-            />
+            <div className="ml4">
+              <ButtonWithIcon
+                icon={caretLeft}
+                variation="secondary"
+                size="small"
+                disabled={isPrevDisabled}
+                onClick={this.handlePrevPage}
+              />
+            </div>
+            <div className="ml2">
+              <ButtonWithIcon
+                icon={caretRight}
+                variation="secondary"
+                size="small"
+                disabled={isNextDisabled}
+                onClick={this.handleNextPage}
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -112,9 +130,12 @@ class Pagination extends PureComponent {
 
 Pagination.defaultProps = {
   rowsOptions: null,
+  hasPageTopIndicator: false,
 }
 
 Pagination.propTypes = {
+  children: PropTypes.node,
+
   rowsOptions: PropTypes.array,
   currentItemFrom: PropTypes.number.isRequired,
   currentItemTo: PropTypes.number.isRequired,
@@ -129,6 +150,8 @@ Pagination.propTypes = {
   onRowsChange: PropTypes.func,
   onNextClick: PropTypes.func,
   onPrevClick: PropTypes.func,
+
+  hasPageTopIndicator: PropTypes.bool,
 }
 
 export default Pagination

--- a/react/components/Pagination/index.js
+++ b/react/components/Pagination/index.js
@@ -54,6 +54,7 @@ class Pagination extends PureComponent {
       textShowRows,
       selectedOption,
       hasPageTopIndicator,
+      itemLabel,
     } = this.props
     const { selectedRowsOptionIndex } = this.state
 
@@ -73,6 +74,7 @@ class Pagination extends PureComponent {
               itemTo={itemTo}
               textOf={textOf}
               totalItems={totalItems}
+              itemLabel={itemLabel}
             />
           </div>
         )}
@@ -148,6 +150,7 @@ Pagination.propTypes = {
   textOf: PropTypes.node.isRequired,
   textShowRows: PropTypes.node.isRequired,
   totalItems: PropTypes.number.isRequired,
+  itemLabel: PropTypes.string,
   /**
    * Use this prop if you want to control the number of rows selected, instead of leaving it to the Pagination component.
    */

--- a/react/components/Pagination/index.js
+++ b/react/components/Pagination/index.js
@@ -1,5 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
+import classnames from 'classnames'
+
 import CaretLeft from '../icon/CaretLeft'
 import CaretRight from '../icon/CaretRight'
 import ButtonWithIcon from '../ButtonWithIcon'
@@ -76,9 +78,13 @@ class Pagination extends PureComponent {
         )}
         {this.props.children}
         <div
-          className={`flex flex-row items-center ${
-            rowsOptions ? 'justify-between' : 'justify-end'
-          }`}>
+          className={classnames([
+            'flex flex-row items-center',
+            {
+              'justify-between': rowsOptions,
+              'justify-end': !rowsOptions,
+            },
+          ])}>
           {dropdownOptions && (
             <div className="flex flex-row pt5 items-baseline">
               <span className="mr4 c-muted-2 t-small self-center">

--- a/react/components/Table/SwitchablePagination.js
+++ b/react/components/Table/SwitchablePagination.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Pagination from '../Pagination'
+
+function SwitchablePagination({ children, enabled, ...paginationProps }) {
+  if (enabled) {
+    return <Pagination {...paginationProps}>{children}</Pagination>
+  }
+  return children
+}
+
+SwitchablePagination.propTypes = {
+  ...Pagination.propTypes,
+  enabled: PropTypes.bool,
+}
+
+export default SwitchablePagination

--- a/react/components/Table/SwitchablePagination.js
+++ b/react/components/Table/SwitchablePagination.js
@@ -10,6 +10,10 @@ function SwitchablePagination({ children, enabled, ...paginationProps }) {
   return children
 }
 
+SwitchablePagination.defaultProps = {
+  enabled: false,
+}
+
 SwitchablePagination.propTypes = {
   ...Pagination.propTypes,
   enabled: PropTypes.bool,

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -5,7 +5,6 @@ import reduce from 'lodash/reduce'
 import map from 'lodash/map'
 
 import Box from '../Box'
-import Pagination from '../Pagination'
 import EmptyState from '../EmptyState'
 import FilterBar from '../FilterBar'
 
@@ -14,6 +13,7 @@ import Toolbar from './Toolbar'
 import CheckboxContainer from './CheckboxContainer'
 import Totalizers from '../Totalizer'
 import BulkActions from './BulkActions'
+import SwitchablePagination from './SwitchablePagination'
 
 class Table extends PureComponent {
   constructor(props) {
@@ -306,50 +306,52 @@ class Table extends PureComponent {
         {totalizers && totalizers.length > 0 && (
           <Totalizers items={totalizers} />
         )}
-        <StickyContainer>
-          <BulkActions
-            hasPrimaryBulkAction={hasPrimaryBulkAction}
-            hasSecondaryBulkActions={hasSecondaryBulkActions}
-            selectedRows={selectedRows}
-            bulkActions={bulkActions}
-            allLinesSelected={allLinesSelected}
-            onSelectAllLines={this.handleSelectAllLines}
-            onDeselectAllLines={this.handleDeselectAllLines}
-          />
-
-          {emptyState ? (
-            <Box>
-              <EmptyState title={emptyStateLabel}>
-                {emptyStateChildren}
-              </EmptyState>
-            </Box>
-          ) : (
-            <SimpleTable
-              fullWidth={fullWidth}
-              items={items}
-              schema={displaySchema}
-              fixFirstColumn={fixFirstColumn}
-              rowHeight={tableRowHeight}
-              disableHeader={disableHeader}
-              emptyStateLabel={emptyStateLabel}
-              emptyStateChildren={emptyStateChildren}
-              dynamicRowHeight={dynamicRowHeight}
-              onRowClick={onRowClick}
-              onRowHover={onRowHover}
-              sort={sort}
-              onSort={onSort}
-              key={hiddenFields.toString()}
-              updateTableKey={updateTableKey}
-              lineActions={lineActions}
-              loading={loading}
-              containerHeight={containerHeight}
-              selectedRowsIndexes={map(selectedRows, 'id')}
-              density={selectedDensity}
+        <SwitchablePagination
+          enabled={!loading && paginationClone}
+          {...paginationClone}>
+          <StickyContainer>
+            <BulkActions
+              hasPrimaryBulkAction={hasPrimaryBulkAction}
+              hasSecondaryBulkActions={hasSecondaryBulkActions}
+              selectedRows={selectedRows}
+              bulkActions={bulkActions}
+              allLinesSelected={allLinesSelected}
+              onSelectAllLines={this.handleSelectAllLines}
+              onDeselectAllLines={this.handleDeselectAllLines}
             />
-          )}
-        </StickyContainer>
 
-        {!loading && paginationClone && <Pagination {...paginationClone} />}
+            {emptyState ? (
+              <Box>
+                <EmptyState title={emptyStateLabel}>
+                  {emptyStateChildren}
+                </EmptyState>
+              </Box>
+            ) : (
+              <SimpleTable
+                fullWidth={fullWidth}
+                items={items}
+                schema={displaySchema}
+                fixFirstColumn={fixFirstColumn}
+                rowHeight={tableRowHeight}
+                disableHeader={disableHeader}
+                emptyStateLabel={emptyStateLabel}
+                emptyStateChildren={emptyStateChildren}
+                dynamicRowHeight={dynamicRowHeight}
+                onRowClick={onRowClick}
+                onRowHover={onRowHover}
+                sort={sort}
+                onSort={onSort}
+                key={hiddenFields.toString()}
+                updateTableKey={updateTableKey}
+                lineActions={lineActions}
+                loading={loading}
+                containerHeight={containerHeight}
+                selectedRowsIndexes={map(selectedRows, 'id')}
+                density={selectedDensity}
+              />
+            )}
+          </StickyContainer>
+        </SwitchablePagination>
       </div>
     )
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a page top indicator option to the `Pagination` component

#### What problem is this solving?
Some pages have content that are so large that the reference of which page is being displayed is lost to the immediate view.

To fix this, add an option to the pagination component in which a page indicator is shown above the content in such a way that the paginated nature of a search result is easier to perceive.

#### How should this be manually tested?
You can [visit this link](https://artur--partnerchallenge26.myvtex.com/admin/received-skus/approved/?elements=15&from=0&to=15) to see an example of a table using the proposed feature

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3827456/69452876-8d20e500-0d41-11ea-8eda-fc2ef7fbba61.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
