### PR TITLE
Remove key from option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.103.2] - 2019-12-20
+
 ### Removed
 
 - `key` that was used as prop in **AutocompleteInput**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
--Remove `key` that was used as prop.
+- `key` that was used as prop in **AutocompleteInput**.
 
 ## [9.103.1] - 2019-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+-Remove `key` that was used as prop.
+
 ## [9.103.1] - 2019-12-20
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.103.1",
+  "version": "9.103.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.103.1",
+  "version": "9.103.2",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/AutocompleteInput/Option.tsx
+++ b/react/components/AutocompleteInput/Option.tsx
@@ -19,7 +19,7 @@ export const autocompleteOptionShape = PropTypes.oneOfType([
   PropTypes.string,
   structuredAutocompleteOptionShape,
 ])
- 
+
 export const getTermFromOption = (option: AutocompleteOption): string =>
   typeof option === 'string' ? option : option.label
 
@@ -32,18 +32,16 @@ const propTypes = {
   searchTerm: PropTypes.string.isRequired,
   /** Option title */
   value: autocompleteOptionShape.isRequired,
-  /** Option key used in the list */
-  key: PropTypes.string.isRequired,
   /** Determine if an option is selected and should be highlighted */
   selected: PropTypes.bool.isRequired,
   /** Click handler */
   onClick: PropTypes.func.isRequired,
 }
 
-const Option: React.FunctionComponent<
-  PropTypes.InferProps<typeof propTypes>
-> = props => {
-  const { icon, selected, roundedBottom, searchTerm, key, onClick } = props
+const Option: React.FunctionComponent<PropTypes.InferProps<
+  typeof propTypes
+>> = props => {
+  const { icon, selected, roundedBottom, searchTerm, onClick } = props
   const [highlightOption, setHighlightOption] = useState(false)
   const value = getTermFromOption(props.value)
 
@@ -72,7 +70,6 @@ const Option: React.FunctionComponent<
 
   return (
     <button
-      key={key}
       className={buttonClasses}
       onFocus={() => setHighlightOption(true)}
       onMouseEnter={() => setHighlightOption(true)}

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -1,10 +1,14 @@
 import uniq from 'lodash/uniq'
 import PropTypes from 'prop-types'
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useRef } from 'react'
 import Spinner from '../Spinner'
 
 import { useClickOutside, useArrowNavigation } from './hooks'
-import Option, { AutocompleteOption, autocompleteOptionShape, getTermFromOption } from './Option'
+import Option, {
+  AutocompleteOption,
+  autocompleteOptionShape,
+  getTermFromOption,
+} from './Option'
 import SearchInput from './SearchInput'
 
 const propTypes = {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the key prop from the option button.

#### What problem is this solving?
The key is already defined [here](https://github.com/vtex/styleguide/blob/422a40f7c9715a6bcd45578e18de50f22e7bd0e1/react/components/AutocompleteInput/index.tsx#L160)

<!--- What is the motivation and context for this change? -->
The key only needs to be defined in the upper level component

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
