### PR TITLE
#trivial: Fix outdated link and references to ProgressBar in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Outdated link to `Progress` in `Spinner` docs.
+- References to deprecated `ProgressBar` in `Progress` docs.
+
 ## [9.112.27] - 2020-03-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixed
-
-- Outdated link to `Progress` in `Spinner` docs.
-- References to deprecated `ProgressBar` in `Progress` docs.
-
 ## [9.112.27] - 2020-03-26
 
 ### Fixed

--- a/react/components/Progress/README.md
+++ b/react/components/Progress/README.md
@@ -10,7 +10,7 @@
 - Don't put more than one "in progress" step.
 - Don't put steps of a different type in between steps of the same type (e.g. ["Completed", "In Progress", "Completed"]). Remember that the component represents a linear progression.
 
-#### Simple ProgressBar example
+#### Simple Progress example
 
 Second Action in Progress
 
@@ -18,7 +18,7 @@ Second Action in Progress
 <Progress type="steps" steps={['completed', 'inProgress', 'toDo']} />
 ```
 
-#### ProgressBar with all steps to do
+#### Progress with all steps to do
 
 First Action Ready to Begin
 
@@ -26,7 +26,7 @@ First Action Ready to Begin
 <Progress type="steps" steps={['toDo', 'toDo', 'toDo', 'toDo']} />
 ```
 
-#### Completed ProgressBar example
+#### Completed Progress example
 
 All completed
 
@@ -34,7 +34,7 @@ All completed
 <Progress type="steps" steps={['completed', 'completed']} />
 ```
 
-#### Slim ProgressBar example
+#### Slim Progress example
 
 Second Action in Progress
 
@@ -42,7 +42,7 @@ Second Action in Progress
 <Progress type="steps" slim steps={['completed', 'inProgress', 'toDo']} />
 ```
 
-#### ProgressBar with a single step in progress example
+#### Progress with a single step in progress example
 
 In Progress
 
@@ -50,7 +50,7 @@ In Progress
 <Progress type="steps" steps={['inProgress']} />
 ```
 
-Simple danger ProgressBar example
+Simple danger Progress example
 
 ```jsx
 <div>

--- a/react/components/Spinner/README.md
+++ b/react/components/Spinner/README.md
@@ -14,7 +14,7 @@
 
 ### Related components
 
-- If you can assess the progression of the task prefer a <a href="#/Components/Display/ProgressBar">Progress Bar</a>.
+- If you can assess the progression of the task prefer a <a href="#/Components/Display/Progress">Progress</a>.
 - For whole screen loading try using Skeleton Pages (work in progress).
 
 #### Default


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

In the related components section of the [Spinner documentation](https://styleguide.vtex.com/#/Components/Display/Spinner) there's an outdated link to _ProgressBar_ (which is now called _Progress_). Also, there are references to the old name of the component in its [own docs page](https://styleguide.vtex.com/#/Components/Display/Progress).

#### How should this be manually tested?

`yarn && yarn start`

#### Screenshots or example usage

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Requires change to documentation, which has been updated accordingly.
