### PR TITLE
Fix table v2 header click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Totalizer` testids.
 - Support for `react-select` custom components
 
+### Added
+
+- Initial state of `useTableSorting` hook can now be set by its client.
+
 ## [9.112.27] - 2020-03-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Dropdown's selected option when value is `undefined`.
 - `ButtonGroup` outline.
+- Table header should not be clickable.
 
 ### Added
 
 - `Totalizer` testids.
 - Support for `react-select` custom components
-
-### Added
-
 - Initial state of `useTableSorting` hook can now be set by its client.
 
 ## [9.112.27] - 2020-03-26

--- a/react/components/EXPERIMENTAL_Table/Sections/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Row.tsx
@@ -46,11 +46,12 @@ function Row(
     data && isRowActive && isRowActive(data)
       ? { backgroundColor: LIGHT_BLUE }
       : {}
-  const clickable = !isHead && onRowClick
-    ? {
-        onClick: () => onRowClick({ rowData: data }),
-      }
-    : {}
+  const clickable =
+    !isHead && onRowClick
+      ? {
+          onClick: () => onRowClick({ rowData: data }),
+        }
+      : {}
   const style = {
     height,
     ...props.style,
@@ -73,7 +74,7 @@ function Row(
             column,
             motion,
             index,
-            isHead
+            isHead,
           })
         }
 

--- a/react/components/EXPERIMENTAL_Table/Sections/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Row.tsx
@@ -18,18 +18,20 @@ interface RowRenderProps {
   column: Column
   motion: ReturnType<typeof useTableMotion>
   index: number
+  isHead: boolean
 }
 
 interface SpecificProps extends NativeTr {
   height: number
   motion?: ReturnType<typeof useTableMotion>
   data?: unknown
+  isHead?: boolean
 }
 
 type Props = RenderProps<SpecificProps, RowRenderProps>
 
 function Row(
-  { children, motion, data, height, ...props }: Props,
+  { children, motion, data, height, isHead = false, ...props }: Props,
   ref: Ref<HTMLTableRowElement>
 ) {
   const LIGHT_BLUE = '#DBE9FD'
@@ -37,14 +39,14 @@ function Row(
   const { columns } = useDataContext()
   const { highlightOnHover, isRowActive, onRowClick } = useBodyContext()
   const className = classNames('w-100 truncate overflow-x-hidden', {
-    'pointer hover-c-link': onRowClick,
-    'hover-bg-muted-5': highlightOnHover || !!onRowClick,
+    'pointer hover-c-link': !isHead && onRowClick,
+    'hover-bg-muted-5': !isHead && (highlightOnHover || !!onRowClick),
   })
   const rowColor =
     data && isRowActive && isRowActive(data)
       ? { backgroundColor: LIGHT_BLUE }
       : {}
-  const clickable = onRowClick
+  const clickable = !isHead && onRowClick
     ? {
         onClick: () => onRowClick({ rowData: data }),
       }
@@ -71,6 +73,7 @@ function Row(
             column,
             motion,
             index,
+            isHead
           })
         }
 

--- a/react/components/EXPERIMENTAL_Table/Sections/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Row.tsx
@@ -18,20 +18,20 @@ interface RowRenderProps {
   column: Column
   motion: ReturnType<typeof useTableMotion>
   index: number
-  isHead: boolean
+  header: boolean
 }
 
 interface SpecificProps extends NativeTr {
   height: number
   motion?: ReturnType<typeof useTableMotion>
   data?: unknown
-  isHead?: boolean
+  header?: boolean
 }
 
 type Props = RenderProps<SpecificProps, RowRenderProps>
 
 function Row(
-  { children, motion, data, height, isHead = false, ...props }: Props,
+  { children, motion, data, height, header = false, ...props }: Props,
   ref: Ref<HTMLTableRowElement>
 ) {
   const LIGHT_BLUE = '#DBE9FD'
@@ -39,15 +39,15 @@ function Row(
   const { columns } = useDataContext()
   const { highlightOnHover, isRowActive, onRowClick } = useBodyContext()
   const className = classNames('w-100 truncate overflow-x-hidden', {
-    'pointer hover-c-link': !isHead && onRowClick,
-    'hover-bg-muted-5': !isHead && (highlightOnHover || !!onRowClick),
+    'pointer hover-c-link': !header && onRowClick,
+    'hover-bg-muted-5': !header && (highlightOnHover || !!onRowClick),
   })
   const rowColor =
     data && isRowActive && isRowActive(data)
       ? { backgroundColor: LIGHT_BLUE }
       : {}
   const clickable =
-    !isHead && onRowClick
+    !header && onRowClick
       ? {
           onClick: () => onRowClick({ rowData: data }),
         }
@@ -74,7 +74,7 @@ function Row(
             column,
             motion,
             index,
-            isHead,
+            header,
           })
         }
 

--- a/react/components/EXPERIMENTAL_Table/Sections/Thead.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Thead.tsx
@@ -42,7 +42,7 @@ function Thead(
       data-testid={`${testId}__header`}
       className={`w-100 ph4 truncate overflow-x-hidden c-muted-2 f6 ${className}`}
       {...restProps}>
-      <Row height={TABLE_HEADER_HEIGHT} isHead>
+      <Row height={TABLE_HEADER_HEIGHT} header>
         {({ column, props: receivedProps }) => {
           const { id, title, sortable } = column
           const currentlySorting =

--- a/react/components/EXPERIMENTAL_Table/Sections/Thead.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Thead.tsx
@@ -42,7 +42,7 @@ function Thead(
       data-testid={`${testId}__header`}
       className={`w-100 ph4 truncate overflow-x-hidden c-muted-2 f6 ${className}`}
       {...restProps}>
-      <Row height={TABLE_HEADER_HEIGHT}>
+      <Row height={TABLE_HEADER_HEIGHT} isHead>
         {({ column, props: receivedProps }) => {
           const { id, title, sortable } = column
           const currentlySorting =

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableSort.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableSort.ts
@@ -23,13 +23,13 @@ type Action = {
   }
 }
 
-const initialState: State = {
+const clearState: State = {
   by: null,
   order: null,
 }
 
-export default function useTableSort() {
-  const [sorted, dispatch] = useReducer(reducer, initialState)
+export default function useTableSort(initialState?: Partial<State>) {
+  const [sorted, dispatch] = useReducer(reducer, {...clearState, ...initialState})
 
   const sortASC = (id: string) =>
     dispatch({ type: ActionType.SortASC, payload: { id } })
@@ -73,7 +73,7 @@ function reducer(state: State, action: Action) {
       }
     }
     case ActionType.Clear: {
-      return initialState
+      return clearState
     }
     default:
       return state

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableSort.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableSort.ts
@@ -29,7 +29,10 @@ const clearState: State = {
 }
 
 export default function useTableSort(initialState?: Partial<State>) {
-  const [sorted, dispatch] = useReducer(reducer, {...clearState, ...initialState})
+  const [sorted, dispatch] = useReducer(reducer, {
+    ...clearState,
+    ...initialState,
+  })
 
   const sortASC = (id: string) =>
     dispatch({ type: ActionType.SortASC, payload: { id } })


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Remove the onClick event of the `Table V2` header and allow user to set initial sorting state.

#### How should this be manually tested?
Sort the collections by their id:
[workspace](https://sortableid--cosmetics1.myvtex.com/admin/app/collections/)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
