### PR TITLE
Fix EXPERIMENTAL_Table toolbar responsiveness on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.104.7] - 2020-01-13
+
 ### Fixed
 
 - `EXPERIMENTAL_Table` toolbar responsiveness on small screens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `EXPERIMENTAL_Table` toolbar responsiveness on small screens.
+
 ## [9.104.6] - 2020-01-13
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.104.6",
+  "version": "9.104.7",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.104.6",
+  "version": "9.104.7",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/Toolbar/ButtonGroup.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/ButtonGroup.tsx
@@ -89,7 +89,7 @@ const ButtonGroup: FC & Composites = ({ children }) => (
     id={NAMESPACES.TOOLBAR.BUTTON_GROUP}
     className={csx(
       ORDER_CLASSNAMES.TOOLBAR_CHILD.BUTTON_GROUP,
-      'flex flex-row items-center'
+      'flex flex-row flex-wrap items-center'
     )}>
     {children}
   </div>

--- a/react/components/EXPERIMENTAL_Table/Toolbar/InputSearch.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/InputSearch.tsx
@@ -1,5 +1,4 @@
 import React, { FC, FormEvent, InputHTMLAttributes } from 'react'
-import csx from 'classnames'
 
 import Input from '../../InputSearch/index'
 import { NAMESPACES, ORDER_CLASSNAMES } from '../constants'
@@ -12,7 +11,7 @@ const InputSearch: FC<InputSearchProps> = ({ onSubmit, ...inputProps }) => {
   return (
     <form
       id={NAMESPACES.TOOLBAR.INPUT_SEARCH}
-      className={csx(ORDER_CLASSNAMES.TOOLBAR_CHILD.INPUT, 'w-40')}
+      className={ORDER_CLASSNAMES.TOOLBAR_CHILD.INPUT}
       onSubmit={onSubmit}>
       <Input {...inputProps} />
     </form>

--- a/react/components/EXPERIMENTAL_Table/Toolbar/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/index.tsx
@@ -23,7 +23,7 @@ const Toolbar: FC & Composites = ({ children }) => {
       id={NAMESPACES.TOOLBAR.CONTAINER}
       className={csx(
         ORDER_CLASSNAMES.TOOLBAR,
-        `mb5 flex flex-row w-100 justify-between`
+        `mb5 flex flex-row flex-wrap w-100 justify-between`
       )}>
       {children}
       {positionFixer}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make toolbar items wrap on small screens, avoiding items to overflow.

#### What problem is this solving?
When the toolbar has to many items it's causing the toolbar to overflow the table.

#### How should this be manually tested?
`yarn && yarn start`

#### Screenshots or example usage
**Before**
![Screenshot from 2020-01-10 13-19-20](https://user-images.githubusercontent.com/6867958/72168313-ae01d000-33ab-11ea-87e1-02c78f8d1bd3.png)

**After**
![Screenshot from 2020-01-10 13-20-32](https://user-images.githubusercontent.com/6867958/72168321-b22ded80-33ab-11ea-9b14-e16ddcac6e87.png)
#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
