### PR TITLE
Keep input focused only while searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `EPERIMENTAL_Select` forcing focus after options are loaded
+
 ## [9.112.3] - 2020-02-27
 
 ### Changed

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -34,7 +34,10 @@ class Select extends Component {
     const { loading } = this.props
     const { loading: prevLoading } = prevProps
 
-    if (searchTerm !== prevSearchTerm || loading !== prevLoading) {
+    if (
+      searchTerm !== prevSearchTerm ||
+      (searchTerm && loading !== prevLoading)
+    ) {
       document.getElementById(this.inputId).focus()
     }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix unwanted focus on `EXPERIMENTAL_Select`.

#### What problem is this solving?
After options were loaded (usually receiving a prop update setting `loading = false`, component forced focus on its input. So, when you open a page with a select, it may scroll and focus on it right after finishing options load. We only want it to keep focused while searching.

#### How should this be manually tested?
old version: https://pricingqa.myvtex.com/admin/promotions/0980ee34-349b-48fa-98b9-3702c4f18ba3

current version: https://vlauxbeta--pricingqa.myvtex.com/admin/promotions/0980ee34-349b-48fa-98b9-3702c4f18ba3

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
