### PR TITLE
Simplify columns API of EXPERIMENTAL_Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [9.98.0] - 2019-12-12
 
+### Added
+
 - `mobileScroll` prop to `Totalizer`
 
 ## [9.97.5] - 2019-12-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.103.3] - 2019-12-20
+
 ### Changed
 
 - columns shape of `EXPERIMENTAL_Table`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- columns shape of `EXPERIMENTAL_Table`.
+
 ## [9.103.2] - 2019-12-20
 
 ### Removed
@@ -80,8 +84,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `EXPERIMENTAL_useTableProportion` hook.
 
 ## [9.98.0] - 2019-12-12
-
-### Added
 
 - `mobileScroll` prop to `Totalizer`
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.103.2",
+  "version": "9.103.3",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.103.2",
+  "version": "9.103.3",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
@@ -16,8 +16,7 @@ const Headings: FC<HeadingsProps> = ({
   return (
     <Row {...rowProps} height={TABLE_HEADER_HEIGHT}>
       {columns.map((columnData: Column, headerIndex: number) => {
-        const { headerRenderer, title, width } = columnData
-        const content = headerRenderer ? headerRenderer({ columnData }) : title
+        const { title, width } = columnData
         return (
           <Row.Cell
             {...cellProps}
@@ -35,7 +34,7 @@ const Headings: FC<HeadingsProps> = ({
                 </span>
               </CellPrefix>
             )}
-            {content}
+            {title}
           </Row.Cell>
         )
       })}

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -5,7 +5,7 @@ The `columns` property is an `Array` used to define the table columns and how th
 ```ts
 type Column = {
   id?: string
-  title?: string
+  title?: string | Element
   width?: number
   cellRenderer?: ({
     cellData: unknown
@@ -13,7 +13,6 @@ type Column = {
     rowHeight: number
     selectedDensity: 'low' | 'medium' | 'high'
   }) => React.ReactNode
-  headerRenderer?: ({ columnData: Column }) => React.ReactNode
 }
 ```
 
@@ -25,19 +24,12 @@ type Column = {
 ##### title
 
 - Controls the title which appears on the table Header.
-- If you want to customize it with a component, you can use the `headerRenderer` prop.
+- It can receive either a string or element.
 
 ##### width
 
 - Defines a fixed width for the specific column.
 - By default, the column's width is defined to fit the available space without breaking the content.
-
-##### headerRenderer
-
-- Customize the render method of a single header column cell.
-- It receives a function that returns a node (react component).
-- The function has the following params: ({ columnData })
-- The default is rendering the value as a string.
 
 ##### cellRenderer
 
@@ -101,12 +93,11 @@ const heroColumns: Array<Column> = [
   {
     /** Definitions for the email prop */
     id: 'email',
-    title: 'Email',
     /** Custom renderer for email prop */
-    headerRenderer: ({ columnData: { title } }) => {
+    title: () => {
       return (
         <React.Fragment>
-          <Emoji symbol="💌" label="mail" /> {title}
+          <Emoji symbol="💌" label="mail" /> Email
         </React.Fragment>
       )
     },
@@ -140,6 +131,14 @@ const heroColumns: Array<Column> = [
 const useTableMeasures = require('./hooks/useTableMeasures.tsx').default
 const Tag = require('../Tag/index.js').default
 
+function Email() {
+  return (
+    <React.Fragment>
+      <Emoji symbol="💌" label="mail" /> Email
+    </React.Fragment>
+  )
+}
+
 const heroColumns = [
   {
     id: 'name',
@@ -147,14 +146,7 @@ const heroColumns = [
   },
   {
     id: 'email',
-    title: 'Email',
-    headerRenderer: ({ columnData: { title } }) => {
-      return (
-        <React.Fragment>
-          <Emoji symbol="💌" label="mail" /> {title}
-        </React.Fragment>
-      )
-    },
+    title: <Email />,
   },
   {
     id: 'age',
@@ -230,14 +222,7 @@ const heroColumns = [
   },
   {
     id: 'email',
-    title: 'Email',
-    headerRenderer: ({ columnData: { title } }) => {
-      return (
-        <span>
-          <Emoji symbol="💌" label="mail" /> {title}
-        </span>
-      )
-    },
+    title: <Email />,
   },
   {
     id: 'age',
@@ -277,6 +262,14 @@ const heroes = [
     country: '🇷🇺Russia',
   },
 ]
+
+function Email() {
+  return (
+    <span>
+      <Emoji symbol="💌" label="mail" /> Email
+    </span>
+  )
+}
 
 function Emoji({ symbol, label = '' }) {
   return (

--- a/react/components/EXPERIMENTAL_Table/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/index.tsx
@@ -78,10 +78,9 @@ export const tablePropTypes = {
   columns: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string,
-      title: PropTypes.string,
-      width: PropTypes.number,
-      cellRender: PropTypes.func,
-      headerRender: PropTypes.func,
+      title: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType, PropTypes.func]),
+      width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      cellRenderer: PropTypes.func,
     })
   ),
   items: PropTypes.arrayOf(PropTypes.object),
@@ -122,10 +121,9 @@ export type CellData = {
 
 export type Column = {
   id?: string
-  title?: string
-  width?: number
+  title?: string | Element | Function
+  width?: number | string
   cellRenderer?: (cellData: CellData) => React.ReactNode
-  headerRenderer?: ({ columnData: unknown }) => React.ReactNode
 }
 
 Table.Toolbar = Toolbar


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

The `headerRenderer` property was deprecated because didn't make a lot of sense based on how the table is being used. Now the title either receives a string or element.

#### How should this be manually tested?

clone the repo and `yarn && yarn start`

#### Screenshots or example usage

No need.

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
