### PR TITLE
Add missing handles from NumericStepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `numeric-stepper__label`, `numeric-stepper-container`, `numeric-steper__input`, `numeric-stepper__plus-button-container`, `numeric-stepper__plus-button`, `numeric-stepper__plus-button__text`, `numeric-stepper__minus-button-container`, `numeric-stepper__minus-button`, `numeric-stepper__minus-button__text` and `numeric-stepper-wrapper` to the elements that didn't have any handle.
+
 ## [9.106.3] - 2020-01-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.107.0] - 2020-01-28
+
 ### Added
 
 - `numeric-stepper__label`, `numeric-stepper-container`, `numeric-steper__input`, `numeric-stepper__plus-button-container`, `numeric-stepper__plus-button`, `numeric-stepper__plus-button__text`, `numeric-stepper__minus-button-container`, `numeric-stepper__minus-button`, `numeric-stepper__minus-button__text` and `numeric-stepper-wrapper` to the elements that didn't have any handle.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.106.3",
+  "version": "9.107.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.106.3",
+  "version": "9.107.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -212,15 +212,17 @@ class NumericStepper extends Component {
     const content = (
       <React.Fragment>
         {label && (
-          <span className={`db mb3 w-100 c-on-base ${labelClasses}`}>
+          <span className={`numeric-stepper__label db mb3 w-100 c-on-base ${labelClasses}`}>
             {label}
           </span>
         )}
-        <div className="flex self-start">
+        <div className="numeric-stepper-container flex self-start">
           <input
             type="tel"
             readOnly={readOnly}
-            className={`z-1 order-1 tc bw1 ${borderClasses} br0 ${inputClasses} ${styles.hideDecorators}`}
+            className={
+              `numeric-stepper__input z-1 order-1 tc bw1 ${borderClasses} br0 ${inputClasses} ${styles.hideDecorators}`
+            }
             style={{
               ...(block && {
                 width: 0,
@@ -232,12 +234,14 @@ class NumericStepper extends Component {
             onFocus={this.handleFocusInput}
             onBlur={this.handleBlurInput}
           />
-          <div className="z-2 order-2 flex-none">
+          <div className="numeric-stepper__plus-button-container z-2 order-2 flex-none">
             <button
               type="button"
-              className={`br2 pa0 bl-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
-                readOnly || isMax ? buttonDisabledClasses : buttonEnabledClasses
-              }`}
+              className={
+                `numeric-stepper__plus-button br2 pa0 bl-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
+                  readOnly || isMax ? buttonDisabledClasses : buttonEnabledClasses
+                }`
+              }
               style={{
                 borderTopLeftRadius: 0,
                 borderBottomLeftRadius: 0,
@@ -248,16 +252,16 @@ class NumericStepper extends Component {
               aria-label="+"
               tabIndex={0}
               onClick={this.handleIncreaseValue}>
-              <div className="b">
+              <div className="numeric-stepper__plus-button__text b">
                 {/* fullwidth plus sign (U+FF0B) http://graphemica.com/%EF%BC%8B */}
                 ＋
               </div>
             </button>
           </div>
-          <div className="z-2 order-0 flex-none">
+          <div className="numeric-stepper__minus-button-container z-2 order-0 flex-none">
             <button
               type="button"
-              className={`br2 pa0 br-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
+              className={`numeric-stepper__minus-button br2 pa0 br-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
                 readOnly || isMin ? buttonDisabledClasses : buttonEnabledClasses
               }`}
               style={{
@@ -273,7 +277,7 @@ class NumericStepper extends Component {
               // Used for screen readers.
               tabIndex={0}
               onClick={this.handleDecreaseValue}>
-              <span className="b">
+              <span className="numeric-stepper__minus-button__text b">
                 {/* fullwidth hyphen-minus (U+FF0D) http://graphemica.com/%EF%BC%8D */}
                 －
               </span>
@@ -287,9 +291,9 @@ class NumericStepper extends Component {
     // iOS from focusing on the text field and popping up the
     // keyboard when increment/decrement is pressed
     if (label && !lean) {
-      return <label>{content}</label>
+      return <label className="numeric-stepper-wrapper">{content}</label>
     }
-    return <div>{content}</div>
+    return <div className="numeric-stepper-wrapper">{content}</div>
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

To solve the same problem of https://github.com/vtex/styleguide/pull/997, but to the `NumericStepper` this time.

#### What problem is this solving?
[Running workspace](https://numericstepper--alssports.myvtex.com/pat25450/p)


#### How should this be manually tested?

#### Screenshots or example usage

Before (the selected element is when the numeric stepper elements start):
![image](https://user-images.githubusercontent.com/8517023/73293495-c0b93900-41e2-11ea-8b3d-dd5c132a6c67.png)


After (the selected element is when the numeric stepper elements start):
![image](https://user-images.githubusercontent.com/8517023/73293428-a5e6c480-41e2-11ea-9b08-71482990a699.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
