### PR TITLE
[EXPERIMENTAL_Table] Auto disable checkbox heading when all checkboxes are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.104.8] - 2020-01-15
+
 ### Added
 
 - Disable `EXPERIMENTAL_Table` check all heading when all checkboxes are disabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Disable `EXPERIMENTAL_Table` check all heading when all checkboxes are disabled.
+
 ## [9.104.7] - 2020-01-13
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.104.7",
+  "version": "9.104.8",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.104.7",
+  "version": "9.104.8",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
@@ -29,6 +29,7 @@ const Headings: FC<HeadingsProps> = ({
                   <CellPrefix.Checkbox
                     checked={checkboxes.allChecked}
                     partial={checkboxes.someChecked}
+                    disabled={checkboxes.allDisabled}
                     // eslint-disable-next-line react/jsx-handler-names
                     onClick={checkboxes.toggleAll}
                   />

--- a/react/components/EXPERIMENTAL_useCheckboxTree/index.tsx
+++ b/react/components/EXPERIMENTAL_useCheckboxTree/index.tsx
@@ -112,6 +112,10 @@ export default function useCheckboxTree<T>({
     return checkedItems.length > 0
   }, [checkedItems])
 
+  const allDisabled = useMemo(() => {
+    return isDisabled(itemTree)
+  }, [isDisabled, itemTree])
+
   const check = (item: T | Tree<T>) => {
     if (!isDisabled(item))
       dispatch({
@@ -146,6 +150,7 @@ export default function useCheckboxTree<T>({
     checkedItems,
     isChecked,
     allChecked,
+    allDisabled,
     someChecked,
     isPartiallyChecked,
     itemTree,


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
When all checkboxes are disabled, the heading 'check all' checkbox doesn't have any effect, so it should be disabled too.

[Running workspace](https://thay--cosmetics1.myvtex.com/admin/collections/628/)

The checkbox next to 'description' should be disabled.

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
