### PR TITLE
Add inner spacing to large dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Apply proper spacing to large dropdowns
+
 ## [9.112.22] - 2020-03-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.23] - 2020-03-18
+
 ### Fixed
 
 - Apply proper spacing to large dropdowns

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.22",
+  "version": "9.112.23",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.22",
+  "version": "9.112.23",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -122,7 +122,7 @@ class Dropdown extends Component {
         [color]: !disabled && valueLabel && !isPlaceholder,
         'c-muted-2': !disabled && valueLabel && isPlaceholder,
         ph2: isInline && size !== 'x-large',
-        'pl5 pr3': !isInline && size !== 'x-large' && size !== 'large',
+        'pl5 pr3': !isInline && size !== 'x-large',
         't-body pv5 ph5': size === 'x-large',
       }
     )

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -103,6 +103,9 @@ class Dropdown extends Component {
       selectTestId,
     } = this.props
 
+    const valueLabel = this.getValueLabel()
+    const showCaption = !valueLabel
+
     const hasValidInitialValue =
       this.getOptionFromValue(this.initialValue) !== null
 

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -103,9 +103,6 @@ class Dropdown extends Component {
       selectTestId,
     } = this.props
 
-    const valueLabel = this.getValueLabel()
-    const showCaption = !valueLabel
-
     const hasValidInitialValue =
       this.getOptionFromValue(this.initialValue) !== null
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
[This PR](https://github.com/vtex/styleguide/pull/1087) removed the spacing for the large variation of the `Dropdown` and we really miss them. I rather use the same spacing as the other sizes as well.

#### What problem is this solving?
Check the large variation here https://styleguide.vtex.com/#/Components/Forms/Dropdown


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://augusto--mystore.mygocommerce.com/admin/app/marketing/promotions/create

#### Screenshots or example usage
<img width="1045" alt="Screen Shot 2020-03-16 at 17 01 26" src="https://user-images.githubusercontent.com/7659279/76795383-cc1eee80-67a7-11ea-94f2-faba432e7fbd.png">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
