### PR TITLE
Add warning icon when input has errorMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Warning icon when input has errorMessage
 - Size prop to checkbox.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Size prop to checkbox.
+
 ### Changed
 
 - `Table`'s `headerRenderer` can be used in columns that are either fixed or sortable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `Table`'s `headerRenderer` can be used in columns that are either fixed or sortable
+
 ## [9.112.15] - 2020-03-10
 
 ### Fixed

--- a/react/components/Checkbox/README.md
+++ b/react/components/Checkbox/README.md
@@ -24,10 +24,11 @@ initialState = { check1: true, check2: false, check3: false }
     <Checkbox
       checked={state.check1}
       id="option-0"
-      label="Checked"
+      label="Checked and small"
       name="default-checkbox-group"
       onChange={e => setState({ check1: !state.check1 })}
       value="option-0"
+      size="small"
     />
   </div>
   <div className="mb3">

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -23,6 +23,7 @@ class Checkbox extends PureComponent {
       value,
       partial,
       forwardedRef,
+      size,
     } = this.props
 
     return (
@@ -97,7 +98,8 @@ class Checkbox extends PureComponent {
           <label
             className={classNames(
               { 'c-disabled': disabled },
-              { 'c-on-base pointer': !disabled }
+              { 'c-on-base pointer': !disabled },
+              { 't-small': size === 'small' }
             )}
             htmlFor={id}>
             {label}
@@ -136,6 +138,8 @@ Checkbox.propTypes = {
   value: PropTypes.string,
   /** Partial state */
   partial: PropTypes.bool,
+  /** Label size */
+  size: PropTypes.oneOf(['small']),
 }
 
 export default withForwardedRef(Checkbox)

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -265,11 +265,12 @@ class Input extends Component {
           )}
         </div>
         {errorMessage && (
-          <div className="c-danger flex t-small mt3 lh-title">
-            <span className="mr2 flex items-center">
+          <div className="c-danger flex items-center t-small mt3 lh-title">
+            {/* use flex to align svg vertically */}
+            <span className="mr2 flex">
               <WarningIcon size={14} />
             </span>
-            <span>{errorMessage}</span>
+            {errorMessage}
           </div>
         )}
         {helpText && (

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import Button from '../Button'
 import styles from './Input.css'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
+import WarningIcon from '../icon/Warning'
 
 class Input extends Component {
   constructor(props) {
@@ -264,7 +265,12 @@ class Input extends Component {
           )}
         </div>
         {errorMessage && (
-          <div className="c-danger t-small mt3 lh-title">{errorMessage}</div>
+          <div className="c-danger flex t-small mt3 lh-title">
+            <span className="mr2 flex items-center">
+              <WarningIcon size={14} />
+            </span>
+            <span>{errorMessage}</span>
+          </div>
         )}
         {helpText && (
           <div className="c-muted-1 t-small mt3 lh-title">{helpText}</div>

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -308,7 +308,7 @@ class CustomTableExample extends React.Component {
 - Customized the render method of a single header cell.
 - It receives a function that returns a node (react component).
 - The function has the following params: ({ columnIndex, key, title })
-- This prop will not work if the `sortable` prop for the same header is active.
+- This prop will also work if either the `sortable` or `fixedColumn` prop for the same header is active. For sortable headers, the sorting caret will be added to the side of your header renderer according to the specified alignment (`headerRight: true/false`).
 
 example customizing number column header to use intl FormattedMessage
 
@@ -319,20 +319,23 @@ const itemsCopy = sampleData.items
   .reverse()
   .splice(20)
 const Tag = require('../Tag').default
+
 class FormattedMessage extends React.Component {
   render() {
     const renderTextByIntlId = id => {
       switch (id) {
-        case 'some.intl.message.id':
-          return 'Number'
-          break
+        case 'value.intl.message.id':
+          return 'Value';
         default:
-          return 'Deafult Header title'
-          break
+          return 'Deafult Header title';
       }
     }
     return <span>{renderTextByIntlId(this.props.id)}</span>
   }
+}
+
+const translate = ({ title }) => {
+  return <FormattedMessage id={title} />
 }
 
 class CustomTableExample extends React.Component {
@@ -340,6 +343,38 @@ class CustomTableExample extends React.Component {
     super()
     this.state = {
       orderedItems: itemsCopy,
+      dataSort: {
+        sortedBy: null,
+        sortOrder: null,
+      },
+    }
+
+    this.sortNumberASC = this.sortNumberASC.bind(this)
+    this.sortNumberDESC = this.sortNumberDESC.bind(this)
+    this.handleSort = this.handleSort.bind(this)
+  }
+
+  sortNumberASC(a, b) {
+    return a.number < b.number ? -1 : a.number > b.number ? 1 : 0
+  }
+  sortNumberDESC(a, b) {
+    return a.number < b.number ? 1 : a.number > b.number ? -1 : 0
+  }
+
+  handleSort({ sortOrder, sortedBy }) {
+    if (sortedBy === 'number') {
+      const orderedItems =
+        sortOrder === 'ASC'
+          ? itemsCopy.slice().sort(this.sortNumberASC)
+          : itemsCopy.slice().sort(this.sortNumberDESC)
+
+      this.setState({
+        orderedItems,
+        dataSort: {
+          sortedBy,
+          sortOrder,
+        },
+      })
     }
   }
 
@@ -351,23 +386,29 @@ class CustomTableExample extends React.Component {
           width: 250,
         },
         email: {
-          title: 'Email',
-          width: 300,
+          title: 'email.intl.message.id',
+          width: 250,
+          headerRenderer: translate,
         },
         number: {
-          title: 'some.intl.message.id',
-          headerRenderer: ({ title }) => {
-            return <FormattedMessage id={title} />
-          },
+          title: 'value.intl.message.id',
+          headerRenderer: translate,
+          sortable: true,
+          headerRight: true,
+          cellRenderer: data => (
+            <div className="w-100 tr">$ {data.cellData}</div>
+          ),
         },
       },
     }
 
     return (
-      <div>
-        <div className="mb5">
-          <Table schema={customSchema} items={this.state.orderedItems} />
-        </div>
+      <div className="mb5">
+        <Table schema={customSchema} items={this.state.orderedItems} sort={{
+            sortedBy: this.state.dataSort.sortedBy,
+            sortOrder: this.state.dataSort.sortOrder,
+          }}
+          onSort={this.handleSort}/>
       </div>
     )
   }

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -285,8 +285,16 @@ class SimpleTable extends Component {
                           schema.properties[property].title || property
                         const headerRight =
                           schema.properties[property].headerRight || false
-                        const headerRenderer =
-                          schema.properties[property].headerRenderer
+                        const header =
+                          (schema.properties[property].headerRenderer &&
+                            schema.properties[property].headerRenderer({
+                              columnIndex,
+                              key,
+                              rowIndex,
+                              style,
+                              title,
+                            })) ||
+                          title
                         const arrowIsDown =
                           sortOrder === 'ASC' && sortedBy === property
                         const arrowIsUp =
@@ -311,11 +319,15 @@ class SimpleTable extends Component {
                               }`}>
                               {schema.properties[property].sortable ? (
                                 <div
-                                  className="w-100 pointer c-muted-1 b t-small"
+                                  className={`w-100 pointer c-muted-1 b t-small flex items-center ${
+                                    headerRight
+                                      ? 'justify-end'
+                                      : 'justify-start'
+                                  }`}
                                   onClick={() => {
                                     onSort(this.toggleSortType(property))
                                   }}>
-                                  {!headerRight && title}
+                                  {!headerRight && header}
                                   <div
                                     className={`inline-flex ${
                                       headerRight ? 'pr2' : 'pl3'
@@ -326,20 +338,12 @@ class SimpleTable extends Component {
                                       <ArrowUp size={ARROW_SIZE} />
                                     ) : null}
                                   </div>
-                                  {headerRight && title}
+                                  {headerRight && header}
                                 </div>
                               ) : columnIndex === 0 && fixFirstColumn ? (
-                                <div className="w-100">{title}</div>
-                              ) : headerRenderer ? (
-                                headerRenderer({
-                                  columnIndex,
-                                  key,
-                                  rowIndex,
-                                  style,
-                                  title,
-                                })
+                                <div className="w-100">{header}</div>
                               ) : (
-                                <span className="w-100">{title}</span>
+                                header
                               )}
                             </div>
                           </CellMeasurer>


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says

#### What problem is this solving?
issue: #938 

#### How should this be manually tested?
Use an input and pass an errorMessage prop

#### Screenshots or example usage
**before**
![image](https://user-images.githubusercontent.com/15680320/76119408-1e088d00-5fce-11ea-8ebd-b8c914762d15.png)

**after**
![image](https://user-images.githubusercontent.com/15680320/76119386-0f21da80-5fce-11ea-8088-67081d9415df.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
