### PR TITLE
Add input css handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- `input` css handle to the `Input` component.
 
 ## [9.111.6] - 2020-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [9.112.0] - 2020-02-19
 ### Added
 
 - `input` css handle to the `Input` component.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.111.6",
+  "version": "9.112.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.111.6",
+  "version": "9.112.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Input/Input.css
+++ b/react/components/Input/Input.css
@@ -1,3 +1,6 @@
+/* handle to select a styleguide input */
+.input {}
+
 /* removes edge clear button on input */
 .hideDecorators::-ms-clear {
   display: none;

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -111,7 +111,7 @@ class Input extends Component {
     let prefixClasses = `${borderRadiusBase} br-0 br--left `
     let suffixClasses = `${borderRadiusBase} bl-0 br--right `
 
-    let classes = `${widthClass} ${box} ${styles.hideDecorators} ${styles.noAppearance} ${borderRadius} bn outline-0 `
+    let classes = `${styles.input} ${widthClass} ${box} ${styles.hideDecorators} ${styles.noAppearance} ${borderRadius} bn outline-0 `
     let labelClasses = 'vtex-input__label db mb3 w-100 c-on-base '
     let prefixAndSuffixClasses =
       'vtex-input__prefix c-muted-2 fw5 flex items-center c-muted-2 t-body '


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a `input` css class/handle to the `Input` component

#### What problem is this solving?
[Running workspace](https://kiwisearch--storecomponents.myvtex.com/)
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Just check the search bar input on the header of the workspace above

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12702016/74854092-9825ea00-531d-11ea-915d-05fe4fb16134.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
