### PR TITLE
Add missing handle to the label of the Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.105.0] - 2020-01-16
+
 ### Added
 - Handle to the label of the `Button`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Handle to the label of the `Button`.
+
 ## [9.104.11] - 2020-01-15
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.104.11",
+  "version": "9.105.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.104.11",
+  "version": "9.105.0",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -57,7 +57,7 @@ class Button extends Component {
       variation === 'danger-tertiary'
 
     let classes = 'vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid '
-    let labelClasses = 'flex items-center justify-center h-100 '
+    let labelClasses = 'vtex-button__label flex items-center justify-center h-100 '
     let loaderSize = 15
     let horizontalPadding = 0
 
@@ -238,7 +238,7 @@ class Button extends Component {
         {...(href && linkModeProps)}>
         {isLoading ? (
           <Fragment>
-            <span className="top-0 left-0 w-100 h-100 absolute flex justify-center items-center">
+            <span className="vtex-button__spinner-container top-0 left-0 w-100 h-100 absolute flex justify-center items-center">
               <Spinner
                 secondary={variation === 'primary' || variation === 'danger'}
                 size={loaderSize}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a missing handle to the label of the Button

#### What problem is this solving?
[Running workspace](https://buttonhandle--storecomponents.myvtex.com/)


The agencies want to style the label of the Button, but with the new styles builder they can't do `.vtex-button span` because we don't allow to style direct elements, so we need to add classes to all elements of the store.

#### How should this be manually tested?

#### Screenshots or example usage

Before:
![image](https://user-images.githubusercontent.com/8517023/72533658-48528f80-3854-11ea-816b-48d0a216b297.png)

Now: 
![image](https://user-images.githubusercontent.com/8517023/72533557-2527e000-3854-11ea-8494-16fbe2291b58.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
