### PR TITLE
Add Box props to Layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Possibility to pass some `Box` props via the `Layout` component.
+
 ## [9.103.6] - 2020-01-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.104.0] - 2020-01-07
+
 ### Added
 
 - Possibility to pass some `Box` props via the `Layout` component.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.103.6",
+  "version": "9.104.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.103.6",
+  "version": "9.104.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Box/index.tsx
+++ b/react/components/Box/index.tsx
@@ -16,14 +16,8 @@ const Box: FC<Props> = ({ children, noPadding, title }) => {
   const padding = noPadding ? '' : 'pa7'
   return (
     <div
-      className={`styleguide__box bg-base t-body c-on-base ${padding} br3 b--muted-4 bt bb bl br`}
-    >
-      {
-        title &&
-        <h3 className="t-heading-4 mt0">
-          {title}
-        </h3>
-      }
+      className={`styleguide__box bg-base t-body c-on-base ${padding} br3 b--muted-4 ba`}>
+      {title && <h3 className="t-heading-4 mt0">{title}</h3>}
       {children}
     </div>
   )

--- a/react/components/PageBlock/index.js
+++ b/react/components/PageBlock/index.js
@@ -6,7 +6,14 @@ import Box from '../Box/index'
 
 class PageBlock extends Component {
   render() {
-    const { title, subtitle, variation, titleAside, testId } = this.props
+    const {
+      title,
+      subtitle,
+      variation,
+      titleAside,
+      testId,
+      boxProps,
+    } = this.props
     const isAnnotated = variation === 'annotated'
 
     const headerClasses = classNames({
@@ -50,24 +57,32 @@ class PageBlock extends Component {
           {variation === 'half' ? (
             <Fragment>
               <div className="w-50-ns w-100 mr3-ns mb0-ns mb5">
-                <Box>{this.props.children && this.props.children[0]}</Box>
+                <Box {...boxProps}>
+                  {this.props.children && this.props.children[0]}
+                </Box>
               </div>
               <div className="w-50-ns w-100 ml3-ns mb5">
-                <Box>{this.props.children && this.props.children[1]}</Box>
+                <Box {...boxProps}>
+                  {this.props.children && this.props.children[1]}
+                </Box>
               </div>
             </Fragment>
           ) : variation === 'aside' ? (
             <Fragment>
               <div className="w-two-thirds-ns w-100 mr3-ns mb0-ns mb5">
-                <Box>{this.props.children && this.props.children[0]}</Box>
+                <Box {...boxProps}>
+                  {this.props.children && this.props.children[0]}
+                </Box>
               </div>
               <div className="w-third-ns w-100 ml3-ns mb5">
-                <Box>{this.props.children && this.props.children[1]}</Box>
+                <Box {...boxProps}>
+                  {this.props.children && this.props.children[1]}
+                </Box>
               </div>
             </Fragment>
           ) : (
             <div className="w-100 mb5">
-              <Box>{this.props.children}</Box>
+              <Box {...boxProps}>{this.props.children}</Box>
             </div>
           )}
         </div>
@@ -119,6 +134,10 @@ PageBlock.propTypes = {
       )
     }
   },
+  boxProps: PropTypes.shape({
+    noPadding: PropTypes.bool,
+    title: PropTypes.string,
+  }),
 }
 
 export default PageBlock


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow the Box component in Layout to receive either the `noPadding` or `title` prop.

#### What problem is this solving?
On mobile cases we will need to reset/redefine the padding of the Box component.

#### How should this be manually tested?
https://kevin--recorrenciaqa.myvtex.com/admin/orders-admin

#### Screenshots or example usage
![kevin--recorrenciaqa myvtex com_admin_orders-admin(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/2573602/71924325-86bdbf80-316d-11ea-98f3-96d868398988.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
