### PR TITLE
Set color to c-muted-2 when toolbar button is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Set color of `EXPERIMENTAL_Table` toolbar buttons to `c-muted-2` when they are disabled.
+
 ## [9.96.10] - 2019-11-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.96.11] - 2019-12-02
+
 ### Fixed
 
 - Set color of `EXPERIMENTAL_Table` toolbar buttons to `c-muted-2` when they are disabled.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.96.10",
+  "version": "9.96.11",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.96.10",
+  "version": "9.96.11",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/Toolbar/Button.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/Button.tsx
@@ -26,6 +26,18 @@ const Button = forwardRef<Ref, ButtonProps>(
     ref
   ) => {
     const isTertiary = variation === ButtonVariation.Tertiary
+
+    const iconClass = csx({
+      mh2: isTertiary,
+      'c-on-base mh2': isTertiary && !disabled,
+      'c-muted-2': disabled,
+    })
+
+    const labelClass = csx({
+      'c-on-base': isTertiary && !disabled,
+      'c-muted-2': disabled,
+    })
+
     return (
       <div
         id={id}
@@ -34,9 +46,7 @@ const Button = forwardRef<Ref, ButtonProps>(
         className={csx('relative', { mh2: isTertiary })}>
         <ButtonWithIcon
           icon={
-            <span
-              className={`${isTertiary ? 'c-on-base mh2' : ''}`}
-              style={ICON_OPTICAL_COMPENSATION}>
+            <span className={iconClass} style={ICON_OPTICAL_COMPENSATION}>
               {icon}
             </span>
           }
@@ -48,9 +58,7 @@ const Button = forwardRef<Ref, ButtonProps>(
           variation={variation}
           size={size}
           onClick={onClick}>
-          {label && (
-            <span className={isTertiary ? 'c-on-base' : ''}>{label}</span>
-          )}
+          {label && <span className={labelClass}>{label}</span>}
         </ButtonWithIcon>
         {children}
       </div>

--- a/react/components/EXPERIMENTAL_Table/Toolbar/Button.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/Button.tsx
@@ -28,7 +28,6 @@ const Button = forwardRef<Ref, ButtonProps>(
     const isTertiary = variation === ButtonVariation.Tertiary
 
     const iconClass = csx({
-      mh2: isTertiary,
       'c-on-base mh2': isTertiary && !disabled,
       'c-muted-2': disabled,
     })


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

[Running workspace](https://exportcolprods2--storecomponents.myvtex.com/admin/app/collections/create)

#### How should this be manually tested?

Check that the color of the export button is different because it is disabled.

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
