### PR TITLE
Initial filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Now the `FilterBar` respects the initial value of the statements object.
+
 ## [9.105.0] - 2020-01-16
 
 ### Added
+
 - Handle to the label of the `Button`.
 
 ## [9.104.11] - 2020-01-15

--- a/react/components/FilterBar/index.js
+++ b/react/components/FilterBar/index.js
@@ -35,8 +35,8 @@ class FilterBar extends PureComponent {
       visibleExtraOptions: [],
     }
   }
-  
-  componentDidMount(){
+
+  componentDidMount = () => {
     this.props.statements.forEach(st => {
       this.handleSubmitFilter(st)
       this.toggleExtraFilterOption(st.subject)

--- a/react/components/FilterBar/index.js
+++ b/react/components/FilterBar/index.js
@@ -31,10 +31,16 @@ const truncateFilterValue = filterValue =>
 class FilterBar extends PureComponent {
   constructor(props) {
     super(props)
-
     this.state = {
       visibleExtraOptions: [],
     }
+  }
+  
+  componentDidMount(){
+    this.props.statements.forEach(st => {
+      this.handleSubmitFilter(st)
+      this.toggleExtraFilterOption(st.subject)
+    })
   }
 
   toggleExtraFilterOption = key => {

--- a/react/components/FilterBar/index.js
+++ b/react/components/FilterBar/index.js
@@ -37,9 +37,9 @@ class FilterBar extends PureComponent {
   }
 
   componentDidMount = () => {
-    this.props.statements.forEach(st => {
-      this.handleSubmitFilter(st)
-      this.toggleExtraFilterOption(st.subject)
+    this.props.statements.forEach(statement => {
+      this.handleSubmitFilter(statement)
+      this.toggleExtraFilterOption(statement.subject)
     })
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

The `FilterBar` did not respect the statements values that were initially passed to it. So there was no way of initially selecting a filter.

#### How should this be manually tested?

Note that the `Status` filter is selected before the user do anything.

[Running workspace](https://addactivefilter--storecomponents.myvtex.com/admin/app/collections/1164/)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
