### PR TITLE
Feature/radiogroup label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.108.3] - 2020-02-03
+
 ### Added
 
 - `RadioGroup` now has `label` and `size` props

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `RadioGroup` now has `label` and `size` props
+
+### Changed
+
+- `RadioGroup` is now surrounded with a `<fieldset>` tag
+
+
 ## [9.108.2] - 2020-01-31
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.108.2",
+  "version": "9.108.3",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.108.2",
+  "version": "9.108.3",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -25,10 +25,7 @@ class RadioGroup extends React.Component {
 
     return (
       <div>
-        <fieldset
-          className="vtex-input w-100"
-          data-testid={testId}
-          style={{ border: 'none', padding: 0 }}>
+        <fieldset className="vtex-input w-100 bn pa0" data-testid={testId}>
           <legend>
             {label && (
               <span

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -20,19 +20,9 @@ class RadioGroup extends React.Component {
       testId,
       size,
     } = this.props
-    let labelClasses = 'vtex-input__label db mb3 w-100 c-on-base '
 
-    switch (size) {
-      case 'small':
-        labelClasses += 't-small '
-        break
-      case 'large':
-        labelClasses += 't-body '
-        break
-      default:
-        labelClasses += 't-small '
-        break
-    }
+    const large = size === 'large'
+
     return (
       <div>
         <fieldset
@@ -40,7 +30,15 @@ class RadioGroup extends React.Component {
           data-testid={testId}
           style={{ border: 'none', padding: 0 }}>
           <legend>
-            {label && <span className={labelClasses}>{label}</span>}
+            {label && (
+              <span
+                className={classNames(
+                  'vtex-input__label db mb3 w-100 c-on-base',
+                  { 't-body': large, 't-small': !large }
+                )}>
+                {label}
+              </span>
+            )}
           </legend>
           {options.map((option, i) => {
             const isFirst = i === 0

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -10,48 +10,77 @@ class RadioGroup extends React.Component {
   }
 
   render() {
-    const { options, value, name, disabled, hideBorder } = this.props
+    const {
+      options,
+      value,
+      name,
+      disabled,
+      hideBorder,
+      label,
+      testId,
+      size,
+    } = this.props
+    let labelClasses = 'vtex-input__label db mb3 w-100 c-on-base '
 
+    switch (size) {
+      case 'small':
+        labelClasses += 't-small '
+        break
+      case 'large':
+        labelClasses += 't-body '
+        break
+      default:
+        labelClasses += 't-small '
+        break
+    }
     return (
       <div>
-        {options.map((option, i) => {
-          const isFirst = i === 0
-          const isLast = i === options.length - 1
-          const isDisabled = disabled || option.disabled
-          const id = `${name}-${i}`
-          return (
-            <label
-              className={`db br3 ${classNames({
-                'b--muted-4 ba pv2 ph4': !hideBorder,
-                pointer: !isDisabled,
-              })}`}
-              key={id}
-              style={{
-                ...(!isFirst && {
-                  borderTopLeftRadius: 0,
-                  borderTopRightRadius: 0,
-                  borderTop: 'none',
-                }),
-                ...(!isLast && {
-                  borderBottomLeftRadius: 0,
-                  borderBottomRightRadius: 0,
-                }),
-              }}>
-              <div className={classNames({ mt3: !hideBorder })}>
-                <Radio
-                  id={id}
-                  isLast={isLast}
-                  name={name}
-                  disabled={isDisabled}
-                  onChange={this.handleChange}
-                  label={option.label}
-                  value={option.value}
-                  checked={value === option.value}
-                />
-              </div>
-            </label>
-          )
-        })}
+        <fieldset
+          className="vtex-input w-100"
+          data-testid={testId}
+          style={{ border: 'none', padding: 0 }}>
+          <legend>
+            {label && <span className={labelClasses}>{label}</span>}
+          </legend>
+          {options.map((option, i) => {
+            const isFirst = i === 0
+            const isLast = i === options.length - 1
+            const isDisabled = disabled || option.disabled
+            const id = `${name}-${i}`
+            return (
+              <label
+                className={`db br3 ${classNames({
+                  'b--muted-4 ba pv2 ph4': !hideBorder,
+                  pointer: !isDisabled,
+                })}`}
+                key={id}
+                style={{
+                  ...(!isFirst && {
+                    borderTopLeftRadius: 0,
+                    borderTopRightRadius: 0,
+                    borderTop: 'none',
+                  }),
+                  ...(!isLast && {
+                    borderBottomLeftRadius: 0,
+                    borderBottomRightRadius: 0,
+                  }),
+                }}>
+                <div className={classNames({ mt3: !hideBorder })}>
+                  <Radio
+                    id={id}
+                    isLast={isLast}
+                    name={name}
+                    disabled={isDisabled}
+                    onChange={this.handleChange}
+                    label={option.label}
+                    value={option.value}
+                    checked={value === option.value}
+                  />
+                </div>
+              </label>
+            )
+          })}
+        </fieldset>
       </div>
     )
   }
@@ -77,6 +106,12 @@ RadioGroup.propTypes = {
   disabled: PropTypes.bool,
   /** Hide group border */
   hideBorder: PropTypes.bool,
+  /** Label */
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** Data attribute */
+  testId: PropTypes.string,
+  /** Input size */
+  size: PropTypes.oneOf(['small', 'regular', 'large']),
 }
 
 RadioGroup.defaultProps = {

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -26,8 +26,8 @@ class RadioGroup extends React.Component {
     return (
       <div>
         <fieldset className="vtex-input w-100 bn pa0" data-testid={testId}>
-          <legend>
-            {label && (
+          {label && (
+            <legend>
               <span
                 className={classNames(
                   'vtex-input__label db mb3 w-100 c-on-base',
@@ -35,8 +35,8 @@ class RadioGroup extends React.Component {
                 )}>
                 {label}
               </span>
-            )}
-          </legend>
+            </legend>
+          )}
           {options.map((option, i) => {
             const isFirst = i === 0
             const isLast = i === options.length - 1

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -25,9 +25,9 @@ class RadioGroup extends React.Component {
 
     return (
       <div>
-        <fieldset className="vtex-input w-100 bn pa0" data-testid={testId}>
+        <fieldset className="vtex-input w-100 bn pa0 m0" data-testid={testId}>
           {label && (
-            <legend>
+            <legend className="dt" style={{ padding: '0.01em 0 0 0' }}>
               <span
                 className={classNames(
                   'vtex-input__label db mb3 w-100 c-on-base',


### PR DESCRIPTION
#### What is the purpose of this pull request?

The purpose of this PR is adding the possibility of adding a label to a RadioGroup

#### What problem is this solving?

It would be needed for labels to be put manually if you wanted to label a RadioGroup before and also now with the fieldset, it is better for screen readers.

#### How should this be manually tested?

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/19346539/73490350-13cdf000-438b-11ea-8825-5dfffb990a6b.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
