### PR TITLE
Change default sized form elements text size to t-body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Default sized form elements text size to `t-body`.
+
 ## [9.103.4] - 2019-12-20
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.103.4",
+  "version": "9.103.5",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.103.4",
+  "version": "9.103.5",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -152,9 +152,9 @@ class Dropdown extends Component {
         break
       default:
         classes += isInline ? 'ph2 ' : 'pl5 pr4 '
-        selectClasses += 't-small '
+        selectClasses += 't-body '
         labelClasses += 't-small '
-        containerClasses += `${isInline ? 'h-auto' : 'h-regular'} t-small `
+        containerClasses += `${isInline ? 'h-auto' : 'h-regular'} t-body `
         iconSize = 18
         break
     }

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -186,7 +186,7 @@ class Input extends Component {
         break
       default:
         prefixSuffixGroupClasses += 'h-regular '
-        classes += `${!token ? 't-small' : ''} `
+        classes += `${!token ? 't-body' : ''} `
         classes += `${
           prefix && suffix ? '' : prefix ? 'pr5 ' : suffix ? 'pl5 ' : 'ph5 '
         }`

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -189,7 +189,7 @@ class NumericStepper extends Component {
       default: {
         buttonClasses += `h-regular ${lean ? 'f4' : 'f6'} `
         const inputWidth = lean ? 'w2' : 'w3'
-        inputClasses += `h-regular t-small ${
+        inputClasses += `h-regular t-body ${
           block ? 'flex-grow-1' : inputWidth
         } `
         labelClasses += 't-small '


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR fix a strange behavior in iPhones. When focusing on form elements, like `input`, the page is zoomed in, because of the text size (14px). It's the default behavior for elements with text size smaller than 16px.

Fixing that, the size of that elements will be consistent with the base text size of the page.

#### How should this be manually tested?

1. Take yout iPhone
2. Add this product to Cart: https://www.madinejeans.com.br/jogger-feminina-saruel/p
3. Click in "Aplicar cupom de desconto"
4. Repeat steps 2 and 3 with this product: https://newinput--gc-jqu0734.myvtex.com/jogger-feminina-saruel-38/p and check the difference.

#### Screenshots or example usage

**Before**

![80596395_1508521655952506_7452573238510485504_n](https://user-images.githubusercontent.com/1315451/71534587-996b0580-28de-11ea-9ca7-78a20e5db605.jpg)

**After**

![80473020_458626545088373_4506977236896710656_n](https://user-images.githubusercontent.com/1315451/71534594-a38d0400-28de-11ea-8ad3-4b7ad758c12c.jpg)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
