### PR TITLE
Fix Dropdown usage inside an Input prefix or suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Broken styles of `Dropdown` inside an `Input` prefix or suffix.
+
 ## [9.112.15] - 2020-03-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.16] - 2020-03-16
+
 ### Fixed
 
 - Broken styles of `Dropdown` inside an `Input` prefix or suffix.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.15",
+  "version": "9.112.16",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.15",
+  "version": "9.112.16",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Dropdown/Dropdown.css
+++ b/react/components/Dropdown/Dropdown.css
@@ -1,0 +1,28 @@
+:global(.vtex-input__prefix) .dropdown,
+:global(.vtex-input__suffix) .dropdown {
+  height: 100%;
+}
+
+:global(.vtex-input__prefix) .dropdown {
+  margin-left: -1rem;
+}
+
+:global(.vtex-input__suffix) .dropdown {
+  margin-right: -1rem;
+}
+
+:global(.vtex-input__prefix) .container,
+:global(.vtex-input__suffix) .container {
+  height: 100%;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0;
+}
+
+:global(.vtex-input__prefix) .container {
+  border-left: none;
+}
+
+:global(.vtex-input__suffix) .container {
+  border-right: none;
+}

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
@@ -107,84 +108,69 @@ class Dropdown extends Component {
 
     const isPlaceholder = this.getSelectedOption() === null
     const isInline = variation.toLowerCase() === 'inline'
-    let width
-    let iconSize
+    const iconSize = size === 'x-large' ? 22 : 18
 
-    let classes = 'bg-transparent bn w-100 h-100 '
-    let containerClasses = `${styles.container} ${
-      isInline ? '' : 'bw1'
-    } br2 relative `
-    let selectClasses = 'o-0 absolute top-0 left-0 h-100 w-100 bottom-00 '
+    const color = isInline ? 'c-link' : 'c-on-base'
 
-    let labelClasses = 'vtex-dropdown__label db mb3 w-100 c-on-base '
+    const buttonClasses = classNames(
+      'vtex-dropdown__button bg-transparent bn w-100 h-100',
+      {
+        pointer: !disabled,
+        'c-disabled': disabled || !valueLabel,
+        [color]: !disabled && valueLabel && !isPlaceholder,
+        'c-muted-2': !disabled && valueLabel && isPlaceholder,
+        ph2: isInline && size !== 'x-large',
+        'pl5 pr3': !isInline && size !== 'x-large' && size !== 'large',
+        't-body pv5 ph5': size === 'x-large',
+      }
+    )
+
+    const rootClasses = classNames(styles.dropdown, 'vtex-dropdown', {
+      'vtex-dropdown--inline dib': isInline,
+    })
+
+    const containerClasses = classNames(styles.container, 'br2 relative', {
+      bw1: !isInline || disabled,
+      ba: disabled || error || errorMessage,
+      'b--disabled bg-disabled': disabled,
+      'b--danger hover-b--danger': (error || errorMessage) && !disabled,
+      fw5: isInline && !error && !errorMessage && !disabled,
+      'bg-base hover-b--muted-3 ba b--muted-4':
+        !isInline && !error && !errorMessage && !disabled,
+      't-body': size !== 'small' && size !== 'x-large',
+      'h-auto': isInline && size !== 'x-large',
+      'h-small': !isInline && size === 'small',
+      'h-large': !isInline && size === 'large',
+      'h-regular':
+        !isInline && size !== 'small' && size !== 'large' && size !== 'x-large',
+    })
+
+    const selectClasses = classNames(
+      'o-0 absolute top-0 left-0 h-100 w-100 bottom-0',
+      {
+        pointer: !disabled,
+        't-body': size !== 'small',
+        't-small': size === 'small',
+      }
+    )
+
+    const labelClasses = classNames(
+      'vtex-dropdown__label db mb3 w-100 c-on-base',
+      {
+        't-small': size !== 'large' && size !== 'x-large',
+        't-body': size === 'large' || size === 'x-large',
+      }
+    )
 
     const valueLabel = this.getValueLabel()
     const showCaption = !valueLabel
 
-    const color = isInline ? 'c-link ' : 'c-on-base '
-
-    classes += disabled ? '' : 'pointer '
-    selectClasses += disabled ? '' : 'pointer '
-    classes +=
-      !disabled && valueLabel
-        ? !isPlaceholder
-          ? color
-          : 'c-muted-2 '
-        : 'c-disabled '
-
-    switch (size) {
-      case 'small':
-        classes += isInline ? 'ph2 ' : 'pl5 pr3 '
-        selectClasses += 't-small '
-        labelClasses += 't-small '
-        containerClasses += `${isInline ? 'h-auto' : 'h-small'} t-small `
-        iconSize = 18
-        break
-      case 'large':
-        classes += isInline ? 'ph2 ' : 'ph5 '
-        selectClasses += 't-body '
-        labelClasses += 't-body '
-        containerClasses += `${isInline ? 'h-auto' : 'h-large'} t-body `
-        iconSize = 18
-        break
-      case 'x-large':
-        // DEPRECATED
-        classes += 't-body pv5 ph5 '
-        selectClasses += 't-body '
-        labelClasses += 't-body '
-        iconSize = 22
-        break
-      default:
-        classes += isInline ? 'ph2 ' : 'pl5 pr4 '
-        selectClasses += 't-body '
-        labelClasses += 't-small '
-        containerClasses += `${isInline ? 'h-auto' : 'h-regular'} t-body `
-        iconSize = 18
-        break
-    }
-
-    const containerStyle = { width }
-
-    if (disabled) {
-      containerClasses += 'ba b--disabled bw1 bg-disabled '
-    } else if (error || errorMessage) {
-      containerClasses += 'ba b--danger hover-b--danger '
-    } else if (isInline) {
-      containerClasses += 'fw5 '
-    } else {
-      containerClasses += 'bg-base hover-b--muted-3 ba b--muted-4 '
-    }
-
     return (
-      <div
-        className={`vtex-dropdown ${
-          isInline ? 'vtex-dropdown--inline dib ' : ''
-        }${styles.dropdown}`}
-        data-testid={testId}>
+      <div className={rootClasses} data-testid={testId}>
         <label className="h-100">
           {label && <span className={labelClasses}>{label}</span>}
-          <div className={containerClasses} style={containerStyle}>
-            <div id={id} className={`vtex-dropdown__button ${classes}`}>
+          <div className={containerClasses}>
+            <div id={id} className={buttonClasses}>
               <div className={`flex ${isInline ? '' : 'h-100'}`}>
                 <div
                   className={`vtex-dropdown__caption flex-auto tl truncate ${

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import ArrowDownIcon from './ArrowDownIcon'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
+import styles from './Dropdown.css'
 
 class Dropdown extends Component {
   constructor(props) {
@@ -110,7 +111,9 @@ class Dropdown extends Component {
     let iconSize
 
     let classes = 'bg-transparent bn w-100 h-100 '
-    let containerClasses = `${isInline ? '' : 'bw1'} br2 relative `
+    let containerClasses = `${styles.container} ${
+      isInline ? '' : 'bw1'
+    } br2 relative `
     let selectClasses = 'o-0 absolute top-0 left-0 h-100 w-100 bottom-00 '
 
     let labelClasses = 'vtex-dropdown__label db mb3 w-100 c-on-base '
@@ -175,10 +178,10 @@ class Dropdown extends Component {
     return (
       <div
         className={`vtex-dropdown ${
-          isInline ? 'vtex-dropdown--inline dib' : ''
-        }`}
+          isInline ? 'vtex-dropdown--inline dib ' : ''
+        }${styles.dropdown}`}
         data-testid={testId}>
-        <label>
+        <label className="h-100">
           {label && <span className={labelClasses}>{label}</span>}
           <div className={containerClasses} style={containerStyle}>
             <div id={id} className={`vtex-dropdown__button ${classes}`}>

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -113,8 +113,7 @@ class Input extends Component {
 
     let classes = `${styles.input} ${box} ${styles.hideDecorators} ${styles.noAppearance} ${borderRadius} bn outline-0 `
     let labelClasses = 'vtex-input__label db mb3 w-100 c-on-base '
-    let prefixAndSuffixClasses =
-      'c-muted-2 fw5 flex items-center c-muted-2 t-body '
+    let prefixAndSuffixClasses = 'c-muted-2 fw5 flex items-center t-body '
     let prefixSuffixGroupClasses =
       'vtex-input-prefix__group flex flex-row items-stretch '
     prefixSuffixGroupClasses += `${borderRadiusBase} ${borderBase} ${

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -109,13 +109,13 @@ class Input extends Component {
     const borderRadius = `${borderRadiusBase} ${
       prefix ? 'bl-0 br--right ' : ''
     } ${suffix ? 'br-0 br--left ' : ''}`
-    let prefixClasses = `${borderRadiusBase} br-0 br--left `
-    let suffixClasses = `${borderRadiusBase} bl-0 br--right `
+    let prefixClasses = `vtex-input__prefix ${borderRadiusBase} br-0 br--left `
+    let suffixClasses = `vtex-input__suffix ${borderRadiusBase} bl-0 br--right `
 
     let classes = `${styles.input} ${widthClass} ${box} ${styles.hideDecorators} ${styles.noAppearance} ${borderRadius} bn outline-0 `
     let labelClasses = 'vtex-input__label db mb3 w-100 c-on-base '
     let prefixAndSuffixClasses =
-      'vtex-input__prefix c-muted-2 fw5 flex items-center c-muted-2 t-body '
+      'c-muted-2 fw5 flex items-center c-muted-2 t-body '
     let prefixSuffixGroupClasses =
       'vtex-input-prefix__group flex flex-row items-stretch '
     prefixSuffixGroupClasses += `${borderRadiusBase} ${borderBase} ${

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -111,11 +111,11 @@ class Input extends Component {
     let prefixClasses = `vtex-input__prefix ${borderRadiusBase} br-0 br--left `
     let suffixClasses = `vtex-input__suffix ${borderRadiusBase} bl-0 br--right `
 
-    let classes = `${styles.input} ${box} ${styles.hideDecorators} ${styles.noAppearance} ${borderRadius} bn outline-0 `
+    let classes = `${styles.input} ${box} ${styles.hideDecorators} ${styles.noAppearance} ${borderRadius} w-100 bn outline-0 `
     let labelClasses = 'vtex-input__label db mb3 w-100 c-on-base '
     let prefixAndSuffixClasses = 'c-muted-2 fw5 flex items-center t-body '
     let prefixSuffixGroupClasses =
-      'vtex-input-prefix__group flex flex-row items-stretch '
+      'vtex-input-prefix__group flex flex-row items-stretch overflow-hidden '
     prefixSuffixGroupClasses += `${borderRadiusBase} ${borderBase} ${
       groupBottom ? 'br--top ' : ''
     }`

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -101,7 +101,6 @@ class Input extends Component {
       dataAttrs[`data-${key}`] = dataAttributes[key]
     }
 
-    const widthClass = 'w-100'
     const box = 'ma0 border-box'
     const borderRadiusBase = 'br2'
     const borderBase = `bw1 b--solid`
@@ -112,7 +111,7 @@ class Input extends Component {
     let prefixClasses = `vtex-input__prefix ${borderRadiusBase} br-0 br--left `
     let suffixClasses = `vtex-input__suffix ${borderRadiusBase} bl-0 br--right `
 
-    let classes = `${styles.input} ${widthClass} ${box} ${styles.hideDecorators} ${styles.noAppearance} ${borderRadius} bn outline-0 `
+    let classes = `${styles.input} ${box} ${styles.hideDecorators} ${styles.noAppearance} ${borderRadius} bn outline-0 `
     let labelClasses = 'vtex-input__label db mb3 w-100 c-on-base '
     let prefixAndSuffixClasses =
       'c-muted-2 fw5 flex items-center c-muted-2 t-body '


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds a better support for the `Dropdown` component inside an `Input` prefix or suffix.

#### What problem is this solving?
[Running workspace](https://lucas--checkoutio.myvtex.com/checkout/?cultureInfo=pt-BR#/profile)

With this, implementing the following design is more straightforward and requires no "hack" in userland.

<img width="463" alt="image" src="https://user-images.githubusercontent.com/10223856/76628652-d75dea00-651b-11ea-998c-3bbd25fd025a.png">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
