### PR TITLE
Added the highlightOnHover prop to EXPERIMENTAL_Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `highlightOnHover` prop to `EXPERIMENTAL_Table`
+
 ## [9.111.1] - 2020-02-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.111.2] - 2020-02-17
+
 ### Added
 
 - `highlightOnHover` prop to `EXPERIMENTAL_Table`

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.111.1",
+  "version": "9.111.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.111.1",
+  "version": "9.111.2",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -11,9 +11,11 @@ const Row: FC<RowProps> & RowComposites = ({
   onClick,
   active,
   motion,
+  highlightOnHover,
 }) => {
   const className = classNames('w-100 truncate overflow-x-hidden', {
-    'pointer hover-c-link hover-bg-muted-5': onClick,
+    'pointer hover-c-link': onClick,
+    'hover-bg-muted-5': highlightOnHover,
     'bg-action-secondary': active,
   })
   const style = {
@@ -49,6 +51,7 @@ export type RowProps = {
   height?: number
   onClick?: () => void
   motion?: ReturnType<typeof useTableMotion>
+  highlightOnHover?: boolean
 }
 
 export default Row

--- a/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
@@ -37,12 +37,11 @@ const Rows: FC<RowsProps> = ({
               onClick: () => onRowClick({ rowData }),
               highlightOnHover: true,
             }
-          : {}
+          : { highlightOnHover }
         return (
           <Row
             {...rowProps}
             {...clickable}
-            highlightOnHover={highlightOnHover}
             height={rowHeight}
             active={(isRowActive && isRowActive(rowData)) || isRowSelected}
             key={rowKey({ rowData })}

--- a/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
@@ -19,6 +19,7 @@ const Rows: FC<RowsProps> = ({
   currentDensity,
   checkboxes,
   rowKey,
+  highlightOnHover,
 }) => {
   const motion = useTableMotion(ROW_TRANSITIONS)
   return items ? (
@@ -34,13 +35,14 @@ const Rows: FC<RowsProps> = ({
         const clickable = onRowClick
           ? {
               onClick: () => onRowClick({ rowData }),
-              link: true,
+              highlightOnHover: true,
             }
           : {}
         return (
           <Row
             {...rowProps}
             {...clickable}
+            highlightOnHover={highlightOnHover}
             height={rowHeight}
             active={(isRowActive && isRowActive(rowData)) || isRowSelected}
             key={rowKey({ rowData })}
@@ -96,6 +98,7 @@ export type RowsProps = {
   rowHeight: number
   cellProps?: Pick<CellProps, 'tagName' | 'className'>
   checkboxes?: Checkboxes<unknown>
+  highlightOnHover?: boolean
 }
 
 export default Rows

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -170,7 +170,14 @@ const items = data.products
 function ColumnsExample() {
   /** The useTableMeasures hook will be discussed on the Measures section */
   const measures = useTableMeasures({ size: items.length })
-  return <Table measures={measures} items={items} columns={columns} />
+  return (
+    <Table
+      measures={measures}
+      items={items}
+      columns={columns}
+      highlightOnHover
+    />
+  )
 }
 ;<ColumnsExample />
 ```

--- a/react/components/EXPERIMENTAL_Table/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/index.tsx
@@ -25,6 +25,7 @@ const Table: FC<TableProps> & TableComposites = ({
   empty,
   checkboxes,
   rowKey,
+  highlightOnHover,
   ...props
 }) => {
   if (!measures) {
@@ -63,6 +64,7 @@ const Table: FC<TableProps> & TableComposites = ({
         {!empty && !loading && (
           <tbody id={NAMESPACES.BODY} data-testid={`${testId}__body`}>
             <Rows
+              highlightOnHover={highlightOnHover}
               rowKey={rowKey}
               checkboxes={checkboxes}
               currentDensity={currentDensity}
@@ -80,55 +82,86 @@ const Table: FC<TableProps> & TableComposites = ({
 }
 
 export const measuresPropTypes = {
+  /** Calculated table height */
   tableHeight: PropTypes.number,
+  /** Height of each row */
   rowHeight: PropTypes.number,
+  /** Current density of the table: compact, regular of comfortable */
   currentDensity: PropTypes.oneOf(DENSITY_OPTIONS),
+  /** Sets the current density */
   setCurrentDensity: PropTypes.func,
 }
 
 export const tablePropTypes = {
+  /** Table composites */
   children: PropTypes.node,
+  /** Return of the useCheckboxTree hook */
   checkboxes: PropTypes.any,
+  /** Return of the useTableMeasures hook */
   measures: PropTypes.shape(measuresPropTypes),
+  /** Function that generates row keys */
   rowKey: PropTypes.func,
+  /** If the table is empty or not */
   empty: PropTypes.bool,
+  /** Array of columns */
   columns: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.string,
+      /** Column id */
+      id: PropTypes.string.isRequired,
+      /** Column title that is displayed on header */
       title: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.elementType,
         PropTypes.func,
       ]),
+      /** Column fixed width. Can be pixel (number) or any other unit (string) */
       width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      /** If the Table can be sorted using the columns as reference */
       sortable: PropTypes.bool,
+      /** How columns cells should be rendered */
       cellRenderer: PropTypes.func,
+      /** If the column is exented or not */
       extended: PropTypes.bool,
+      /** If the column is condensed or not */
       condensed: PropTypes.arrayOf(PropTypes.string),
     })
   ),
+  /** Array of items */
   items: PropTypes.arrayOf(PropTypes.object),
+  /** If the Table is loading or not */
   loading: PropTypes.oneOfType([
     PropTypes.shape({
       renderAs: PropTypes.func,
     }),
     PropTypes.bool,
   ]),
+  /** Function trigged on a row click */
   onRowClick: PropTypes.func,
+  /** Function that defines if a row is active or not */
   isRowActive: PropTypes.func,
+  /** Table EmptyState component */
   emptyState: PropTypes.shape({
     label: PropTypes.string,
     children: PropTypes.element,
   }),
+  /** Sorting properties */
   sorting: PropTypes.shape({
+    /** Sorted properties */
     sorted: PropTypes.shape({
+      /** Columns that is currently sorting the items */
       by: PropTypes.string,
+      /** If is ascending or descending */
       order: PropTypes.string,
     }),
+    /** Clear the sorting */
     clear: PropTypes.func,
+    /** Sort function */
     sort: PropTypes.func,
   }),
+  /** Base testId */
   testId: PropTypes.string,
+  /** If the rows should be highlighted on :hover */
+  highlightOnHover: PropTypes.bool,
 }
 
 export type TableProps = InferProps<typeof tablePropTypes> & {


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?
[Running workspace](https://matheus--cosmetics1.myvtex.com/admin/collections/) (click on a collection and check the products table)

The Table should have the support to highlight rows on `:hover`, even if they are not clickable.

#### How should this be manually tested?

Clone the repo and `yarn && yarn start`

#### Screenshots or example usage

```js
import React from 'react'
import { EXPERIMENTAL_Table } from '@vtex.styleguide'

const columns = [...]
const items = [...]

function UseCase(){
  // ...
  return <Table columns={columns} items={items} highlightOnHover />
}
```

![Screen Recording 2020-02-17 at 10 40 37 2020-02-17 10_41_18](https://user-images.githubusercontent.com/6964311/74658931-13e33380-5172-11ea-85a0-c3721be823e7.gif)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
