### PR TITLE
Fix highlight color of a selected row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Color of active row on `EXPERIMENTAL_Table`.
+
 ## [9.112.2] - 2020-02-27
 
 ### Fixed

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -13,6 +13,7 @@ const Row: FC<RowProps> & RowComposites = ({
   highlightOnHover,
 }) => {
   const LIGHT_BLUE = '#DBE9FD'
+  const rowColor = active ? { backgroundColor: LIGHT_BLUE } : {}
 
   const className = classNames('w-100 truncate overflow-x-hidden', {
     'hover-bg-muted-5': highlightOnHover,
@@ -23,10 +24,7 @@ const Row: FC<RowProps> & RowComposites = ({
   const style = {
     height,
     ...motion,
-  }
-
-  if (active) {
-    style['background-color'] = LIGHT_BLUE
+    ...rowColor,
   }
 
   return (

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -16,9 +16,9 @@ const Row: FC<RowProps> & RowComposites = ({
   const rowColor = active ? { backgroundColor: LIGHT_BLUE } : {}
 
   const className = classNames('w-100 truncate overflow-x-hidden', {
+    'pointer hover-c-link': onClick,	
     'hover-bg-muted-5': highlightOnHover,
     'bg-action-secondary': active,
-    'pointer hover-c-link hover-bg-muted-5': onClick,
   })
 
   const style = {

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -15,11 +15,11 @@ const Row: FC<RowProps> & RowComposites = ({
   const LIGHT_BLUE = '#DBE9FD'
 
   const className = classNames('w-100 truncate overflow-x-hidden', {
-    'pointer hover-c-link hover-bg-muted-5': onClick,
+    'pointer hover-c-link': onClick,
     'hover-bg-muted-5': highlightOnHover,
-    'c-on-base bg-action-secondary': active,
-
+    'bg-action-secondary': active,
   })
+  
   const style = {
     height,
     ...motion,

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -12,15 +12,23 @@ const Row: FC<RowProps> & RowComposites = ({
   motion,
   highlightOnHover,
 }) => {
+  const LIGHT_BLUE = '#DBE9FD'
+
   const className = classNames('w-100 truncate overflow-x-hidden', {
     'pointer hover-c-link hover-bg-muted-5': onClick,
     'hover-bg-muted-5': highlightOnHover,
     'c-on-base bg-action-secondary': active,
+
   })
   const style = {
     height,
     ...motion,
   }
+
+  if (active) {
+    style['background-color'] = LIGHT_BLUE
+  }
+
   return (
     <tr style={style} onClick={onClick} className={className}>
       {children}

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -19,7 +19,7 @@ const Row: FC<RowProps> & RowComposites = ({
     'bg-action-secondary': active,
     'pointer hover-c-link hover-bg-muted-5': onClick,
   })
-
+  
   const style = {
     height,
     ...motion,

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -19,7 +19,7 @@ const Row: FC<RowProps> & RowComposites = ({
     'bg-action-secondary': active,
     'pointer hover-c-link hover-bg-muted-5': onClick,
   })
-  
+
   const style = {
     height,
     ...motion,

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -15,11 +15,11 @@ const Row: FC<RowProps> & RowComposites = ({
   const LIGHT_BLUE = '#DBE9FD'
 
   const className = classNames('w-100 truncate overflow-x-hidden', {
-    'pointer hover-c-link': onClick,
     'hover-bg-muted-5': highlightOnHover,
     'bg-action-secondary': active,
+    'pointer hover-c-link hover-bg-muted-5': onClick,
   })
-  
+
   const style = {
     height,
     ...motion,

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -16,7 +16,7 @@ const Row: FC<RowProps> & RowComposites = ({
   const rowColor = active ? { backgroundColor: LIGHT_BLUE } : {}
 
   const className = classNames('w-100 truncate overflow-x-hidden', {
-    'pointer hover-c-link': onClick,	
+    'pointer hover-c-link': onClick,
     'hover-bg-muted-5': highlightOnHover,
     'bg-action-secondary': active,
   })


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
The color of a secondary button clicked should be `#DBE9FD (light blue)`

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Running workspace](https://mariana--cosmetics1.myvtex.com/admin/collections/1019/)

#### Screenshots or example usage
* Before: 
![image](https://user-images.githubusercontent.com/20481790/74261478-165d0d80-4cda-11ea-9c12-2aa9c8f963fc.png)

* After: 
![image](https://user-images.githubusercontent.com/20481790/74261628-44425200-4cda-11ea-960e-4f605736048d.png)



#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
