### PR TITLE
fix filter tag not closing when filter is cleaned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- FilterTag not closing when filter is cleaned.
+
 ## [9.112.5] - 2020-02-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.6] - 2020-03-02
+
 ### Fixed
 
 - FilterTag not closing when filter is cleaned.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.5",
+  "version": "9.112.6",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.5",
+  "version": "9.112.6",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/FilterBar/FilterTag.js
+++ b/react/components/FilterBar/FilterTag.js
@@ -306,6 +306,7 @@ class FilterTag extends PureComponent {
               onClick={() => {
                 this.resetVirtualStatement()
                 onClickClear()
+                this.handleCloseMenu()
               }}>
               <IconClear solid size={16} />
             </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
The filter tag is not closing when filter is cleaned.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
[Running workspace](https://thay--cosmetics1.myvtex.com/admin/collections/1022/)

**Before**
![Coleções errado](https://user-images.githubusercontent.com/6867958/75681389-3e54e680-5c72-11ea-8fd6-9912eb34c611.gif)

**After**
![Coleções certo](https://user-images.githubusercontent.com/6867958/75681237-f0d87980-5c71-11ea-957e-ad1faf31c935.gif)

#### How should this be manually tested?
1. Select a filter and apply
2. Open the filter
3. Click on clear and see if the filter will close.
#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
