### PR TITLE
[FIX] RefError by accessing 'valueLabel' const on Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.20] - 2020-03-17
+
 ### Fixed
 
 - ReferenceError by accessing 'valueLabel' const on `Dropdown`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- ReferenceError by accessing 'valueLabel' const on `Dropdown`.
+
 ## [9.112.19] - 2020-03-16
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.19",
+  "version": "9.112.20",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.19",
+  "version": "9.112.20",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -106,6 +106,8 @@ class Dropdown extends Component {
     const hasValidInitialValue =
       this.getOptionFromValue(this.initialValue) !== null
 
+    const valueLabel = this.getValueLabel()
+    const showCaption = !valueLabel
     const isPlaceholder = this.getSelectedOption() === null
     const isInline = variation.toLowerCase() === 'inline'
     const iconSize = size === 'x-large' ? 22 : 18
@@ -161,9 +163,6 @@ class Dropdown extends Component {
         't-body': size === 'large' || size === 'x-large',
       }
     )
-
-    const valueLabel = this.getValueLabel()
-    const showCaption = !valueLabel
 
     return (
       <div className={rootClasses} data-testid={testId}>


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### What problem is this solving?

The variable was being accessed before definition.

#### How should this be manually tested?

clone the repo and `yarn && yarn start`

#### Screenshots or example usage

![Screen Shot 2020-03-16 at 13 42 35](https://user-images.githubusercontent.com/6964311/76781084-e9928f00-678c-11ea-9a5c-9dd1e486fb9f.png)

#### Types of changes

- [x] Bugfix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
