### PR TITLE
Fix Tooltip display verification logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.109.4] - 2020-02-11
+
 ### Fixed
 
 - `Tooltip` display verification logic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Tooltip` display verification logic.
+
 ## [9.109.3] - 2020-02-10
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.109.3",
+  "version": "9.109.4",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.109.3",
+  "version": "9.109.4",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -76,7 +76,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
     'absolute pv3 ph4 bg-base--inverted c-on-base--inverted br2 shadow-4 mw5 overflow-hidden',
     style.popup,
     {
-      dn: (!visible && !showPopup) || !childRect || !popupRect,
+      dn: !visible || !showPopup || !childRect || !popupRect,
       'o-0': !visible || !hasComputedDimensions(popupRect),
       'o-100': visible && hasComputedDimensions(popupRect),
       't-mini': size === 'mini',


### PR DESCRIPTION
#### What is the purpose of this pull request?
The `Tooltip` container was appearing in the DOM even if its children are not `onHover`.

#### What problem is this solving?
[Running workspace](https://vitoria--cosmetics1.myvtex.com/admin/collections/1014/).

#### How should this be manually tested?
Pass the mouse over the line action buttons in the products table.

#### Screenshots or example usage

##### Before
![before](https://user-images.githubusercontent.com/12852518/74243634-df2d3300-4cbe-11ea-804f-5d6ebe0efdad.gif)

In this usage, the click area of a button is reduced when we pass the mouse over another button bellow it because the tooltip container is above it even when it is not appearing.

##### After
![after](https://user-images.githubusercontent.com/12852518/74243663-e94f3180-4cbe-11ea-967e-084fd2848669.gif)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
