### PR TITLE
Adds `buttonProps` properties to `Input` and `InputButton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.11] - 2020-03-06
+
 ### Added
 
 - New `buttonProps` prop to `Input` and `InputButton` component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New `buttonProps` prop to `Input` and `InputButton` component
+
 ## [9.112.10] - 2020-03-06
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.10",
+  "version": "9.112.11",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.10",
+  "version": "9.112.11",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -85,6 +85,7 @@ class Input extends Component {
       suffix: suffixProp,
       suffixIcon,
       button,
+      buttonProps,
       isLoadingButton,
       groupBottom,
       disabled,
@@ -251,6 +252,7 @@ class Input extends Component {
           {button && size !== 'small' && (
             <span className="flex items-center mr1">
               <Button
+                {...buttonProps}
                 disabled={disabled || isLoadingButton}
                 isLoading={isLoadingButton}
                 size={size === 'large' ? 'regular' : 'small'}
@@ -276,6 +278,7 @@ Input.defaultProps = {
   autoFocus: false,
   token: false,
   dataAttributes: {},
+  buttonProps: {},
   disabled: false,
   label: '',
   multiple: false,
@@ -319,6 +322,9 @@ Input.propTypes = {
   /** @ignore
    * Spec attribute */
   button: PropTypes.string,
+  /** @ignore
+   * Spec attribute */
+  buttonProps: PropTypes.object,
   /** List of data attributes as a object like `{'locale': 'en-US'}` */
   dataAttributes: PropTypes.object,
   /** Spec attribute */

--- a/react/components/InputButton/index.js
+++ b/react/components/InputButton/index.js
@@ -6,23 +6,31 @@ import { withForwardedRef } from '../../modules/withForwardedRef'
 
 class InputButton extends Component {
   render() {
-    const { button, isLoading, ...props } = this.props
+    const { button, isLoading, buttonProps, ...props } = this.props
 
     return (
       <div>
-        <Input {...props} button={button} isLoadingButton={isLoading} />
+        <Input
+          {...props}
+          button={button}
+          buttonProps={buttonProps}
+          isLoadingButton={isLoading}
+        />
       </div>
     )
   }
 }
 
 InputButton.defaultProps = {
+  buttonProps: {},
   isLoading: false,
 }
 
 InputButton.propTypes = {
   /** (InputButton spec attribute) */
   button: PropTypes.string,
+  /** (InputButton spec attribute) */
+  buttonProps: PropTypes.object,
   /** Loading state */
   isLoading: PropTypes.bool,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Currently, the `InputButton` styleguide component does not allow you to pass props to the button it renders. The reason for this is that the component was meant to be inside of a `form`, however, the `Location Field (Input)` Place Component needs to render a `InputButton` without the context of a form, since that component in itself can be embedded into another form, which would create a form inside of a form.
The solution is to provide a way to add props to this button, so that one can pass actions like `onClick` to it, in such a way that you don't need a wrapper form to use the component.

#### What problem is this solving?

The component is being used under the "LocationInput" title.

[Workspace](https://locinput--checkoutio.myvtex.com/places)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
