### PR TITLE
Fix/table searchinput standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.104.6] - 2020-01-13
+
 ### Fixed
 
 - `Table` toolbar's searchInput width on mobile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Table` toolbar's searchInput width on mobile.
+
 ## [9.104.5] - 2020-01-09
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.104.5",
+  "version": "9.104.6",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.104.5",
+  "version": "9.104.6",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -147,8 +147,7 @@ class Toolbar extends PureComponent {
         id="toolbar"
         className={`mb5 flex flex-row w-100 ${
           isSearchBarVisible ? 'justify-between' : 'justify-end'
-        }`}
-      >
+        }`}>
         {inputSearch && (
           <div className={inputSearchAlone ? 'w-100 w-40-ns' : 'w-40'}>
             <InputSearch
@@ -164,14 +163,12 @@ class Toolbar extends PureComponent {
               id="toggleDensity"
               title={density.buttonLabel}
               ref={this.densityBtnRef}
-              className="relative mh1"
-            >
+              className="relative mh1">
               <ButtonWithIcon
                 icon={
                   <span
                     className="c-on-base mh2"
-                    style={ICON_OPTICAL_COMPENSATION}
-                  >
+                    style={ICON_OPTICAL_COMPENSATION}>
                     <IconDensity size={MEDIUM_ICON_SIZE} />
                   </span>
                 }
@@ -185,19 +182,17 @@ class Toolbar extends PureComponent {
                   className={`absolute ${
                     density.alignMenu === 'right' ? 'right-0' : 'left-0'
                   } z-999 ba b--muted-4 br2 mt2 mh2`}
-                  style={BOX_SHADOW_STYLE}
-                >
+                  style={BOX_SHADOW_STYLE}>
                   <div className="w-100 b2 br2 bg-base">
                     <div
                       style={{ height: 3 * FIELDS_BOX_ITEM_HEIGHT }}
-                      className="overflow-auto"
-                    >
+                      className="overflow-auto">
                       {DENSITY_OPTIONS.map((key, index) => {
                         const isKeySelected = selectedDensity === key
                         return (
                           <div
                             key={index}
-                            className={`TRX flex justify-between ph6 pv3 ${
+                            className={`flex justify-between ph6 pv3 ${
                               isKeySelected ? 'b--emphasis' : 'b--transparent'
                             } pointer hover-bg-muted-5 bl bw1`}
                             onClick={() => {
@@ -205,11 +200,9 @@ class Toolbar extends PureComponent {
                               this.handleToggleBox('isDensityBoxVisible')
                               density.handleCallback &&
                                 density.handleCallback(key)
-                            }}
-                          >
+                            }}>
                             <span
-                              className={`w-100 ${isKeySelected ? 'fw5' : ''}`}
-                            >
+                              className={`w-100 ${isKeySelected ? 'fw5' : ''}`}>
                               {density[`${key}OptionLabel`]}
                             </span>
                           </div>
