### PR TITLE
Added useTableProportion hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.98.1] - 2019-12-12
+
 ### Added
 
 - `EXPERIMENTAL_useTableProportion` hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `EXPERIMENTAL_useTableProportion` hook.
+
 ## [9.98.0] - 2019-12-12
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.98.0",
+  "version": "9.98.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.98.0",
+  "version": "9.98.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/EXPERIMENTAL_useTableProportion.ts
+++ b/react/EXPERIMENTAL_useTableProportion.ts
@@ -1,0 +1,3 @@
+export {
+  default,
+} from './components/EXPERIMENTAL_Table/hooks/useTableProportion'

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -11,16 +11,12 @@ const Row: FC<RowProps> & RowComposites = ({
   onClick,
   active,
 }) => {
-  const className = csx('w-100 ph4 truncate overflow-x-hidden', {
+  const className = csx('w-100 truncate overflow-x-hidden', {
     'pointer hover-c-link hover-bg-muted-5': onClick,
     'bg-action-secondary': active,
   })
   return (
-    <Tag
-      key={`${NAMESPACES.ROW}-${uuid()}`}
-      style={{ height: height }}
-      onClick={onClick}
-      className={className}>
+    <Tag style={{ height }} onClick={onClick} className={className}>
       {children}
     </Tag>
   )
@@ -34,16 +30,12 @@ export const Cell: FC<CellProps> = ({
   as: Tag = 'td',
   className = '',
 }) => {
-  const classNames = csx('truncate v-mid ph2 pv0 tl bb b--muted-4', className, {
+  const classNames = csx('v-mid pv0 tl bb b--muted-4', className, {
     'pointer hover-c-link hover-bg-muted-5': onClick,
   })
 
   return (
-    <Tag
-      onClick={onClick}
-      id={`${NAMESPACES.CELL}-${id}`}
-      style={{ minWidth: width }}
-      className={classNames}>
+    <Tag onClick={onClick} style={{ width }} className={classNames}>
       {children}
     </Tag>
   )
@@ -55,7 +47,7 @@ export type RowComposites = {
 
 export type CellProps = {
   id?: string
-  width?: number
+  width?: number | string
   as?: 'td' | 'th' | 'div' | 'li'
   className?: string
   onClick?: () => void

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -23,14 +23,13 @@ const Row: FC<RowProps> & RowComposites = ({
 }
 
 export const Cell: FC<CellProps> = ({
-  id,
   children,
   width,
   onClick,
   as: Tag = 'td',
   className = '',
 }) => {
-  const classNames = csx('v-mid pv0 tl bb b--muted-4', className, {
+  const classNames = csx('v-mid ph3 pv0 tl bb b--muted-4', className, {
     'pointer hover-c-link hover-bg-muted-5': onClick,
   })
 

--- a/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
@@ -47,17 +47,15 @@ const Rows: FC<RowsProps> = ({
             : cellData
           return (
             <Row.Cell {...cellProps} key={`cel-${uuid()}`} width={width}>
-              {cellIndex === 0 && (
+              {cellIndex === 0 && checkboxes && (
                 <CellPrefix>
-                  {checkboxes && (
-                    <span className="ph3">
-                      <CellPrefix.Checkbox
-                        checked={isRowChecked}
-                        partial={isRowPartiallyChecked}
-                        onClick={toggleChecked}
-                      />
-                    </span>
-                  )}
+                  <span className="ph3">
+                    <CellPrefix.Checkbox
+                      checked={isRowChecked}
+                      partial={isRowPartiallyChecked}
+                      onClick={toggleChecked}
+                    />
+                  </span>
                 </CellPrefix>
               )}
               {content}

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -391,6 +391,7 @@ const columns = [
   {
     id: 'name',
     title: 'Name',
+    cellRenderer,
   },
   {
     id: 'country',
@@ -400,7 +401,8 @@ const columns = [
 
 const items = [
   {
-    name: 'En Sabah Nuh',
+    name:
+      '⚠️ This is just a text that is very very very large and should be fully visible when it is confortable and truncated otherwise. If you are seeing this part, it means that you are ona  low density 🤓!',
     country: '🇨🇺Cuba',
   },
   {
@@ -417,6 +419,18 @@ const items = [
   },
 ]
 
+function cellRenderer({ cellData, selectedDensity }) {
+  const confortable = selectedDensity === 'low'
+
+  return confortable ? (
+    <div className="dib">
+      <div className="db ws-normal tj">{cellData}</div>
+    </div>
+  ) : (
+    <div className="dib mw6 truncate">{cellData}</div>
+  )
+}
+
 function ProportionExample() {
   const measures = useTableMeasures({
     size: items.length,
@@ -427,7 +441,23 @@ function ProportionExample() {
     ratio: [3, 1],
   })
 
-  return <Table measures={measures} columns={sizedColumns} items={items} />
+  const densityProps = {
+    label: 'Line density',
+    lowOptionLabel: 'Low',
+    mediumOptionLabel: 'Medium',
+    highOptionLabel: 'High',
+    density: measures,
+  }
+
+  return (
+    <Table measures={measures} columns={sizedColumns} items={items}>
+      <Table.Toolbar>
+        <Table.Toolbar.ButtonGroup>
+          <Table.Toolbar.ButtonGroup.Density {...densityProps} />
+        </Table.Toolbar.ButtonGroup>
+      </Table.Toolbar>
+    </Table>
+  )
 }
 ;<ProportionExample />
 ```

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -381,6 +381,57 @@ function ClickExample() {
 ;<ClickExample />
 ```
 
+# Proportion
+
+```js
+const useTableMeasures = require('./hooks/useTableMeasures.tsx').default
+const useTableProportion = require('./hooks/useTableProportion.ts').default
+
+const columns = [
+  {
+    id: 'name',
+    title: 'Name',
+  },
+  {
+    id: 'country',
+    title: 'Country',
+  },
+]
+
+const items = [
+  {
+    name: 'En Sabah Nuh',
+    country: '🇨🇺Cuba',
+  },
+  {
+    name: 'Abdul Qamar',
+    country: '🇸🇦Saudi Arabia',
+  },
+  {
+    name: 'Goose the Cat',
+    country: '🇺🇸USA',
+  },
+  {
+    name: 'Brian Braddock',
+    country: '🇬🇧Great Britain',
+  },
+]
+
+function ProportionExample() {
+  const measures = useTableMeasures({
+    size: items.length,
+  })
+
+  const { sizedColumns } = useTableProportion({
+    columns,
+    ratio: [3, 1],
+  })
+
+  return <Table measures={measures} columns={sizedColumns} items={items} />
+}
+;<ProportionExample />
+```
+
 # Loading
 
 ```js

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableProportion.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableProportion.ts
@@ -19,11 +19,10 @@ export default function useTableProportion({ columns, ratio }: ProportionData) {
 
 function calculateWidths(columns: Array<Column>, ratio: Array<number>) {
   const slicedRatio = ratio.slice(0, columns.length)
-
   const sum = (acc: number, num: number) => acc + num
   const ratioSum = slicedRatio.reduce(sum, 0)
-  const minPortion = 100 / ratioSum
-
+  const fullPortion = 100
+  const minPortion = fullPortion / ratioSum
   return slicedRatio.map(value => `${value * minPortion}%`)
 }
 

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableProportion.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableProportion.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react'
+import { Column } from '../index'
+
+export default function useTableProportion({ columns, ratio }: ProportionData) {
+  const calculatedWidths = useMemo(() => calculateWidths(columns, ratio), [
+    columns,
+    ratio,
+  ])
+
+  const sizedColumns = useMemo(
+    () => columns.map((col, i) => ({ ...col, width: calculatedWidths[i] })),
+    [columns, ratio]
+  )
+
+  return {
+    sizedColumns,
+  }
+}
+
+function calculateWidths(columns: Array<Column>, ratio: Array<number>) {
+  const slicedRatio = ratio.slice(0, columns.length)
+
+  const sum = (acc: number, num: number) => acc + num
+  const ratioSum = slicedRatio.reduce(sum, 0)
+  const minPortion = 100 / ratioSum
+
+  return slicedRatio.map(value => `${value * minPortion}%`)
+}
+
+type ProportionData = {
+  columns: Array<Column>
+  ratio: Array<number>
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Add useTableProportion hook.
- Solve cell bugs.

⚠️ The detailed documentation will be present on #953 

#### What problem is this solving?

You can consider this hook a shorthand for setting columns width based on a passed ratio array.

#### How should this be manually tested?
Clone the repo and `yarn && yarn start`

#### Screenshots or example usage

This represents the ratio `[3,1]`. This means that the first column will grow three times more than the second.
<img width="848" alt="Screen Shot 2019-12-12 at 10 13 39" src="https://user-images.githubusercontent.com/6964311/70715196-89410c80-1cc8-11ea-9bb3-a0b35320be52.png">

If we want to divide equaly, just  set 1 to every col `[1,1]`
<img width="848" alt="Screen Shot 2019-12-12 at 10 14 11" src="https://user-images.githubusercontent.com/6964311/70715198-8b0ad000-1cc8-11ea-9023-89d85aba8a45.png">

⚠️ The proportions respect the `truncate of rows`. This means that doesn't matter how large one ratio is compared to other ones - the content will **NOT** break by `default`. In the screenshot below you can see the ratio `[100, 1]`. 
<img width="848" alt="Screen Shot 2019-12-12 at 10 15 06" src="https://user-images.githubusercontent.com/6964311/70715208-8d6d2a00-1cc8-11ea-9f28-a697a0377117.png">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
