### PR TITLE
Enable headerRenderer usage in all header options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Table`'s `headerRenderer` can be used in columns that are either fixed or sortable
+
 ## [9.112.15] - 2020-03-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
 - `Table`'s `headerRenderer` can be used in columns that are either fixed or sortable
 

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -403,14 +403,12 @@ class CustomTableExample extends React.Component {
     }
 
     return (
-      <div>
-        <div className="mb5">
-          <Table schema={customSchema} items={this.state.orderedItems} sort={{
-              sortedBy: this.state.dataSort.sortedBy,
-              sortOrder: this.state.dataSort.sortOrder,
-            }}
-            onSort={this.handleSort}/>
-        </div>
+      <div className="mb5">
+        <Table schema={customSchema} items={this.state.orderedItems} sort={{
+            sortedBy: this.state.dataSort.sortedBy,
+            sortOrder: this.state.dataSort.sortOrder,
+          }}
+          onSort={this.handleSort}/>
       </div>
     )
   }

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -319,20 +319,23 @@ const itemsCopy = sampleData.items
   .reverse()
   .splice(20)
 const Tag = require('../Tag').default
+
 class FormattedMessage extends React.Component {
   render() {
     const renderTextByIntlId = id => {
       switch (id) {
-        case 'some.intl.message.id':
-          return 'Number'
-          break
+        case 'value.intl.message.id':
+          return 'Value';
         default:
-          return 'Deafult Header title'
-          break
+          return 'Deafult Header title';
       }
     }
     return <span>{renderTextByIntlId(this.props.id)}</span>
   }
+}
+
+const translate = ({ title }) => {
+  return <FormattedMessage id={title} />
 }
 
 class CustomTableExample extends React.Component {
@@ -340,6 +343,38 @@ class CustomTableExample extends React.Component {
     super()
     this.state = {
       orderedItems: itemsCopy,
+      dataSort: {
+        sortedBy: null,
+        sortOrder: null,
+      },
+    }
+
+    this.sortNumberASC = this.sortNumberASC.bind(this)
+    this.sortNumberDESC = this.sortNumberDESC.bind(this)
+    this.handleSort = this.handleSort.bind(this)
+  }
+
+  sortNumberASC(a, b) {
+    return a.number < b.number ? -1 : a.number > b.number ? 1 : 0
+  }
+  sortNumberDESC(a, b) {
+    return a.number < b.number ? 1 : a.number > b.number ? -1 : 0
+  }
+
+  handleSort({ sortOrder, sortedBy }) {
+    if (sortedBy === 'number') {
+      const orderedItems =
+        sortOrder === 'ASC'
+          ? itemsCopy.slice().sort(this.sortNumberASC)
+          : itemsCopy.slice().sort(this.sortNumberDESC)
+
+      this.setState({
+        orderedItems,
+        dataSort: {
+          sortedBy,
+          sortOrder,
+        },
+      })
     }
   }
 
@@ -351,14 +386,18 @@ class CustomTableExample extends React.Component {
           width: 250,
         },
         email: {
-          title: 'Email',
-          width: 300,
+          title: 'email.intl.message.id',
+          width: 250,
+          headerRenderer: translate,
         },
         number: {
-          title: 'some.intl.message.id',
-          headerRenderer: ({ title }) => {
-            return <FormattedMessage id={title} />
-          },
+          title: 'value.intl.message.id',
+          headerRenderer: translate,
+          sortable: true,
+          headerRight: true,
+          cellRenderer: data => (
+            <div className="w-100 tr">$ {data.cellData}</div>
+          ),
         },
       },
     }
@@ -366,7 +405,11 @@ class CustomTableExample extends React.Component {
     return (
       <div>
         <div className="mb5">
-          <Table schema={customSchema} items={this.state.orderedItems} />
+          <Table schema={customSchema} items={this.state.orderedItems} sort={{
+              sortedBy: this.state.dataSort.sortedBy,
+              sortOrder: this.state.dataSort.sortOrder,
+            }}
+            onSort={this.handleSort}/>
         </div>
       </div>
     )

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -308,7 +308,7 @@ class CustomTableExample extends React.Component {
 - Customized the render method of a single header cell.
 - It receives a function that returns a node (react component).
 - The function has the following params: ({ columnIndex, key, title })
-- This prop will not work if the `sortable` prop for the same header is active.
+- This prop will also work if either the `sortable` or `fixedColumn` prop for the same header is active. For sortable headers, the sorting caret will be added to the side of your header renderer according to the specified alignment (`headerRight: true/false`).
 
 example customizing number column header to use intl FormattedMessage
 

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -285,8 +285,16 @@ class SimpleTable extends Component {
                           schema.properties[property].title || property
                         const headerRight =
                           schema.properties[property].headerRight || false
-                        const headerRenderer =
-                          schema.properties[property].headerRenderer
+                        const header =
+                          (schema.properties[property].headerRenderer &&
+                            schema.properties[property].headerRenderer({
+                              columnIndex,
+                              key,
+                              rowIndex,
+                              style,
+                              title,
+                            })) ||
+                          title
                         const arrowIsDown =
                           sortOrder === 'ASC' && sortedBy === property
                         const arrowIsUp =
@@ -311,11 +319,11 @@ class SimpleTable extends Component {
                               }`}>
                               {schema.properties[property].sortable ? (
                                 <div
-                                  className="w-100 pointer c-muted-1 b t-small"
+                                  className="w-100 pointer c-muted-1 b t-small flex items-center"
                                   onClick={() => {
                                     onSort(this.toggleSortType(property))
                                   }}>
-                                  {!headerRight && title}
+                                  {!headerRight && header}
                                   <div
                                     className={`inline-flex ${
                                       headerRight ? 'pr2' : 'pl3'
@@ -326,20 +334,12 @@ class SimpleTable extends Component {
                                       <ArrowUp size={ARROW_SIZE} />
                                     ) : null}
                                   </div>
-                                  {headerRight && title}
+                                  {headerRight && header}
                                 </div>
                               ) : columnIndex === 0 && fixFirstColumn ? (
-                                <div className="w-100">{title}</div>
-                              ) : headerRenderer ? (
-                                headerRenderer({
-                                  columnIndex,
-                                  key,
-                                  rowIndex,
-                                  style,
-                                  title,
-                                })
+                                <div className="w-100">{header}</div>
                               ) : (
-                                <span className="w-100">{title}</span>
+                                header
                               )}
                             </div>
                           </CellMeasurer>

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -319,7 +319,11 @@ class SimpleTable extends Component {
                               }`}>
                               {schema.properties[property].sortable ? (
                                 <div
-                                  className="w-100 pointer c-muted-1 b t-small flex items-center"
+                                  className={`w-100 pointer c-muted-1 b t-small flex items-center ${
+                                    headerRight
+                                      ? 'justify-end'
+                                      : 'justify-start'
+                                  }`}
                                   onClick={() => {
                                     onSort(this.toggleSortType(property))
                                   }}>


### PR DESCRIPTION
#### What is the purpose of this pull request?

To make possible the usage of the `headerRenderer` even when column options such as `sortable` and `fixFirstColumn` are enabled.

#### What problem is this solving?
When either of `sortable` or `fixFirstColumn` are enabled, the column stops using the `headerRenderer` option and uses the default `title` instead.

#### How should this be manually tested?
[Here](https://artur--sandboxintegracao.myvtex.com/admin/sellers/?sortOrder=ASC&sortedBy=name) is an example of a Table with a sortable column that also uses a header renderer

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3827456/72919386-2494bb00-3d26-11ea-8a74-b88eb630f48f.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
