### PR TITLE
remove overflow-x-auto property on EXPERIMENTAL_Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- `overflow-x-auto` property on `EXPERIMENTAL_Table` data. 
+
 ## [9.108.1] - 2020-01-30
 
 ### Changed

--- a/react/components/EXPERIMENTAL_Table/DataTable/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/index.tsx
@@ -23,10 +23,7 @@ const DataTable: FC<DataTableProps> = ({
     <div
       id={NAMESPACES.TABLE}
       style={{ minHeight: height, ...motion }}
-      className={classNames(
-        'order-1 mw-100 overflow-x-auto',
-        ORDER_CLASSNAMES.TABLE
-      )}>
+      className={classNames('order-1 mw-100', ORDER_CLASSNAMES.TABLE)}>
       <Tag className={`w-100 ${className}`} style={{ borderSpacing: 0 }}>
         {children}
       </Tag>


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
This property doesn't allow to add elements that overflow the table, like tooltips.

An example that is necessary to remove this property:

[Running workspace](https://thay2--cosmetics1.myvtex.com/admin/collections/989/)

PR: https://github.com/vtex/admin-collections/pull/223


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
1. Click on a product image
2. The image will be zoom in.

#### Screenshots or example usage
![Screenshot from 2020-01-30 14-35-55](https://user-images.githubusercontent.com/6867958/73475718-a52f6900-436f-11ea-8722-dfebd2a4e2f3.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
