### PR TITLE
Fix useCheckboxTree using stale values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `EXPERIMENTAL_useCheckboxTree` using stale values in `toggleAll` function.
+
 ## [9.104.0] - 2020-01-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.104.1] - 2020-01-08
+
 ### Fixed
 
 - `EXPERIMENTAL_useCheckboxTree` using stale values in `toggleAll` function.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.104.0",
+  "version": "9.104.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.104.0",
+  "version": "9.104.1",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_useCheckboxTree/index.tsx
+++ b/react/components/EXPERIMENTAL_useCheckboxTree/index.tsx
@@ -39,7 +39,7 @@ export default function useCheckboxTree<T>({
 
   const toggleAll = useCallback(() => {
     toggle(itemTree)
-  }, [checkedItems])
+  }, [itemTree, toggle])
 
   useEffect(() => {
     onToggle && onToggle({ checkedItems, disabledItems })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the dependency array in the `toggleAll` function, preventing it from using stale values.

#### What problem is this solving?
When you called `toggleAll` after changing the `items` parameter, the function was using stale values due to the function not being updated.

#### How should this be manually tested?
[Workspace](https://lucas--cosmetics1.myvtex.com/admin/app/collections/350/)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
