### PR TITLE
Allow the use of defaultMenuIsOpen in EXPERIMENTAL_Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.105.4] - 2020-01-22
+
 ### Added
 
 - `defaultMenuIsOpen` prop in `EXPERIMENTAL_Select`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- Now `defaultMenuIsOpen` can be used in `EXPERIMENTAL_Select`.
+- `defaultMenuIsOpen` prop in `EXPERIMENTAL_Select`.
 
 ## [9.105.3] - 2020-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Now `defaultMenuIsOpen` can be used in `EXPERIMENTAL_Select`.
+
 ## [9.105.3] - 2020-01-22
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.105.3",
+  "version": "9.105.4",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.105.3",
+  "version": "9.105.4",
   "scripts": {
     "test": "node config/test.js",
     "test:codemod": "jest codemod",

--- a/react/components/EXPERIMENTAL_Conditions/Atoms/ObjectAtom.js
+++ b/react/components/EXPERIMENTAL_Conditions/Atoms/ObjectAtom.js
@@ -50,7 +50,7 @@ class ObjectAtom extends React.Component {
           extraParams: currentVerb.object.extraParams,
           onChangeObjectCallback,
         })}
-      </div> 
+      </div>
     )
   }
 }

--- a/react/components/EXPERIMENTAL_Conditions/Atoms/ObjectAtom.js
+++ b/react/components/EXPERIMENTAL_Conditions/Atoms/ObjectAtom.js
@@ -50,7 +50,7 @@ class ObjectAtom extends React.Component {
           extraParams: currentVerb.object.extraParams,
           onChangeObjectCallback,
         })}
-      </div>
+      </div> 
     )
   }
 }

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -260,7 +260,7 @@ Select.propTypes = {
   value: PropTypes.oneOfType([OptionShape, OptionsShape]),
   /** Max height (in _px_) of the selected values container */
   valuesMaxHeight: PropTypes.number,
-  /** If its options are initially shown*/
+  /** If its options are initially shown */
   defaultMenuIsOpen: PropTypes.bool,
 }
 

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -60,9 +60,11 @@ class Select extends Component {
       value,
       valuesMaxHeight,
       clearable,
+      defaultMenuIsOpen
     } = this.props
 
     const reactSelectComponentProps = {
+      defaultMenuIsOpen,
       ref: forwardedRef,
       autoFocus,
       className: `pointer b--danger bw1 ${getFontClassNameFromSize(size)} ${

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -197,6 +197,7 @@ Select.defaultProps = {
   placeholder: 'Select...',
   size: 'regular',
   clearable: true,
+  defaultMenuIsOpen: false,
 }
 
 const OptionShape = PropTypes.shape({

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -60,7 +60,7 @@ class Select extends Component {
       value,
       valuesMaxHeight,
       clearable,
-      defaultMenuIsOpen
+      defaultMenuIsOpen,
     } = this.props
 
     const reactSelectComponentProps = {
@@ -260,6 +260,8 @@ Select.propTypes = {
   value: PropTypes.oneOfType([OptionShape, OptionsShape]),
   /** Max height (in _px_) of the selected values container */
   valuesMaxHeight: PropTypes.number,
+  /** If its options are initially shown*/
+  defaultMenuIsOpen: PropTypes.bool,
 }
 
 export default withForwardedRef(Select)


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Check the use of the prop in the `Status` filter.

[workspace using new prop](https://addactivefilter--storecomponents.myvtex.com/admin/app/collections/1164/)
[workspace not using new prop](https://addactivefilter1--storecomponents.myvtex.com/admin/app/collections/1164/)

*Before*
![chrome-capture](https://user-images.githubusercontent.com/4912690/72838877-f18ff000-3c6f-11ea-986a-c774093de738.gif)

*After*
![chrome-capture (1)](https://user-images.githubusercontent.com/4912690/72838893-fa80c180-3c6f-11ea-818a-c7d42f09fb81.gif)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
