### PR TITLE
Add option to keep toast open after update of its content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.108.0] - 2020-01-29
+
 ### Added
 
 - `keepAfterUpdate` option to `Toast`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `keepAfterUpdate` option to `Toast`.
+
 ## [9.107.0] - 2020-01-28
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.107.0",
+  "version": "9.108.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.107.0",
+  "version": "9.108.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -212,7 +212,8 @@ class NumericStepper extends Component {
     const content = (
       <React.Fragment>
         {label && (
-          <span className={`numeric-stepper__label db mb3 w-100 c-on-base ${labelClasses}`}>
+          <span
+            className={`numeric-stepper__label db mb3 w-100 c-on-base ${labelClasses}`}>
             {label}
           </span>
         )}
@@ -220,9 +221,7 @@ class NumericStepper extends Component {
           <input
             type="tel"
             readOnly={readOnly}
-            className={
-              `numeric-stepper__input z-1 order-1 tc bw1 ${borderClasses} br0 ${inputClasses} ${styles.hideDecorators}`
-            }
+            className={`numeric-stepper__input z-1 order-1 tc bw1 ${borderClasses} br0 ${inputClasses} ${styles.hideDecorators}`}
             style={{
               ...(block && {
                 width: 0,
@@ -237,11 +236,9 @@ class NumericStepper extends Component {
           <div className="numeric-stepper__plus-button-container z-2 order-2 flex-none">
             <button
               type="button"
-              className={
-                `numeric-stepper__plus-button br2 pa0 bl-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
-                  readOnly || isMax ? buttonDisabledClasses : buttonEnabledClasses
-                }`
-              }
+              className={`numeric-stepper__plus-button br2 pa0 bl-0 flex items-center justify-center ${borderClasses} ${buttonClasses} ${
+                readOnly || isMax ? buttonDisabledClasses : buttonEnabledClasses
+              }`}
               style={{
                 borderTopLeftRadius: 0,
                 borderBottomLeftRadius: 0,

--- a/react/components/ToastProvider/README.md
+++ b/react/components/ToastProvider/README.md
@@ -10,6 +10,7 @@
 
 
 ```js
+import { useState } from 'react'
 const Button = require('../Button').default
 const ToastConsumer = require('./index').ToastConsumer
 
@@ -22,7 +23,9 @@ const App = () => (
   </ToastProvider>
 )
 
-const Content = () => (
+const Content = () => {
+  const [count, setCount] = useState(0)
+  return(
   // Wrap the components that are going to display toasts
   // on a ToastConsumer, with a function as a child, as
   // the example below:
@@ -215,9 +218,36 @@ const Content = () => (
         </div>
       )}
     </ToastConsumer>
-
+    <div className="mv5 mt8">
+      Link on toast action
+    </div>
+    <ToastConsumer>
+      {({showToast, hideToast}) => (
+        <div className="flex">
+          <div className="mr5">
+            <Button
+              size="small"
+              variation="secondary"
+              onClick={
+                () => {
+                  setCount(count => count + 1)
+                  showToast({
+                    message: `You clicked ${count} times`,
+                    keepAfterUpdate: true,
+                    duration: 5000,
+                  })
+                }
+              }
+            >
+              One more in same Toast
+            </Button>
+          </div>
+        </div>
+      )}
+    </ToastConsumer>
   </div>
 )
+}
 
 
 ;<App/>

--- a/react/components/ToastProvider/Toast.js
+++ b/react/components/ToastProvider/Toast.js
@@ -127,6 +127,10 @@ export default class Toast extends Component {
     ) {
       this.updateButtonWrap()
     }
+
+    if (this.props.keepAfterUpdate) {
+      this.startAutoClose()
+    }
   }
 
   // Lets the toast to be single line on mobile
@@ -236,6 +240,7 @@ Toast.propTypes = {
     rel: PropTypes.string,
     download: PropTypes.string,
   }),
+  keepAfterUpdate: PropTypes.string,
   visible: PropTypes.bool,
   duration: PropTypes.number,
   dismissable: PropTypes.bool,

--- a/react/components/ToastProvider/ToastManager.js
+++ b/react/components/ToastProvider/ToastManager.js
@@ -51,6 +51,7 @@ export default class ToastManager extends Component {
           dismissable,
           duration,
           horizontalPosition,
+          keepAfterUpdate,
         },
         isToastVisible: true,
       })
@@ -137,9 +138,10 @@ export default class ToastManager extends Component {
               action={currentToast.action}
               duration={currentToast.duration}
               dismissable={currentToast.dismissable}
+              horizontalPosition={currentToast.horizontalPosition}
+              keepAfterUpdate={currentToast.keepAfterUpdate}
               visible={this.state.isToastVisible}
               onClose={this.handleToastClose}
-              horizontalPosition={currentToast.horizontalPosition}
             />
           )}
         </div>

--- a/react/components/ToastProvider/ToastManager.js
+++ b/react/components/ToastProvider/ToastManager.js
@@ -27,9 +27,10 @@ export default class ToastManager extends Component {
       dismissable,
       duration,
       horizontalPosition = 'left',
+      keepAfterUpdate = false,
     } = args
 
-    if (this.state.currentToast) {
+    if (this.state.currentToast && !keepAfterUpdate) {
       // If there is a toast present already, queue up the next toast
       // It will be displayed when the current toast is closed, on handleToastClose
       this.setState({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,6 +1109,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
   integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
 
+"@types/node@^12.12.21":
+  version "12.12.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.26.tgz#213e153babac0ed169d44a6d919501e68f59dea9"
+  integrity sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==
+
 "@types/prop-types@^15.7.1":
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
@@ -4243,7 +4248,7 @@ eslint-config-vtex-react@^5.1.0:
     eslint-plugin-react "^7.14.3"
     eslint-plugin-react-hooks "^1.6.1"
 
-eslint-config-vtex@^11.2.0:
+eslint-config-vtex@^11.2.0, eslint-config-vtex@^11.2.1:
   version "11.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-11.2.1.tgz#da553f600661fff05b58414a1345d8602b9c76d9"
   integrity sha512-6LSzwT9ch3Y2cyEIIiysADIdpomhIxT5rLrScfE3C90+rHbP7g72hgqx9uZWKpvXfpoarEqsaxEyGG03z1BloA==
@@ -4462,7 +4467,7 @@ eslint@^4.0.0:
     table "4.0.2"
     text-table "~0.2.0"
 
-eslint@^6.8.0:
+eslint@^6.7.2:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
   integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
@@ -11167,10 +11172,10 @@ typescript@^2.5.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
-typescript@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^3.7.3:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"
@@ -11367,6 +11372,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-media@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-media/-/use-media-1.4.0.tgz#e777bf1f382a7aacabbd1f9ce3da2b62e58b2a98"
+  integrity sha512-XsgyUAf3nhzZmEfhc5MqLHwyaPjs78bgytpVJ/xDl0TF4Bptf3vEpBNBBT/EIKOmsOc8UbuECq3mrP3mt1QANA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### How should this be manually tested?

Insert any name for the collection and click save repeatedly
Just using the button, nothing should be functional
[without keepAfterUpdate option](https://withoutop--cosmetics1.myvtex.com/admin/collections/create/)
[with keepAfterUpdate option](https://withop--cosmetics1.myvtex.com/admin/collections/create)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
