### PR TITLE
Change Toast's keepAfterUpdate propType to bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `showToast` warning when it is used at any context
+
 ## [9.110.0] - 2020-02-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.110.1] - 2020-02-12
+
 ### Fixed
 
 - `showToast` warning when it is used at any context

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.110.0",
+  "version": "9.110.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.110.0",
+  "version": "9.110.1",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/ToastProvider/Toast.js
+++ b/react/components/ToastProvider/Toast.js
@@ -240,7 +240,7 @@ Toast.propTypes = {
     rel: PropTypes.string,
     download: PropTypes.string,
   }),
-  keepAfterUpdate: PropTypes.string,
+  keepAfterUpdate: PropTypes.bool,
   visible: PropTypes.bool,
   duration: PropTypes.number,
   dismissable: PropTypes.bool,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change `Toast`'s `keepAfterUpdate` prop type to boolean

#### What problem is this solving?
[Control workspace](https://anita--sandboxintegracao.myvtex.com/admin/sellers/planilha/)
[Running workspace](https://artur--sandboxintegracao.myvtex.com/admin/sellers/planilha/)

This addresses a warning that appears whenever `showToast` is used

#### How should this be manually tested?

**Control**
1. Visit the control workspace and open your browse's Dev Tools
2. Click on the pencil icon at the upper right corner
3. Click `save` at the modal's bottom right corner
4. Watch the console. A toast-related warning about `keepAfterUpdate` should appear

**Fixed**
1. Visit the running workspace and open your browse's Dev Tools
2. Click on the pencil icon at the upper right corner
3. Click `save` at the modal's bottom right corner
4. Watch the console. No toast-related warnings should appear

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3827456/74378916-8f855f00-4dc5-11ea-940b-b5daba9e5ad5.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
