### PR TITLE
Add useCallback in the EXPERIMENTAL_useTableVisibility to avoid always updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.15] - 2020-03-10
+
 ### Fixed
 
 - Add `useCallback` in the `showAllColumns` and `hideAllColumns` in the `EXPERIMENTAL_useTableVisibility`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `useCallback` in the `showAllColumns` and `hideAllColumns` in the `EXPERIMENTAL_useTableVisibility`.
+
 ## [9.112.14] - 2020-03-10
 
 ## Changed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.14",
+  "version": "9.112.15",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.14",
+  "version": "9.112.15",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableVisibility.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableVisibility.ts
@@ -27,7 +27,7 @@ export default function useTableVisibility({
 
   const hideAllColumns = useCallback(() => {
     setHiddenColumns(columns.map(col => col.id))
-  }, [])
+  }, [columns])
 
   return {
     columns,

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableVisibility.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableVisibility.ts
@@ -21,13 +21,13 @@ export default function useTableVisibility({
     )
   }, [])
 
-  const showAllColumns = () => {
+  const showAllColumns = useCallback(() => {
     setHiddenColumns([])
-  }
+  }, [])
 
-  const hideAllColumns = () => {
+  const hideAllColumns = useCallback(() => {
     setHiddenColumns(columns.map(col => col.id))
-  }
+  }, [])
 
   return {
     columns,


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

##### :warning:  This PR is depended on [#PR 267](https://github.com/vtex/admin-collections/pull/267). :warning: 

#### What problem is this solving?
[Running workspace](https://vitoria--cosmetics1.myvtex.com/admin/collections/2335/)

When using the `showAllColumns` of the `EXPERIMENTAL_useTableVisibility`, the maximum deph update was reached.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
