### PR TITLE
Add the disabled state to Numeric Stepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **NumericStepper** `disabled` prop.
+
 ## [9.103.4] - 2019-12-20
 
 ### Added

--- a/react/components/NumericStepper/README.md
+++ b/react/components/NumericStepper/README.md
@@ -88,6 +88,8 @@ initialState = {
   value2: 1,
   value3: 1,
   value4: 1,
+  value5: 1,
+  value6: 1,
 }
 
 ;<React.Fragment>
@@ -125,6 +127,25 @@ initialState = {
       readOnly
       value={state.value4}
       onChange={event => setState({ value4: event.value })}
+    />
+  </div>
+  <div className="mb5">
+    <NumericStepper
+      label="Disabled"
+      minValue={1}
+      disabled
+      value={state.value5}
+      onChange={event => setState({ value5: event.value })}
+    />
+  </div>
+  <div className="mb5">
+    <NumericStepper
+      label="lean Disabled"
+      minValue={1}
+      lean
+      disabled
+      value={state.value6}
+      onChange={event => setState({ value6: event.value })}
     />
   </div>
 </React.Fragment>

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -154,6 +154,7 @@ class NumericStepper extends Component {
       label,
       lean,
       readOnly,
+      disabled,
     } = this.props
 
     const isMin = value <= normalizeMin(minValue)
@@ -220,6 +221,7 @@ class NumericStepper extends Component {
           <input
             type="tel"
             readOnly={readOnly}
+            disabled={disabled}
             className={`z-1 order-1 tc bw1 ${borderClasses} br0 ${inputClasses} ${styles.hideDecorators}`}
             style={{
               ...(block && {
@@ -236,7 +238,9 @@ class NumericStepper extends Component {
             <button
               type="button"
               className={`br2 pa0 bl-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
-                readOnly || isMax ? buttonDisabledClasses : buttonEnabledClasses
+                readOnly || disabled || isMax
+                  ? buttonDisabledClasses
+                  : buttonEnabledClasses
               }`}
               style={{
                 borderTopLeftRadius: 0,
@@ -244,7 +248,7 @@ class NumericStepper extends Component {
                 width: lean ? '2em' : '3em',
                 transition: 'opacity 150ms',
               }}
-              disabled={readOnly || isMax}
+              disabled={readOnly || disabled || isMax}
               aria-label="+"
               tabIndex={0}
               onClick={this.handleIncreaseValue}>
@@ -258,7 +262,9 @@ class NumericStepper extends Component {
             <button
               type="button"
               className={`br2 pa0 br-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
-                readOnly || isMin ? buttonDisabledClasses : buttonEnabledClasses
+                readOnly || disabled || isMin
+                  ? buttonDisabledClasses
+                  : buttonEnabledClasses
               }`}
               style={{
                 borderTopRightRadius: 0,
@@ -266,7 +272,7 @@ class NumericStepper extends Component {
                 width: lean ? '2em' : '3em',
                 transition: 'opacity 150ms',
               }}
-              disabled={readOnly || isMin}
+              disabled={readOnly || disabled || isMin}
               aria-label="−"
               // This is a minus sign (U+2212), not a regular hyphen (-, U+002D),
               // which is the default keyboard character.
@@ -308,6 +314,8 @@ NumericStepper.propTypes = {
   defaultValue: PropTypes.number,
   /** Makes input readonly and disables buttons */
   readOnly: PropTypes.bool,
+  /** Makes input disabled and disables buttons */
+  disabled: PropTypes.bool,
   /** Input size */
   size: PropTypes.oneOf(['small', 'regular', 'large']),
   /** Block or default size. */
@@ -323,6 +331,7 @@ NumericStepper.defaultProps = {
   maxValue: Infinity,
   defaultValue: 0,
   readOnly: false,
+  disabled: false,
   size: 'regular',
   block: false,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the `disabled` state to **NumericStepper** component and closes the [issue 942](https://github.com/vtex/styleguide/issues/962)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8717661/71600000-00312e80-2b2c-11ea-9bd1-d9e7e5120526.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
