### PR TITLE
Fix error when deleting a filter tag applied in the FilterBar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.106.2] - 2020-01-27
+
 ### Fixed
 
 - Error caused by deleting a filter tag while the `Menu` is still active in the `FilterBar` component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fix an error that can be caused when deleting a filter tag applied in the FilterBar component
+- Error caused by deleting a filter tag while the `Menu` is still active in the `FilterBar` component.
 
 ## [9.106.1] - 2020-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix an error that can be caused when deleting a filter tag applied in the FilterBar component
+
 ## [9.106.1] - 2020-01-27
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.106.1",
+  "version": "9.106.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.106.1",
+  "version": "9.106.2",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Statement/index.tsx
+++ b/react/components/Statement/index.tsx
@@ -30,6 +30,9 @@ const Statement: React.FC<Props> = ({
   statement = { subject: '', verb: '', object: null, error: null },
   subjectPlaceholder,
 }) => {
+  const verbOptions =
+    statement.subject &&
+    options[statement.subject].verbs.find(verb => verb.value === statement.verb)
   const statementAtoms = [
     !omitSubject && (
       <SubjectAtom
@@ -81,12 +84,7 @@ const Statement: React.FC<Props> = ({
         }
         onChangeStatement(newStatement)
       }}
-      renderObject={
-        statement.subject &&
-        options[statement.subject].verbs.find(
-          verb => verb.value === statement.verb
-        ).object
-      }
+      renderObject={verbOptions && verbOptions.object}
     />,
   ]
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix an error caused when deleting a filter tag in the `FilterBar` component 
<!--- Describe your changes in detail. -->

#### What problem is this solving?
Deleting a filter tag in the `FilterBar` component can generate an error

[Running workspace](https://filtertag--cosmetics1.myvtex.com/admin/collections/create/)

<!--- What is the motivation and context for this change? -->
#### How should this be manually tested?
Just follow the steps shown bellow in the usage example.

#### Screenshots or example usage
##### Before:
![before-filtertag](https://user-images.githubusercontent.com/20579226/72986482-0b901680-3dc7-11ea-872d-1058b530cc96.gif)
##### After:
![after-filtertag](https://user-images.githubusercontent.com/20579226/72986495-12b72480-3dc7-11ea-9406-03dc434e5cf9.gif)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
