### PR TITLE
Fixed EXPERIMENTAL_Table background colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.2] - 2020-02-27
+
 ### Fixed
 
 - `EXPERIMENTAL_Table` background colors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `EXPERIMENTAL_Table` background colors.
+
 ## [9.112.1] - 2020-02-20
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.1",
+  "version": "9.112.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.1",
+  "version": "9.112.2",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Table/DataTable/Cell.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Cell.tsx
@@ -32,19 +32,18 @@ const Cell: FC<CellProps> & CellComposites = ({
   width,
   onClick,
   className: classNameProp,
-  active = false,
-  link = false,
+  sorting,
   sticky = false,
   header,
 }) => {
   const { hover, ...events } = useHover()
   const className = classNames(
-    'v-mid ph3 pv0 tl bb b--muted-4 bg-base',
+    'v-mid ph3 pv0 tl bb b--muted-4',
     classNameProp,
     {
       pointer: onClick,
-      'hover-c-link hover-bg-muted-5': link,
-      'c-on-base': active,
+      'c-on-base': sorting,
+      'bg-base': header,
       'top-0 z3': sticky && header,
       z1: !sticky,
     }
@@ -89,11 +88,11 @@ function Eyesight({ children, visible }) {
   )
 }
 
-const Suffix: FC<SuffixProps> = ({ active, ascending }) => {
+const Suffix: FC<SuffixProps> = ({ sorting, ascending }) => {
   const Caret = ascending ? CaretDown : CaretUp
   const hover = useContext(HoverContext)
   return (
-    <Eyesight visible={active || hover}>
+    <Eyesight visible={sorting || hover}>
       <Caret className="ml2" size={10} />
     </Eyesight>
   )
@@ -112,7 +111,7 @@ type PrefixProps = {
 }
 
 type SuffixProps = {
-  active: boolean
+  sorting: boolean
   ascending: boolean
 }
 
@@ -127,8 +126,7 @@ export type CellProps = {
   className?: string
   onClick?: () => void
   showArrow?: boolean
-  active?: boolean
-  link?: boolean
+  sorting?: boolean
   sticky?: boolean
   header?: boolean
 }

--- a/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Headings.tsx
@@ -20,14 +20,15 @@ const Headings: FC<HeadingsProps> = ({
       {columns.map((columnData: Column, headerIndex: number) => {
         const { id, title, width, sortable } = columnData
         const cellClassName = classNames('bt normal', { pointer: sortable })
-        const active = sorting && sorting.sorted && sorting.sorted.by === id
+        const cellSorting =
+          sorting && sorting.sorted && sorting.sorted.by === id
         const ascending = sorting && sorting.sorted.order !== 'DSC'
         const onclick =
           sortable && sorting ? { onClick: () => sorting.sort(id) } : {}
         return (
           <Row.Cell
             {...onclick}
-            active={active}
+            sorting={cellSorting}
             className={cellClassName}
             key={headerIndex}
             width={width}
@@ -47,7 +48,9 @@ const Headings: FC<HeadingsProps> = ({
               </Cell.Prefix>
             )}
             {title}
-            {sortable && <Cell.Suffix active={active} ascending={ascending} />}
+            {sortable && (
+              <Cell.Suffix sorting={cellSorting} ascending={ascending} />
+            )}
           </Row.Cell>
         )
       })}

--- a/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/DataTable/Row.tsx
@@ -13,9 +13,9 @@ const Row: FC<RowProps> & RowComposites = ({
   highlightOnHover,
 }) => {
   const className = classNames('w-100 truncate overflow-x-hidden', {
-    'pointer hover-c-link': onClick,
+    'pointer hover-c-link hover-bg-muted-5': onClick,
     'hover-bg-muted-5': highlightOnHover,
-    'bg-action-secondary': active,
+    'c-on-base bg-action-secondary': active,
   })
   const style = {
     height,


### PR DESCRIPTION
#### What is the purpose of this pull request?

As title says

#### What problem is this solving?
[Running workspace](https://wksquebrada--cosmetics1.myvtex.com/admin/app/collections/1349/)

After [the sticky-header pr](https://github.com/vtex/styleguide/pull/1047) the backgrounds do not work as intended because of `bg-base
`. This PR fixes it.

#### How should this be manually tested?

Clone the repo and `yarn && yarn start`

#### Screenshots or example usage

Now:
![with bug](https://user-images.githubusercontent.com/6964311/75045213-a735a500-54a1-11ea-981d-e598606fe2e2.gif)

After Changes:
![without bug](https://user-images.githubusercontent.com/6964311/75045244-b61c5780-54a1-11ea-9126-7afdbc2edfe8.gif)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
