### PR TITLE
Remove gap between columns when scrollbar appears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `EPERIMENTAL_Select` forcing focus after options are loaded
+- Gap betwenn columns when scrollbar appears
 
 ## [9.112.3] - 2020-02-27
 

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -243,6 +243,7 @@ class SimpleTable extends Component {
                     }
                     height={tableHeight}
                     width={width}
+                    key={width}
                     deferredMeasurementCache={this._cache}
                     tabIndex={null}
                     fixedRowCount={disableHeader ? 0 : 1}


### PR DESCRIPTION
#### What is the purpose of this pull request?
As title says.

#### What problem is this solving?
When there is a column without width defined (meaning it should use the available width), after content is loaded and a scrollbar appears (in case it does), the column size is not updated and a gap remains between them. Only happens when full width is used.

#### How should this be manually tested?
Before: https://pricingqa.myvtex.com/admin/promotions
Now: https://vlauxbeta--pricingqa.myvtex.com/admin/promotions

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5256673/75559768-ce045600-5a22-11ea-97f9-165c51d5e016.png)

![image](https://user-images.githubusercontent.com/5256673/75559751-c349c100-5a22-11ea-9c84-4196a345892a.png)


#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
