### PR TITLE
Do not disable new button and search while loading table's content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.14] - 2020-03-10
+
 ## Changed
 
 - Keep newLine button and search enabled on Table's toolbar while loading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Changed
+
+- Do not disable newLine button and search on Table's toolbar while loading
+
 ## [9.112.13] - 2020-03-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Changed
 
-- Do not disable newLine button and search on Table's toolbar while loading
+- Keep newLine button and search enabled on Table's toolbar while loading
 
 ## [9.112.13] - 2020-03-09
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.13",
+  "version": "9.112.14",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.13",
+  "version": "9.112.14",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Table/Toolbar.js
+++ b/react/components/Table/Toolbar.js
@@ -125,7 +125,7 @@ class Toolbar extends PureComponent {
       density.highOptionLabel
 
     const newLineButtonProps = {
-      disabled: loading || (newLine && newLine.disabled),
+      disabled: newLine && newLine.disabled,
       isLoading: newLine && newLine.isLoading,
       variation: 'primary',
       size: 'regular',
@@ -151,7 +151,6 @@ class Toolbar extends PureComponent {
         {inputSearch && (
           <div className={inputSearchAlone ? 'w-100 w-40-ns' : 'w-40'}>
             <InputSearch
-              disabled={loading}
               {...inputSearch}
               onSubmit={this.handleInputSearchSubmit}
             />


### PR DESCRIPTION
#### What is the purpose of this pull request?
As discussed on previous [Styleguide meeting](https://www.notion.so/Table-loading-state-disabling-ALL-buttons-ef37023799ab4a4dbf329a3db6954a54
), we don't want to disable search field and "new" button while loading table's content anymore.

#### How should this be manually tested?
[Running workspace](https://vlauxbeta--pricingqa.myvtex.com/admin/promotions)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
