### PR TITLE
Fix proptypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.103.1] - 2019-12-20
+
 ### Fixed
 
 - PropTypes in `Progress` and `Radio` components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- PropTypes in `Progress` and `Radio` components.
+
 ## [9.103.0] - 2019-12-19
+
 ### Added
+
 - `BubbleChart` to `EXPERIMENTAL_Charts`
 
 ## [9.102.0] - 2019-12-19

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.103.0",
+  "version": "9.103.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.103.0",
+  "version": "9.103.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Progress/Steps/index.js
+++ b/react/components/Progress/Steps/index.js
@@ -4,8 +4,9 @@ import Step from './Step'
 
 export const ProgressStepsTypes = {
   /** Array of steps, it should be composed of instances of the following strings:'completed', 'inProgress' and 'toDo' */
-  steps: PropTypes.arrayOf(PropTypes.oneOf(['completed', 'inProgress', 'toDo']))
-    .isRequired,
+  steps: PropTypes.arrayOf(
+    PropTypes.oneOf(['completed', 'inProgress', 'toDo'])
+  ),
   /** Boolean representing a dangerous state of the progress (e.g. a late or critical progress), if true this changes the color of the steps */
   danger: PropTypes.bool,
   /** Boolean representing if the progress bar should be slim or not, if true this decreases the height of the bar */

--- a/react/components/Radio/index.js
+++ b/react/components/Radio/index.js
@@ -109,6 +109,7 @@ Radio.defaultProps = {
   checked: false,
   disabled: false,
   required: false,
+  isLast: false,
 }
 
 Radio.propTypes = {
@@ -119,7 +120,7 @@ Radio.propTypes = {
   /** (Radio spec attribute) */
   id: PropTypes.string.isRequired,
   /** (Radio spec attribute) */
-  isLast: PropTypes.string.bool,
+  isLast: PropTypes.bool,
   /** Radio label */
   label: PropTypes.node.isRequired,
   /** (Radio spec attribute) */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Progress `steps` prop is not required if progress type is line. As the line progress and steps progress props are merged, a better way of handling it is not making it required at all (but if you have any other suggestion its really welcome).
It also fixes the prop `isLast` of the radio component.

Click `Export` and select any format. Check that no warning is shown about the progress.
Try opening the `import` modal. Check that no warnings are shown for the radio.

[Workspace with error](https://tsmaststyle--storecomponents.myvtex.com/admin/app/collections/1112)

[Fixed workspace](https://exportcolprods2--storecomponents.myvtex.com/admin/app/collections/1112)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
