### PR TITLE
CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Want to contribute to VTEX Styleguide? There are a few things you need to know.
 
 ### Release Schedule
-Thursday release: patch version at the thursday of every week for routine bugfix (anytime for urgent bugfix).
+Thursday release: patch version at the Thursday of every week for routine bug fix (anytime for urgent bug fix).
 
 Tuesday release: minor version at the tuesday of every month for new features.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,4 +13,4 @@ Major version releases are not included in this schedule.
 All work on VTEX Styleguide happens directly on GitHub. Both core team members and external contributors send pull requests which go through the same review process.
 
 ### Branch Organization
-According to our [release schedule](#release-schedule), we maintain two branches, `master` and `dev`. If you send a bugfix pull request, please do it against the `master` branch, if it's a feature pull request, please do it against the `dev` branch.
+According to our [release schedule](#release-schedule), we maintain two branches, `master` and `features`. If you send a bugfix pull request, please do it against the `master` branch, if it's a feature pull request, please do it against the `features` branch.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing to VTEX Styleguide
+
+Want to contribute to VTEX Styleguide? There are a few things you need to know.
+
+### Release Schedule
+Thursday release: patch version at the thursday of every week for routine bugfix (anytime for urgent bugfix).
+
+Tuesday release: minor version at the tuesday of every month for new features.
+
+Major version release is not included in this schedule for breaking change and new features.
+
+### Open Development
+All work on VTEX Styleguide happens directly on GitHub. Both core team members and external contributors send pull requests which go through the same review process.
+
+### Branch Organization
+According to our [release schedule](#release-schedule), we maintain two branches, `master` and `dev`. If you send a bugfix pull request, please do it against the `master` branch, if it's a feature pull request, please do it against the `dev` branch.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,4 +13,4 @@ Major version releases are not included in this schedule.
 All work on VTEX Styleguide happens directly on GitHub. Both core team members and external contributors send pull requests which go through the same review process.
 
 ### Branch Organization
-According to our [release schedule](#release-schedule), we maintain two branches, `master` and `features`. If you send a bugfix pull request, please do it against the `master` branch, if it's a feature pull request, please do it against the `features` branch.
+According to our [release schedule](#release-schedule), we maintain two branches: `master` and `features`. Bug fixes should have `master` as it base branch, while new features should be merged into `features`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thursday release: patch version at the Thursday of every week for routine bug fi
 
 Tuesday release: minor version at the Tuesday of every week for new features.
 
-Major version release is not included in this schedule for breaking change and new features.
+Major version releases are not included in this schedule.
 
 ### Open Development
 All work on VTEX Styleguide happens directly on GitHub. Both core team members and external contributors send pull requests which go through the same review process.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Want to contribute to VTEX Styleguide? There are a few things you need to know.
 ### Release Schedule
 Thursday release: patch version at the Thursday of every week for routine bug fix (anytime for urgent bug fix).
 
-Tuesday release: minor version at the Tuesday of every month for new features.
+Tuesday release: minor version at the Tuesday of every week for new features.
 
 Major version release is not included in this schedule for breaking change and new features.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Want to contribute to VTEX Styleguide? There are a few things you need to know.
 ### Release Schedule
 Thursday release: patch version at the Thursday of every week for routine bug fix (anytime for urgent bug fix).
 
-Tuesday release: minor version at the tuesday of every month for new features.
+Tuesday release: minor version at the Tuesday of every month for new features.
 
 Major version release is not included in this schedule for breaking change and new features.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Want to contribute to VTEX Styleguide? There are a few things you need to know.
 
 ### Release Schedule
-Thursday release: patch version at the Thursday of every week for routine bug fix (anytime for urgent bug fix).
+Thursday release: patch version weekly on each Thursday for routine bug fix (anytime for urgent bug fix).
 
 Tuesday release: minor version at the Tuesday of every week for new features.
 


### PR DESCRIPTION
Due to several problems that have been happening with the release, we have created a new contribution policy. 

The idea is that you don't have to worry about releasing, it will be done by people from the core team. 

> New changelog entries to the Unreleased section are still required in pull requests