### PR TITLE
Add modalClassName to Modal component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `modalClassName` prop to modal.
+
 ## [9.108.8] - 2020-02-04
 
 ### Changed

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -138,7 +138,7 @@ Modal.defaultProps = {
   showCloseIcon: true,
   showTopBar: true,
   showBottomBarBorder: true,
-  modalClassName: ''
+  modalClassName: '',
 }
 
 Modal.propTypes = {
@@ -172,7 +172,7 @@ Modal.propTypes = {
   /** Event fired when the closing transition is finished */
   onCloseTransitionFinish: PropTypes.func,
   /** Classname to be used in modal main container, allows to change modal width, for example */
-  modalClassName: PropTypes.String
+  modalClassName: PropTypes.String,
 }
 
 export default Modal

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -59,6 +59,7 @@ class Modal extends PureComponent {
       showBottomBarBorder,
       onCloseTransitionFinish,
       container,
+      modalClassName,
     } = this.props
     const { shadowBottom, shadowTop } = this.state
 
@@ -78,7 +79,7 @@ class Modal extends PureComponent {
           }`,
           modal: `vtex-modal__modal ${
             responsiveFullScreen ? 'br2-ns w-100 h-100 h-auto-ns' : 'br2 w-100'
-          } ${styles.mh100} flex flex-column`,
+          } ${styles.mh100} flex flex-column ${modalClassName}`,
           closeIcon: 'vtex-modal__close-icon',
         }}
         styles={{

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -138,6 +138,7 @@ Modal.defaultProps = {
   showCloseIcon: true,
   showTopBar: true,
   showBottomBarBorder: true,
+  modalClassName: ''
 }
 
 Modal.propTypes = {
@@ -170,6 +171,8 @@ Modal.propTypes = {
   showTopBar: PropTypes.bool,
   /** Event fired when the closing transition is finished */
   onCloseTransitionFinish: PropTypes.func,
+  /** Classname to be used in modal main container, allows to change modal width, for example */
+  modalClassName: PropTypes.String
 }
 
 export default Modal


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->
Allow the user to provide classNames to `Modal` component. The modal width is too large for some cases and not flexible. This allows its users to customize that and other styles through classnames.

#### What problem is this solving?
[Running workspace](https://modalcreatecol--cosmetics1.myvtex.com/admin/app/collections/create)


<!--- What is the motivation and context for this change? -->

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
