### PR TITLE
Spread react-select props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `Totalizer` testids.
 - Support for `react-select` custom components
+- Support for `react-select` custom components.
 
 ## [9.112.27] - 2020-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `Totalizer` testids.
+- Support for `react-select` custom components
 
 ## [9.112.27] - 2020-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `Totalizer` testids.
 - Support for `react-select` custom components
-- Support for `react-select` custom components.
 
 ## [9.112.27] - 2020-03-26
 

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -64,6 +64,7 @@ class Select extends Component {
       valuesMaxHeight,
       clearable,
       defaultMenuIsOpen,
+      components,
     } = this.props
 
     const reactSelectComponentProps = {
@@ -90,6 +91,7 @@ class Select extends Component {
         IndicatorSeparator: () => null,
         MultiValueRemove,
         Placeholder,
+        ...components,
       },
       defaultValue,
       formatCreateLabel,
@@ -266,6 +268,8 @@ Select.propTypes = {
   valuesMaxHeight: PropTypes.number,
   /** If its options are initially shown */
   defaultMenuIsOpen: PropTypes.bool,
+  /** Compositional components that are used in react-select. */
+  components: PropTypes.object,
 }
 
 export default withForwardedRef(Select)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow user to customize compositional react-select components (as discussed in the weekly design meeting)

#### What problem is this solving?
In some specific cases, there is a need to customize the react-select compositional components. To allow this, we need to spread the `component` prop received to `react-select`.

Use case: on the new promotions admin, there is a specific select were we just want to show a short version of the label in the option tag.

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
