### PR TITLE
Fix AutocompleteInput styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- truncates and bold styles in `AutoCompleteInput` options.
+- truncate in `AutoCompleteInput` options.
 
 ## [9.112.26] - 2020-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.112.27] - 2020-03-26
+
 ### Fixed
 
 - Truncate big texts in `AutoCompleteInput` options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- truncates and bold styles in `AutoCompleteInput` options.
+
 ## [9.112.26] - 2020-03-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- truncate in `AutoCompleteInput` options.
+- Truncate big texts in `AutoCompleteInput` options.
 
 ## [9.112.26] - 2020-03-23
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.26",
+  "version": "9.112.27",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.26",
+  "version": "9.112.27",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/AutocompleteInput/Option.tsx
+++ b/react/components/AutocompleteInput/Option.tsx
@@ -54,11 +54,11 @@ const Option: React.FunctionComponent<PropTypes.InferProps<
     const match = value.substr(index, searchTerm.length)
     const suffix = value.substring(index + match.length)
     return (
-      <span className="truncate">
-        <span className="fw7">{prefix}</span>
-        {match}
-        <span className="fw7">{suffix}</span>
-      </span>
+      <>
+        {prefix}
+        <span className="fw7">{match}</span>
+        {suffix}
+      </>
     )
   }
 
@@ -75,9 +75,9 @@ const Option: React.FunctionComponent<PropTypes.InferProps<
       onMouseEnter={() => setHighlightOption(true)}
       onMouseLeave={() => setHighlightOption(false)}
       onClick={onClick}>
-      <span className="h1 flex items-center">
+      <span className="h1 flex items-center truncate">
         <span className="mr3 c-muted-2 flex pt1">{icon}</span>
-        {renderOptionValue()}
+        <span className="truncate">{renderOptionValue()}</span>
       </span>
     </button>
   )

--- a/react/components/AutocompleteInput/Option.tsx
+++ b/react/components/AutocompleteInput/Option.tsx
@@ -55,9 +55,9 @@ const Option: React.FunctionComponent<PropTypes.InferProps<
     const suffix = value.substring(index + match.length)
     return (
       <>
-        {prefix}
-        <span className="fw7">{match}</span>
-        {suffix}
+        <span className="fw7">{prefix}</span>
+        {match}
+        <span className="fw7">{suffix}</span>
       </>
     )
   }

--- a/react/components/AutocompleteInput/Option.tsx
+++ b/react/components/AutocompleteInput/Option.tsx
@@ -75,7 +75,7 @@ const Option: React.FunctionComponent<PropTypes.InferProps<
       onMouseEnter={() => setHighlightOption(true)}
       onMouseLeave={() => setHighlightOption(false)}
       onClick={onClick}>
-      <span className="h1 flex items-center truncate">
+      <span className="h1 flex items-center">
         <span className="mr3 c-muted-2 flex pt1">{icon}</span>
         <span className="truncate">{renderOptionValue()}</span>
       </span>


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
As the title says

#### How should this be manually tested?
Type `veg` in the products autocomplete input
[workspace](https://fixautocompletetext--cosmetics1.myvtex.com/admin/app/collections/2340/)

#### Screenshots or example usage
Before
![chrome-capture (1)](https://user-images.githubusercontent.com/4912690/77446938-d48daf80-6dcd-11ea-8429-e41d017bbe18.gif)
After
![chrome-capture (2)](https://user-images.githubusercontent.com/4912690/77456280-c9408100-6dd9-11ea-87db-a797bc10869b.gif)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
