### PR TITLE
Changed EXPERIMENTAL_Table density names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `EXPERIMENTAL_Table` density names.
+
 ## [9.108.0] - 2020-01-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.108.1] - 2020-01-30
+
 ### Changed
 
 - `EXPERIMENTAL_Table` density names.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.108.0",
+  "version": "9.108.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.108.0",
+  "version": "9.108.1",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
@@ -15,7 +15,7 @@ const Rows: FC<RowsProps> = ({
   rowProps,
   isRowActive,
   rowHeight,
-  selectedDensity,
+  currentDensity,
   checkboxes,
   rowKey,
 }) => {
@@ -52,7 +52,7 @@ const Rows: FC<RowsProps> = ({
                     cellData,
                     rowData,
                     rowHeight,
-                    selectedDensity,
+                    currentDensity,
                     motion,
                   })
                 : cellData
@@ -84,7 +84,7 @@ const Rows: FC<RowsProps> = ({
 export type RowsProps = {
   columns: Array<Column>
   items: Items
-  selectedDensity: Density
+  currentDensity: Density
   rowKey?: ({ rowData: unknown }) => string
   onRowClick?: ({ rowData: unknown }) => void
   isRowActive?: (rowData: unknown) => boolean

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -11,7 +11,7 @@ type Column = {
     cellData: unknown
     rowData: unknown
     rowHeight: number
-    selectedDensity: 'low' | 'medium' | 'high'
+    currentDensity: 'compact' | 'regular' | 'comfortable'
   }) => React.ReactNode
 }
 ```
@@ -35,11 +35,11 @@ type Column = {
 
 - Customize the render method of a single column cell.
 - It receives a function that returns a node (react component).
-- The function has the following params: ({ cellData, rowData, rowHeight, selectedDensity })
+- The function has the following params: ({ cellData, rowData, rowHeight, currentDensity })
   - cellData: the value of the current cell.
   - rowData: the value of the current row.
   - rowHeight: current height of the row.
-  - selectedDensity: current table density.
+  - currentDensity: current table density.
 - The default is rendering the value as a string.
 
 To illustrate this info, let's suppose we have a list of heroes, each one with properties `name`, `email`, `age` and `country`:
@@ -395,23 +395,22 @@ const columns = [
   {
     id: 'name',
     title: 'Name',
-    sortable: true
+    sortable: true,
   },
   {
     id: 'qty',
     title: 'Qty',
-    sortable: true
+    sortable: true,
   },
   {
     id: 'costPrice',
     title: 'Cost',
-    sortable: true
-
+    sortable: true,
   },
   {
     id: 'retailPrice',
     title: 'Retail',
-    sortable: true
+    sortable: true,
   },
 ]
 
@@ -424,12 +423,16 @@ function SortExample() {
     size: products.length,
   })
 
-  const ascOrdering = prop => (a, b) => a[prop] > b[prop] ? 1 : a[prop] < b [prop] ? -1 : 0
-  const dscOrdering = prop => (a, b) => a[prop] > b[prop] ? -1 : a[prop] < b [prop] ? 1 : 0
+  const ascOrdering = prop => (a, b) =>
+    a[prop] > b[prop] ? 1 : a[prop] < b[prop] ? -1 : 0
+  const dscOrdering = prop => (a, b) =>
+    a[prop] > b[prop] ? -1 : a[prop] < b[prop] ? 1 : 0
 
   const items = React.useMemo(() => {
-    const { sorted: { order, by } } = sorting
-    if(!order){
+    const {
+      sorted: { order, by },
+    } = sorting
+    if (!order) {
       return products
     }
     const ascending = order === 'ASC'
@@ -471,7 +474,7 @@ const items = [
   {
     id: 1,
     name:
-      '⚠️ This is just a text that is very very very large and should be fully visible when it is confortable and truncated otherwise. If you are seeing this part, it means that you are ona  low density 🤓!',
+      '⚠️ This is just a text that is very very very large and should be fully visible when it is confortable and truncated otherwise. If you are seeing this part, it means that you are ona  comfortable density 🤓!',
     country: '🇨🇺Cuba',
   },
   {
@@ -491,8 +494,8 @@ const items = [
   },
 ]
 
-function cellRenderer({ cellData, selectedDensity }) {
-  const confortable = selectedDensity === 'low'
+function cellRenderer({ cellData, currentDensity }) {
+  const confortable = currentDensity === 'comfortable'
 
   return confortable ? (
     <div className="dib">
@@ -515,9 +518,9 @@ function ProportionExample() {
 
   const densityProps = {
     label: 'Line density',
-    lowOptionLabel: 'Low',
-    mediumOptionLabel: 'Medium',
-    highOptionLabel: 'High',
+    compactLabel: 'Compact',
+    regularLabel: 'Regular',
+    comfortableLabel: 'Comfortable',
     density: measures,
   }
 
@@ -2147,9 +2150,9 @@ function ToolbarExample() {
 
   const density = {
     label: 'Line density',
-    lowOptionLabel: 'Low',
-    mediumOptionLabel: 'Medium',
-    highOptionLabel: 'High',
+    compactLabel: 'Compact',
+    regularLabel: 'Regular',
+    comfortableLabel: 'Comfortable',
   }
 
   const download = {

--- a/react/components/EXPERIMENTAL_Table/Toolbar/ButtonDensity.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/ButtonDensity.tsx
@@ -20,7 +20,7 @@ const ButtonDensity: FC<ButtonDensityProps> = ({
   density,
   ...options
 }) => {
-  const { selectedDensity, setSelectedDensity } = density
+  const { currentDensity, setCurrentDensity } = density
   const { buttonRef, toggleBox, setBoxVisible, boxVisible } = usePopoverMenu()
   return (
     <Button
@@ -33,17 +33,17 @@ const ButtonDensity: FC<ButtonDensityProps> = ({
       {boxVisible && (
         <Box height={BOX_HEIGHT} alignMenu={alignMenu}>
           {DENSITY_OPTIONS.map((key: Density, index) => {
-            const isKeySelected = selectedDensity === key
+            const isKeySelected = currentDensity === key
             return (
               <Item
                 key={index}
                 isSelected={isKeySelected}
                 onClick={() => {
-                  setSelectedDensity(key)
+                  setCurrentDensity(key)
                   setBoxVisible(false)
                   handleCallback && handleCallback(key)
                 }}>
-                {options[`${key}OptionLabel`]}
+                {options[`${key}Label`]}
               </Item>
             )
           })}
@@ -56,9 +56,9 @@ const ButtonDensity: FC<ButtonDensityProps> = ({
 export type ButtonDensityProps = {
   density: ReturnType<typeof useTableMeasures>
   label: string
-  lowOptionLabel: string
-  mediumOptionLabel: string
-  highOptionLabel: string
+  compactLabel: string
+  regularLabel: string
+  comfortableLabel: string
   handleCallback: Function
   alignMenu: Alignment
   disabled: boolean

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableMeasures.tsx
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableMeasures.tsx
@@ -6,12 +6,12 @@ export const TABLE_HEADER_HEIGHT = 36
 
 export default function useTableMeasures({
   size = 0,
-  density = Density.MEDIUM,
+  density = Density.Regular,
 }: MeasuresInput) {
-  const [selectedDensity, setSelectedDensity] = useState<Density>(density)
+  const [currentDensity, setCurrentDensity] = useState<Density>(density)
 
-  const rowHeight = useMemo(() => getRowHeight(selectedDensity), [
-    selectedDensity,
+  const rowHeight = useMemo(() => getRowHeight(currentDensity), [
+    currentDensity,
   ])
 
   const tableHeight = useMemo(() => calculateTableHeight(rowHeight, size), [
@@ -20,10 +20,10 @@ export default function useTableMeasures({
   ])
 
   return {
-    selectedDensity,
+    currentDensity,
     rowHeight,
     tableHeight,
-    setSelectedDensity,
+    setCurrentDensity,
   }
 }
 
@@ -49,26 +49,30 @@ export function getScrollbarWidth(): number {
 }
 
 export enum Density {
-  LOW = 'low',
-  MEDIUM = 'medium',
-  HIGH = 'high',
+  Compact = 'compact',
+  Regular = 'regular',
+  Comfortable = 'comfortable',
 }
 
 export enum DesitySizes {
-  low = 76,
-  medium = 48,
-  high = 32,
+  Compact = 32,
+  Regular = 48,
+  Comfortable = 76,
 }
 
-export const DENSITY_OPTIONS = [Density.LOW, Density.MEDIUM, Density.HIGH]
+export const DENSITY_OPTIONS = [
+  Density.Compact,
+  Density.Regular,
+  Density.Comfortable,
+]
 
 export function getRowHeight(density: Density): number {
   switch (density) {
-    case Density.LOW:
-      return DesitySizes.low
-    case Density.MEDIUM:
-      return DesitySizes.medium
-    case Density.HIGH:
-      return DesitySizes.high
+    case Density.Compact:
+      return DesitySizes.Compact
+    case Density.Regular:
+      return DesitySizes.Regular
+    case Density.Comfortable:
+      return DesitySizes.Comfortable
   }
 }

--- a/react/components/EXPERIMENTAL_Table/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/index.tsx
@@ -29,7 +29,7 @@ const Table: FC<TableProps> & TableComposites = ({
     throw new Error('Provide measures to the Table')
   }
 
-  const { tableHeight, rowHeight, selectedDensity } = measures
+  const { tableHeight, rowHeight, currentDensity } = measures
   const { columns, onRowClick, items, sorting } = props
   const motion = useTableMotion()
 
@@ -60,7 +60,7 @@ const Table: FC<TableProps> & TableComposites = ({
             <Rows
               rowKey={rowKey}
               checkboxes={checkboxes}
-              selectedDensity={selectedDensity}
+              currentDensity={currentDensity}
               columns={columns}
               items={items}
               rowHeight={rowHeight}
@@ -77,8 +77,8 @@ const Table: FC<TableProps> & TableComposites = ({
 export const measuresPropTypes = {
   tableHeight: PropTypes.number,
   rowHeight: PropTypes.number,
-  selectedDensity: PropTypes.oneOf(DENSITY_OPTIONS),
-  setSelectedDensity: PropTypes.func,
+  currentDensity: PropTypes.oneOf(DENSITY_OPTIONS),
+  setCurrentDensity: PropTypes.func,
 }
 
 export const tablePropTypes = {
@@ -143,7 +143,7 @@ export type CellData = {
   cellData: unknown
   rowData: unknown
   rowHeight: number
-  selectedDensity: Density
+  currentDensity: Density
   motion: ReturnType<typeof useTableMotion>
 }
 

--- a/react/components/EXPERIMENTAL_TableTree/README.md
+++ b/react/components/EXPERIMENTAL_TableTree/README.md
@@ -290,9 +290,9 @@ function ToolbarExample() {
 
   const density = {
     label: 'Line density',
-    lowOptionLabel: 'Low',
-    mediumOptionLabel: 'Medium',
-    highOptionLabel: 'High',
+    compactLabel: 'Compact',
+    regularLabel: 'Regular',
+    comfortableLabel: 'Comfortable',
   }
 
   const download = {
@@ -361,10 +361,7 @@ function ToolbarExample() {
             {...buttonColumns}
           />
           <TableTree.Toolbar.ButtonGroup.Density
-            density={{
-              selectedDensity: measures.selectedDensity,
-              setSelectedDensity: measures.setSelectedDensity,
-            }}
+            density={measures}
             {...density}
           />
           <TableTree.Toolbar.ButtonGroup.Download {...download} />

--- a/react/components/EXPERIMENTAL_TableTree/Tree/Node.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/Node.tsx
@@ -18,7 +18,7 @@ const Node: FC<NodeProps> = ({
   isCollapsed,
   data,
   depth,
-  selectedDensity,
+  currentDensity,
   onRowClick,
 }) => {
   const motion = useTableMotion(ROW_TRANSITIONS)
@@ -62,7 +62,7 @@ const Node: FC<NodeProps> = ({
                 cellData,
                 rowData: data,
                 rowHeight,
-                selectedDensity,
+                currentDensity,
                 motion,
               })
             : cellData
@@ -104,7 +104,7 @@ const Node: FC<NodeProps> = ({
         (data[nodesKey] as Array<unknown>).map(data => (
           <Node
             onRowClick={onRowClick}
-            selectedDensity={selectedDensity}
+            currentDensity={currentDensity}
             isCollapsed={isCollapsed}
             toggleCollapsed={toggleCollapsed}
             checkboxes={checkboxes}
@@ -126,7 +126,7 @@ type NodeProps = {
   toggleCollapsed: (uniqueKey: unknown) => void
   isCollapsed: (uniqueKey: unknown) => boolean
   columns: Array<Column>
-  selectedDensity: Density
+  currentDensity: Density
   rowHeight: number
   nodesKey: string
   checkboxes?: Checkboxes<unknown>

--- a/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/Tree/index.tsx
@@ -56,7 +56,7 @@ const Tree: FC<TreeProps> = ({
 
 type TreeProps = {
   items: Items
-  selectedDensity: Density
+  currentDensity: Density
   nodesKey: string
   columns: Array<Column>
   comparator: comparatorCurry<TreeType<unknown>>

--- a/react/components/EXPERIMENTAL_TableTree/index.tsx
+++ b/react/components/EXPERIMENTAL_TableTree/index.tsx
@@ -39,7 +39,7 @@ const TableTree: FC<Props> & TableComposites = ({
     throw new Error('Provide measures to the TableTree')
   }
 
-  const { tableHeight, rowHeight, selectedDensity } = measures
+  const { tableHeight, rowHeight, currentDensity } = measures
   const motion = useTableMotion(CONTAINER_TRANSITIONS)
 
   return (
@@ -57,7 +57,7 @@ const TableTree: FC<Props> & TableComposites = ({
         {!empty && !loading && (
           <tbody>
             <Tree
-              selectedDensity={selectedDensity}
+              currentDensity={currentDensity}
               checkboxes={checkboxes}
               columns={columns}
               items={items}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Renames:
🖥 Density: from `low`, `medium`, `high` ➡️`comfortable`, `regular`, `compact`.
🛠 `selectedDensity` ➡️`currentDensity`

#### What problem is this solving?

[Running workspace](https://densitynames--cosmetics1.myvtex.com/admin/collections/)

#### How should this be manually tested?

Clone the repo and `yarn && yarn start`

#### Screenshots or example usage

Before:
<img width="849" alt="Screen Shot 2020-01-29 at 11 22 31" src="https://user-images.githubusercontent.com/6964311/73364628-a6866600-4289-11ea-8979-7d00dbf53d73.png">

After:
<img width="849" alt="Screen Shot 2020-01-29 at 11 21 46" src="https://user-images.githubusercontent.com/6964311/73364585-940c2c80-4289-11ea-8513-3128520531d0.png">

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
