### PR TITLE
Added sticky header to EXPERIMENTAL_Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `stickyHeader` prop to `EXPERIMENTAL_Table`.
+
 ## [9.112.0] - 2020-02-19
+
 ### Added
 
 - `input` css handle to the `Input` component.
@@ -16,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Moved the  `postinstall` script to `prepare`, to avoid adding devDependencies on production.
+- Moved the `postinstall` script to `prepare`, to avoid adding devDependencies on production.
 
 ## [9.111.5] - 2020-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.1] - 2020-02-20
+
 ### Added
 
 - `stickyHeader` prop to `EXPERIMENTAL_Table`.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.0",
+  "version": "9.112.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.0",
+  "version": "9.112.1",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Table/DataTable/Cell.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Cell.tsx
@@ -35,19 +35,31 @@ const Cell: FC<CellProps> & CellComposites = ({
   className: classNameProp = '',
   active = false,
   link = false,
+  sticky = false,
+  header,
 }) => {
   const { hover, ...events } = useHover()
   const className = classNames(
-    'v-mid ph3 pv0 tl bb b--muted-4',
+    'v-mid ph3 pv0 tl bb b--muted-4 bg-base',
     classNameProp,
     {
       pointer: onClick,
       'hover-c-link hover-bg-muted-5': link,
       'c-on-base': active,
+      'top-0 z3': sticky && header,
+      z1: !sticky,
     }
   )
+
   return (
-    <Tag {...events} onClick={onClick} style={{ width }} className={className}>
+    <Tag
+      {...events}
+      onClick={onClick}
+      style={{
+        position: sticky ? 'sticky' : 'static',
+        width,
+      }}
+      className={className}>
       <HoverProvider value={hover}>{children}</HoverProvider>
     </Tag>
   )
@@ -118,6 +130,8 @@ export type CellProps = {
   showArrow?: boolean
   active?: boolean
   link?: boolean
+  sticky?: boolean
+  header?: boolean
 }
 
 export default Cell

--- a/react/components/EXPERIMENTAL_Table/DataTable/Cell.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Cell.tsx
@@ -31,8 +31,7 @@ const Cell: FC<CellProps> & CellComposites = ({
   children,
   width,
   onClick,
-  tagName: Tag = 'td',
-  className: classNameProp = '',
+  className: classNameProp,
   active = false,
   link = false,
   sticky = false,
@@ -50,6 +49,7 @@ const Cell: FC<CellProps> & CellComposites = ({
       z1: !sticky,
     }
   )
+  const Tag = header ? 'th' : 'td'
 
   return (
     <Tag
@@ -124,7 +124,6 @@ export type CellComposites = {
 export type CellProps = {
   id?: string
   width?: number | string | React.ReactText
-  tagName?: 'td' | 'th' | 'div' | 'li'
   className?: string
   onClick?: () => void
   showArrow?: boolean

--- a/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
@@ -5,13 +5,12 @@ import { TABLE_HEADER_HEIGHT } from '../hooks/useTableMeasures'
 import Row, { RowProps } from './Row'
 import { Column } from '../types'
 import { Checkboxes } from '../../EXPERIMENTAL_useCheckboxTree/types'
-import Cell, { CellProps } from './Cell'
+import Cell from './Cell'
 import useTableSort from '../hooks/useTableSort'
 
 const Headings: FC<HeadingsProps> = ({
   columns,
   checkboxes,
-  cellProps,
   rowProps,
   sorting,
   sticky,
@@ -28,7 +27,6 @@ const Headings: FC<HeadingsProps> = ({
         return (
           <Row.Cell
             {...onclick}
-            {...cellProps}
             active={active}
             className={cellClassName}
             key={headerIndex}
@@ -57,16 +55,9 @@ const Headings: FC<HeadingsProps> = ({
   )
 }
 
-Headings.defaultProps = {
-  cellProps: {
-    tagName: 'th',
-  },
-}
-
 type HeadingsProps = {
   columns: Array<Column>
   rowProps?: RowProps
-  cellProps?: Pick<CellProps, 'tagName'>
   checkboxes?: Checkboxes<unknown>
   sorting?: Partial<ReturnType<typeof useTableSort>>
   sticky?: boolean

--- a/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
@@ -14,6 +14,7 @@ const Headings: FC<HeadingsProps> = ({
   cellProps,
   rowProps,
   sorting,
+  sticky,
 }) => {
   return (
     <Row {...rowProps} height={TABLE_HEADER_HEIGHT}>
@@ -31,7 +32,9 @@ const Headings: FC<HeadingsProps> = ({
             active={active}
             className={cellClassName}
             key={headerIndex}
-            width={width}>
+            width={width}
+            sticky={sticky}
+            header>
             {checkboxes && headerIndex === 0 && (
               <Cell.Prefix>
                 <span className="ph3">
@@ -66,6 +69,7 @@ type HeadingsProps = {
   cellProps?: Pick<CellProps, 'tagName'>
   checkboxes?: Checkboxes<unknown>
   sorting?: Partial<ReturnType<typeof useTableSort>>
+  sticky?: boolean
 }
 
 export default React.memo(Headings)

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -5,7 +5,6 @@ import useTableMotion from '../hooks/useTableMotion'
 import Cell, { CellProps, CellComposites } from './Cell'
 
 const Row: FC<RowProps> & RowComposites = ({
-  tagName: Tag = 'tr',
   children,
   height,
   onClick,
@@ -23,9 +22,9 @@ const Row: FC<RowProps> & RowComposites = ({
     ...motion,
   }
   return (
-    <Tag style={style} onClick={onClick} className={className}>
+    <tr style={style} onClick={onClick} className={className}>
       {children}
-    </Tag>
+    </tr>
   )
 }
 
@@ -46,7 +45,6 @@ export type RowComposites = {
 }
 
 export type RowProps = {
-  tagName?: 'tr' | 'div' | 'ul'
   active?: boolean
   height?: number
   onClick?: () => void

--- a/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Rows.tsx
@@ -6,13 +6,11 @@ import { Column, Items } from '../types'
 import { Density } from '../hooks/useTableMeasures'
 import { Checkboxes } from '../../EXPERIMENTAL_useCheckboxTree/types'
 import useTableMotion from '../hooks/useTableMotion'
-import { CellProps } from './Cell'
 
 const Rows: FC<RowsProps> = ({
   columns,
   items,
   onRowClick,
-  cellProps,
   rowProps,
   isRowActive,
   rowHeight,
@@ -62,7 +60,7 @@ const Rows: FC<RowsProps> = ({
                   })
                 : data
               return (
-                <Row.Cell {...cellProps} key={column.id} width={width}>
+                <Row.Cell key={column.id} width={width}>
                   {cellIndex === 0 && checkboxes && (
                     <Row.Cell.Prefix>
                       <span className="ph3">
@@ -95,7 +93,6 @@ export type RowsProps = {
   isRowActive?: (rowData: unknown) => boolean
   rowProps?: RowProps
   rowHeight: number
-  cellProps?: Pick<CellProps, 'tagName' | 'className'>
   checkboxes?: Checkboxes<unknown>
   highlightOnHover?: boolean
 }

--- a/react/components/EXPERIMENTAL_Table/DataTable/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/index.tsx
@@ -18,14 +18,18 @@ const DataTable: FC<DataTableProps> = ({
   emptyState,
   motion,
   testId,
+  stickyHeader,
 }) => {
   const showLoading = !empty && loading
   const showEmptyState = empty && emptyState
   return (
     <div
-      style={{ minHeight: height, ...motion }}
+      style={{ height, ...motion }}
       className={classNames(
-        'order-1 mw-100 overflow-x-auto',
+        'order-1 mw-100 overflow-x-auto relative',
+        {
+          'overflow-y-auto': stickyHeader,
+        },
         ORDER_CLASSNAMES.TABLE
       )}>
       <Tag
@@ -74,6 +78,7 @@ export type DataTableProps = E2ETestable & {
     label?: string
     children?: Element
   }
+  stickyHeader?: boolean
 }
 
 export default DataTable

--- a/react/components/EXPERIMENTAL_Table/DataTable/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/index.tsx
@@ -12,7 +12,6 @@ const DataTable: FC<DataTableProps> = ({
   children,
   height,
   className,
-  tagName: Tag,
   empty,
   loading,
   emptyState,
@@ -32,13 +31,13 @@ const DataTable: FC<DataTableProps> = ({
         },
         ORDER_CLASSNAMES.TABLE
       )}>
-      <Tag
+      <table
         id={NAMESPACES.TABLE}
         data-testid={testId}
-        className={`w-100 ${className}`}
+        className={classNames('w-100', className)}
         style={{ borderSpacing: 0 }}>
         {children}
-      </Tag>
+      </table>
       {showLoading && (
         <Loading
           testId={`${testId}__loading`}
@@ -58,14 +57,8 @@ const DataTable: FC<DataTableProps> = ({
   )
 }
 
-DataTable.defaultProps = {
-  tagName: 'table',
-  className: '',
-}
-
 export type DataTableProps = E2ETestable & {
   height: number
-  tagName?: 'table' | 'div' | 'section'
   className?: string
   empty: boolean
   motion: ReturnType<typeof useTableMotion>

--- a/react/components/EXPERIMENTAL_Table/README.md
+++ b/react/components/EXPERIMENTAL_Table/README.md
@@ -328,6 +328,44 @@ function SimpleExample() {
 ;<SimpleExample />
 ```
 
+# Sticky Header
+
+To achieve a Table with a sticky header and a scrollable body, we can combine `useTableMeasures` hook with the `stickyHeader` prop.
+
+```js
+const useTableMeasures = require('./hooks/useTableMeasures.tsx').default
+const items = require('./sampleData.ts').customers
+
+const columns = [
+  {
+    id: 'id',
+    title: 'ID',
+  },
+  {
+    id: 'name',
+    title: 'Name',
+  },
+  {
+    id: 'email',
+    title: 'Email',
+  },
+  {
+    id: 'location',
+    title: 'Location',
+  },
+]
+
+function StickyExample() {
+  // Define the max number of items that will be displayed
+  const measures = useTableMeasures({ size: 5 })
+
+  return (
+    <Table measures={measures} columns={columns} items={items} stickyHeader />
+  )
+}
+;<StickyExample />
+```
+
 # State handlers
 
 ## useTableMeasures

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableMotion.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableMotion.ts
@@ -59,12 +59,14 @@ function useReducedMotion(init = false) {
   useEffect(() => {
     const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
     setReduced(mql.matches)
-    const handleChange = () => {
-      setReduced(mql.matches)
+    function listener(e: MediaQueryListEvent) {
+      if (e.type === 'change') {
+        throttle(() => setReduced(mql.matches), 200)
+      }
     }
-    mql.addEventListener('change', throttle(handleChange, 200))
+    mql.addListener(listener)
     return () => {
-      mql.removeEventListener('change', handleChange)
+      mql.removeListener(listener)
     }
   }, [])
   return reduced

--- a/react/components/EXPERIMENTAL_Table/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/index.tsx
@@ -26,14 +26,18 @@ const Table: FC<TableProps> & TableComposites = ({
   checkboxes,
   rowKey,
   highlightOnHover,
-  ...props
+  stickyHeader,
+  columns,
+  onRowClick,
+  items,
+  sorting,
+  testId,
 }) => {
   if (!measures) {
     throw new Error('Provide measures to the Table')
   }
 
   const { tableHeight, rowHeight, currentDensity } = measures
-  const { columns, onRowClick, items, sorting, testId } = props
   const motion = useTableMotion()
 
   return (
@@ -44,6 +48,7 @@ const Table: FC<TableProps> & TableComposites = ({
       className="flex flex-column">
       <TableProvider testId={testId}>{children}</TableProvider>
       <DataTable
+        stickyHeader={stickyHeader}
         testId={testId}
         empty={empty}
         loading={loading}
@@ -55,6 +60,7 @@ const Table: FC<TableProps> & TableComposites = ({
           data-testid={`${testId}__header`}
           className="w-100 ph4 truncate overflow-x-hidden c-muted-2 f6">
           <Headings
+            sticky={stickyHeader}
             sorting={sorting}
             columns={columns}
             checkboxes={checkboxes}
@@ -162,6 +168,8 @@ export const tablePropTypes = {
   testId: PropTypes.string,
   /** If the rows should be highlighted on :hover */
   highlightOnHover: PropTypes.bool,
+  /** If the header is sticky or not */
+  stickyHeader: PropTypes.bool,
 }
 
 export type TableProps = InferProps<typeof tablePropTypes> & {
@@ -188,6 +196,7 @@ Table.ActionBar = ActionBar
 Table.defaultProps = {
   rowKey: ({ rowData }) => `row-${rowData.id}`,
   testId: 'vtex-table-v2',
+  stickyHeader: false,
 }
 
 export default Table


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### What problem is this solving?

The Table headers can be fixed for a better viz when the items list is large.
This PR also removes the possibility of passing different elements then `td`, `th`, `tr` or `table`. This is to grant accessibility.

#### How should this be manually tested?

Clone the repo and `yarn && yarn start`

#### Screenshots or example usage

![Screen Recording 2020-02-17 at 17 07 05 2020-02-17 17_07_51](https://user-images.githubusercontent.com/6964311/74683536-0a74be00-51a8-11ea-87bb-005bba33e8a2.gif)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
