### PR TITLE
Fix outline on ButtonGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Dropdown's selected option when value is `undefined`.
+- `ButtonGroup` outline.
 
 ## [9.112.27] - 2020-03-26
 

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -200,6 +200,7 @@ class Button extends Component {
     if (isActiveOfGroup && !disabled) {
       style.backgroundColor = '#0c389f'
       style.borderColor = '#0c389f'
+      style.zIndex = 2
     }
 
     const linkModeProps = {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix outline of ButtonGroup.

#### What problem is this solving?
Underlapping outline.

#### How should this be manually tested?
`yarn styleguide`

#### Screenshots or example usage
Before:
![Screen Shot 2020-04-01 at 18 41 38](https://user-images.githubusercontent.com/2573602/78189649-d2b89180-7448-11ea-8916-e7266de75f48.png)

After:
![Screen Shot 2020-04-01 at 18 41 45](https://user-images.githubusercontent.com/2573602/78189659-d6e4af00-7448-11ea-921f-ac9f782c650e.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
