### PR TITLE
Add warning icon when input has errorMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Warning icon when input has errorMessage
+
 ## [9.112.7] - 2020-03-02
 
 ### Added

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -263,11 +263,12 @@ class Input extends Component {
           )}
         </div>
         {errorMessage && (
-          <div className="c-danger flex t-small mt3 lh-title">
-            <span className="mr2 flex items-center">
+          <div className="c-danger flex items-center t-small mt3 lh-title">
+            {/* use flex to align svg vertically */}
+            <span className="mr2 flex">
               <WarningIcon size={14} />
             </span>
-            <span>{errorMessage}</span>
+            {errorMessage}
           </div>
         )}
         {helpText && (

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import Button from '../Button'
 import styles from './Input.css'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
+import WarningIcon from '../icon/Warning'
 
 class Input extends Component {
   constructor(props) {
@@ -262,7 +263,12 @@ class Input extends Component {
           )}
         </div>
         {errorMessage && (
-          <div className="c-danger t-small mt3 lh-title">{errorMessage}</div>
+          <div className="c-danger flex t-small mt3 lh-title">
+            <span className="mr2 flex items-center">
+              <WarningIcon size={14} />
+            </span>
+            <span>{errorMessage}</span>
+          </div>
         )}
         {helpText && (
           <div className="c-muted-1 t-small mt3 lh-title">{helpText}</div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says

#### What problem is this solving?
issue: #938 

#### How should this be manually tested?
Use an input and pass an errorMessage prop

#### Screenshots or example usage
**before**
![image](https://user-images.githubusercontent.com/15680320/76119408-1e088d00-5fce-11ea-8ebd-b8c914762d15.png)

**after**
![image](https://user-images.githubusercontent.com/15680320/76119386-0f21da80-5fce-11ea-8088-67081d9415df.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
