### PR TITLE
Feature/checkbox ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `forwardRef` to Checkbox
+- `forwardRef` to `Checkbox` component.
 
 ### Fixed
 
-- Avoid calling `onChange` callback when undefined
+- Avoid calling `onChange` callback when `undefined`.
 
 ## [9.106.2] - 2020-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `forwardRef` to Checkbox
+
+### Fixed
+
+- Avoid calling `onChange` callback when undefined
+
 ## [9.106.2] - 2020-01-27
 
 ### Fixed

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -6,7 +6,10 @@ import CheckIcon from '../icon/Check'
 import CheckPartial from '../icon/CheckPartial'
 
 class Checkbox extends PureComponent {
-  handleChange = e => !this.props.disabled && this.props.onChange(e)
+  handleChange = e =>
+    this.props.onChange
+      ? !this.props.disabled && this.props.onChange(e)
+      : undefined
 
   render() {
     const {

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -22,6 +22,7 @@ class Checkbox extends PureComponent {
       required,
       value,
       partial,
+      forwardedRef,
     } = this.props
 
     return (
@@ -69,7 +70,7 @@ class Checkbox extends PureComponent {
           </div>
           <input
             checked={checked}
-            ref={this.props.forwardedRef}
+            ref={forwardedRef}
             className={classNames('h1 w1 absolute o-0', {
               pointer: !disabled,
             })}

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import CheckIcon from '../icon/Check'
 import CheckPartial from '../icon/CheckPartial'
+import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
 
 class Checkbox extends PureComponent {
   handleChange = e =>
@@ -68,6 +69,7 @@ class Checkbox extends PureComponent {
           </div>
           <input
             checked={checked}
+            ref={this.props.forwardedRef}
             className={classNames('h1 w1 absolute o-0', {
               pointer: !disabled,
             })}
@@ -106,6 +108,8 @@ Checkbox.defaultProps = {
 Checkbox.propTypes = {
   /** (Input spec attribute) */
   checked: PropTypes.bool,
+  /** @ignore Forwarded Ref */
+  forwardedRef: refShape,
   /** (Input spec attribute) */
   disabled: PropTypes.bool,
   /** (Input spec attribute) */
@@ -124,4 +128,4 @@ Checkbox.propTypes = {
   partial: PropTypes.bool,
 }
 
-export default Checkbox
+export default withForwardedRef(Checkbox)


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `forwardRef` to Checkbox and fixed calling `onChange` callback when it is undefined

#### What problem is this solving?

- Make it possible to use ref
- Make it possible to use without passing `onChange` callback

#### How should this be manually tested?

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
