### PR TITLE
Fix the tooltip overflowing with long words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- The `Tooltip` component overflows when there are long words.
+
 ## [9.112.23] - 2020-03-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.24] - 2020-03-19
+
 ### Fixed
 
 - The `Tooltip` component overflows when there are long words.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.23",
+  "version": "9.112.24",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.23",
+  "version": "9.112.24",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -100,6 +100,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
           ...positionStyle,
           zIndex: zIndex.tooltip,
           transition: `opacity ${duration}ms ${timmingFn} ${delay}ms`,
+          wordBreak: 'break-all',
         }}
         ref={popupRef}
         onTransitionEnd={() => setShowPopup(visible)}>

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -44,6 +44,13 @@ const propTypes = {
   timmingFn: PropTypes.string,
   /** Child ref. Used to correctly position the tooltip */
   childRef: getChildRefPropType(),
+  /** Element that inserts line break style in the word. Used to prevent width overflow */
+  wordBreak: PropTypes.oneOf<string>([
+    'normal',
+    'break-all',
+    'keep-all',
+    'break-word',
+  ]),
 }
 
 const defaultProps = {
@@ -60,6 +67,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   duration,
   timmingFn,
   childRef,
+  wordBreak,
 }) => {
   const [showPopup, setShowPopup] = useState(visible)
   const popupRef = useRef<HTMLDivElement>()
@@ -100,7 +108,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
           ...positionStyle,
           zIndex: zIndex.tooltip,
           transition: `opacity ${duration}ms ${timmingFn} ${delay}ms`,
-          wordBreak: 'break-all',
+          wordBreak,
         }}
         ref={popupRef}
         onTransitionEnd={() => setShowPopup(visible)}>

--- a/react/components/Tooltip/index.tsx
+++ b/react/components/Tooltip/index.tsx
@@ -28,6 +28,13 @@ const propTypes = {
   duration: PropTypes.number,
   /** Tooltip timming function used to animate the tooltip */
   timmingFn: PropTypes.string,
+  /** Element that inserts line break style in the word. Used to prevent width overflow */
+  wordBreak: PropTypes.oneOf<string>([
+    'normal',
+    'break-all',
+    'keep-all',
+    'break-word',
+  ]),
 }
 
 type Props = PropTypes.InferProps<typeof propTypes>
@@ -39,6 +46,7 @@ const defaultProps: Props = {
   delay: 0,
   duration: 200,
   timmingFn: 'ease-in-out',
+  wordBreak: 'normal',
 }
 
 const Tooltip: FC<Props> = ({ trigger, children, ...popupProps }) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says
<!--- Describe your changes in detail. -->

#### What problem is this solving?
[clubhouse](https://app.clubhouse.io/vtex/story/31018/ui-implementation-resolver-problema-do-tooltip-quebrando-na-tabela-de-produtos)
[story related](https://app.clubhouse.io/vtex/story/30998/corre%C3%A7%C3%B5es-das-colunas-e-tooltips-na-tabela)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
In this [workspace](https://lucasan2--cosmetics1.myvtex.com/admin/collections/) go to a collection page and on the second page of the product table you will see the example shown below

#### Screenshots or example usage
### Before
![Captura de tela de 2020-03-19 11-07-55](https://user-images.githubusercontent.com/20579226/77077836-8a26c000-69d4-11ea-8722-e9c1c9c6bdca.png)
### After
![Captura de tela de 2020-03-19 11-08-12](https://user-images.githubusercontent.com/20579226/77077824-8430df00-69d4-11ea-8a72-8ab4439fa4da.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