@@ -226,14 +219,12 @@ class Toolbar extends PureComponent {
               id="toggleFieldsBtn"
               title={fields.label}
               ref={this.fieldsBtnRef}
-              className="relative mh1"
-            >
+              className="relative mh1">
               <ButtonWithIcon
                 icon={
                   <span
                     className="c-on-base mh2"
-                    style={ICON_OPTICAL_COMPENSATION}
-                  >
+                    style={ICON_OPTICAL_COMPENSATION}>
                     <IconColumns size={MEDIUM_ICON_SIZE} />
                   </span>
                 }
@@ -246,37 +237,32 @@ class Toolbar extends PureComponent {
                 <div
                   className={`absolute ${
                     fields.alignMenu === 'right' ? 'right-0' : 'left-0'
-                  } z-999 ba b--muted-4 br2 mt2 mh2`}
-                >
+                  } z-999 ba b--muted-4 br2 mt2 mh2`}>
                   <div
                     className="w-100 b2 br2 bg-base"
                     style={{
                       ...BOX_SHADOW_STYLE,
                       width: FIELDS_BOX_WIDTH,
-                    }}
-                  >
+                    }}>
                     <div className="flex inline-flex bb b--muted-4 w-100 pl6 pv4">
                       <Button
                         variation="secondary"
                         size="small"
-                        onClick={onShowAllColumns}
-                      >
+                        onClick={onShowAllColumns}>
                         {fields.showAllLabel}
                       </Button>
                       <div className="mh4">
                         <Button
                           variation="secondary"
                           size="small"
-                          onClick={onHideAllColumns}
-                        >
+                          onClick={onHideAllColumns}>
                           {fields.hideAllLabel}
                         </Button>
                       </div>
                     </div>
                     <div
                       style={{ height: this.calculateFieldsBoxHeight() }}
-                      className="overflow-auto"
-                    >
+                      className="overflow-auto">
                       {Object.keys(schema.properties)
                         .filter(
                           field =>
@@ -286,8 +272,7 @@ class Toolbar extends PureComponent {
                           <div
                             key={index}
                             className="flex justify-between ph6 pv3 pointer hover-bg-muted-5"
-                            onClick={() => onToggleColumn(field)}
-                          >
+                            onClick={() => onToggleColumn(field)}>
                             <span className="w-70 truncate">
                               {schema.properties[field].title || field}
                             </span>
@@ -308,8 +293,7 @@ class Toolbar extends PureComponent {
               <ButtonWithIcon
                 icon={
                   <span
-                    className={`${download.disabled ? '' : forcedColor} mh2`}
-                  >
+                    className={`${download.disabled ? '' : forcedColor} mh2`}>
                     <IconDownload size={MEDIUM_ICON_SIZE} />
                   </span>
                 }
@@ -317,8 +301,7 @@ class Toolbar extends PureComponent {
                 disabled={download.disabled}
                 isLoading={download.isLoading}
                 size="small"
-                onClick={download.handleCallback}
-              >
+                onClick={download.handleCallback}>
                 {download.label && (
                   <span className={`${download.disabled ? '' : forcedColor}`}>
                     {download.label}
@@ -333,8 +316,7 @@ class Toolbar extends PureComponent {
                 icon={
                   <span
                     className={`${upload.disabled ? '' : forcedColor} mh2`}
-                    style={ICON_OPTICAL_COMPENSATION}
-                  >
+                    style={ICON_OPTICAL_COMPENSATION}>
                     <IconUpload size={HEAVY_ICON_SIZE} />
                   </span>
                 }
@@ -342,8 +324,7 @@ class Toolbar extends PureComponent {
                 disabled={upload.disabled}
                 isLoading={upload.isLoading}
                 size="small"
-                onClick={upload.handleCallback}
-              >
+                onClick={upload.handleCallback}>
                 {upload.label && (
                   <span className={`${upload.disabled ? '' : forcedColor}`}>
                     {upload.label}
@@ -383,8 +364,7 @@ class Toolbar extends PureComponent {
                     key="new-line-button"
                     icon={<IconPlus solid size={LIGHT_ICON_SIZE} />}
                     onClick={newLine.handleCallback}
-                    {...newLineButtonProps}
-                  >
+                    {...newLineButtonProps}>
                     {newLine.label}
                   </ButtonWithIcon>,
                   <ActionMenu
@@ -399,8 +379,7 @@ class Toolbar extends PureComponent {
               <ButtonWithIcon
                 icon={<IconPlus solid size={LIGHT_ICON_SIZE} />}
                 onClick={newLine.handleCallback}
-                {...newLineButtonProps}
-              >
+                {...newLineButtonProps}>
                 {newLine.label}
               </ButtonWithIcon>
             ))}

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -133,14 +133,24 @@ class Toolbar extends PureComponent {
 
     const forcedColor = 'c-on-base'
 
+    const inputSearchAlone =
+      inputSearch &&
+      !isDensityVisible &&
+      !isFieldsVisible &&
+      !isDownloadVisible &&
+      !isUploadVisible &&
+      !isExtraActionsVisible &&
+      !isNewLineVisible
+
     return (
       <div
         id="toolbar"
         className={`mb5 flex flex-row w-100 ${
           isSearchBarVisible ? 'justify-between' : 'justify-end'
-        }`}>
+        }`}
+      >
         {inputSearch && (
-          <div className="w-40">
+          <div className={inputSearchAlone ? 'w-100 w-40-ns' : 'w-40'}>
             <InputSearch
               disabled={loading}
               {...inputSearch}
@@ -154,12 +164,14 @@ class Toolbar extends PureComponent {
               id="toggleDensity"
               title={density.buttonLabel}
               ref={this.densityBtnRef}
-              className="relative mh1">
+              className="relative mh1"
+            >
               <ButtonWithIcon
                 icon={
                   <span
                     className="c-on-base mh2"
-                    style={ICON_OPTICAL_COMPENSATION}>
+                    style={ICON_OPTICAL_COMPENSATION}
+                  >
                     <IconDensity size={MEDIUM_ICON_SIZE} />
                   </span>
                 }
@@ -173,17 +185,19 @@ class Toolbar extends PureComponent {
                   className={`absolute ${
                     density.alignMenu === 'right' ? 'right-0' : 'left-0'
                   } z-999 ba b--muted-4 br2 mt2 mh2`}
-                  style={BOX_SHADOW_STYLE}>
+                  style={BOX_SHADOW_STYLE}
+                >
                   <div className="w-100 b2 br2 bg-base">
                     <div
                       style={{ height: 3 * FIELDS_BOX_ITEM_HEIGHT }}
-                      className="overflow-auto">
+                      className="overflow-auto"
+                    >
                       {DENSITY_OPTIONS.map((key, index) => {
                         const isKeySelected = selectedDensity === key
                         return (
                           <div
                             key={index}
-                            className={`flex justify-between ph6 pv3 ${
+                            className={`TRX flex justify-between ph6 pv3 ${
                               isKeySelected ? 'b--emphasis' : 'b--transparent'
                             } pointer hover-bg-muted-5 bl bw1`}
                             onClick={() => {
@@ -191,9 +205,11 @@ class Toolbar extends PureComponent {
                               this.handleToggleBox('isDensityBoxVisible')
                               density.handleCallback &&
                                 density.handleCallback(key)
-                            }}>
+                            }}
+                          >
                             <span
-                              className={`w-100 ${isKeySelected ? 'fw5' : ''}`}>
+                              className={`w-100 ${isKeySelected ? 'fw5' : ''}`}
+                            >
                               {density[`${key}OptionLabel`]}
                             </span>
                           </div>
@@ -210,12 +226,14 @@ class Toolbar extends PureComponent {
               id="toggleFieldsBtn"
               title={fields.label}
               ref={this.fieldsBtnRef}
-              className="relative mh1">
+              className="relative mh1"
+            >
               <ButtonWithIcon
                 icon={
                   <span
                     className="c-on-base mh2"
-                    style={ICON_OPTICAL_COMPENSATION}>
+                    style={ICON_OPTICAL_COMPENSATION}
+                  >
                     <IconColumns size={MEDIUM_ICON_SIZE} />
                   </span>
                 }
@@ -228,32 +246,37 @@ class Toolbar extends PureComponent {
                 <div
                   className={`absolute ${
                     fields.alignMenu === 'right' ? 'right-0' : 'left-0'
-                  } z-999 ba b--muted-4 br2 mt2 mh2`}>
+                  } z-999 ba b--muted-4 br2 mt2 mh2`}
+                >
                   <div
                     className="w-100 b2 br2 bg-base"
                     style={{
                       ...BOX_SHADOW_STYLE,
                       width: FIELDS_BOX_WIDTH,
-                    }}>
+                    }}
+                  >
                     <div className="flex inline-flex bb b--muted-4 w-100 pl6 pv4">
                       <Button
                         variation="secondary"
                         size="small"
-                        onClick={onShowAllColumns}>
+                        onClick={onShowAllColumns}
+                      >
                         {fields.showAllLabel}
                       </Button>
                       <div className="mh4">
                         <Button
                           variation="secondary"
                           size="small"
-                          onClick={onHideAllColumns}>
+                          onClick={onHideAllColumns}
+                        >
                           {fields.hideAllLabel}
                         </Button>
                       </div>
                     </div>
                     <div
                       style={{ height: this.calculateFieldsBoxHeight() }}
-                      className="overflow-auto">
+                      className="overflow-auto"
+                    >
                       {Object.keys(schema.properties)
                         .filter(
                           field =>
@@ -263,7 +286,8 @@ class Toolbar extends PureComponent {
                           <div
                             key={index}
                             className="flex justify-between ph6 pv3 pointer hover-bg-muted-5"
-                            onClick={() => onToggleColumn(field)}>
+                            onClick={() => onToggleColumn(field)}
+                          >
                             <span className="w-70 truncate">
                               {schema.properties[field].title || field}
                             </span>
@@ -284,7 +308,8 @@ class Toolbar extends PureComponent {
               <ButtonWithIcon
                 icon={
                   <span
-                    className={`${download.disabled ? '' : forcedColor} mh2`}>
+                    className={`${download.disabled ? '' : forcedColor} mh2`}
+                  >
                     <IconDownload size={MEDIUM_ICON_SIZE} />
                   </span>
                 }
@@ -292,7 +317,8 @@ class Toolbar extends PureComponent {
                 disabled={download.disabled}
                 isLoading={download.isLoading}
                 size="small"
-                onClick={download.handleCallback}>
+                onClick={download.handleCallback}
+              >
                 {download.label && (
                   <span className={`${download.disabled ? '' : forcedColor}`}>
                     {download.label}
@@ -307,7 +333,8 @@ class Toolbar extends PureComponent {
                 icon={
                   <span
                     className={`${upload.disabled ? '' : forcedColor} mh2`}
-                    style={ICON_OPTICAL_COMPENSATION}>
+                    style={ICON_OPTICAL_COMPENSATION}
+                  >
                     <IconUpload size={HEAVY_ICON_SIZE} />
                   </span>
                 }
@@ -315,7 +342,8 @@ class Toolbar extends PureComponent {
                 disabled={upload.disabled}
                 isLoading={upload.isLoading}
                 size="small"
-                onClick={upload.handleCallback}>
+                onClick={upload.handleCallback}
+              >
                 {upload.label && (
                   <span className={`${upload.disabled ? '' : forcedColor}`}>
                     {upload.label}
@@ -355,7 +383,8 @@ class Toolbar extends PureComponent {
                     key="new-line-button"
                     icon={<IconPlus solid size={LIGHT_ICON_SIZE} />}
                     onClick={newLine.handleCallback}
-                    {...newLineButtonProps}>
+                    {...newLineButtonProps}
+                  >
                     {newLine.label}
                   </ButtonWithIcon>,
                   <ActionMenu
@@ -370,7 +399,8 @@ class Toolbar extends PureComponent {
               <ButtonWithIcon
                 icon={<IconPlus solid size={LIGHT_ICON_SIZE} />}
                 onClick={newLine.handleCallback}
-                {...newLineButtonProps}>
+                {...newLineButtonProps}
+              >
                 {newLine.label}
               </ButtonWithIcon>
             ))}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Set the width of the inputSearch bar to 100% on mobile when no other items are set in the toolbar.

#### What problem is this solving?
A width set to 40%.

#### How should this be manually tested?
https://kevin--recorrenciaqa.myvtex.com/admin/orders-admin

#### Screenshots or example usage
![kevin--recorrenciaqa myvtex com_admin_orders-admin(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/2573602/72175129-240d3380-33ba-11ea-93eb-1a1a19dc6a53.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
