### PR TITLE
Toolbar buttons default size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Toolbar buttons default size is now regular.
+
 ## [9.108.1] - 2020-01-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.108.2] - 2020-01-31
+
 ### Changed
 
 - Toolbar buttons default size is now regular.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.108.1",
+  "version": "9.108.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.108.1",
+  "version": "9.108.2",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -128,7 +128,7 @@ class Toolbar extends PureComponent {
       disabled: loading || (newLine && newLine.disabled),
       isLoading: newLine && newLine.isLoading,
       variation: 'primary',
-      size: 'small',
+      size: 'regular',
     }
 
     const forcedColor = 'c-on-base'
@@ -174,7 +174,7 @@ class Toolbar extends PureComponent {
                 }
                 disabled={loading}
                 variation="tertiary"
-                size="small"
+                size="regular"
                 onClick={() => this.handleToggleBox('isDensityBoxVisible')}
               />
               {isDensityBoxVisible && (
@@ -230,7 +230,7 @@ class Toolbar extends PureComponent {
                 }
                 disabled={loading}
                 variation="tertiary"
-                size="small"
+                size="regular"
                 onClick={() => this.handleToggleBox('isFieldsBoxVisible')}
               />
               {isFieldsBoxVisible && (
@@ -247,14 +247,14 @@ class Toolbar extends PureComponent {
                     <div className="flex inline-flex bb b--muted-4 w-100 pl6 pv4">
                       <Button
                         variation="secondary"
-                        size="small"
+                        size="regular"
                         onClick={onShowAllColumns}>
                         {fields.showAllLabel}
                       </Button>
                       <div className="mh4">
                         <Button
                           variation="secondary"
-                          size="small"
+                          size="regular"
                           onClick={onHideAllColumns}>
                           {fields.hideAllLabel}
                         </Button>
@@ -277,7 +277,7 @@ class Toolbar extends PureComponent {
                               {schema.properties[field].title || field}
                             </span>
                             <Toggle
-                              size="small"
+                              size="regular"
                               checked={!hiddenFields.includes(field)}
                             />
                           </div>
@@ -300,7 +300,7 @@ class Toolbar extends PureComponent {
                 variation="tertiary"
                 disabled={download.disabled}
                 isLoading={download.isLoading}
-                size="small"
+                size="regular"
                 onClick={download.handleCallback}>
                 {download.label && (
                   <span className={`${download.disabled ? '' : forcedColor}`}>
@@ -323,7 +323,7 @@ class Toolbar extends PureComponent {
                 variation="tertiary"
                 disabled={upload.disabled}
                 isLoading={upload.isLoading}
-                size="small"
+                size="regular"
                 onClick={upload.handleCallback}>
                 {upload.label && (
                   <span className={`${upload.disabled ? '' : forcedColor}`}>
@@ -344,7 +344,7 @@ class Toolbar extends PureComponent {
                       <IconOptionsDots />
                     </span>
                   ),
-                  size: 'small',
+                  size: 'regular',
                 }}
                 options={extraActions.actions.map(action => {
                   return {


### PR DESCRIPTION
#### What is the purpose of this pull request?

The default size of the `SearchInput` of the Styleguide Table's toolbar is different from the other Buttons of the toolbar.

#### What problem is this solving?

Toolbar buttons default sizes incoherence. 
Resolves #990 

#### How should this be manually tested?

Checkout to this branch and look at the exemples with a toolbar like the above

<img width="903" alt="Screen Shot 2020-01-23 at 3 06 44 PM" src="https://user-images.githubusercontent.com/52427813/73010882-04cac900-3df2-11ea-8c51-54b8c0a3c7f3.png">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
