### PR TITLE
Add 'fit' prop to PageBlock and Box components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.113.0] - 2020-04-07
+
 ### Added
 
 - `fit` prop to `PageBlock` and `Box` components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `fill` prop to `PageBlock` and `Box` components.
+- `fit` prop to `PageBlock` and `Box` components.
 
 ## [9.112.28] - 2020-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `fill` prop to `PageBlock` and `Box` components.
+
 ## [9.112.28] - 2020-04-02
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.112.28",
+  "version": "9.113.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.112.28",
+  "version": "9.113.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Box/index.tsx
+++ b/react/components/Box/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import PropTypes, { InferProps } from 'prop-types'
+import classNames from 'classnames'
 
 const propTypes = {
   /** Content of the box */
@@ -8,15 +9,22 @@ const propTypes = {
   noPadding: PropTypes.bool,
   /** Title to the box */
   title: PropTypes.string,
+  /** Defines if the Box should fill the parent element's height and width */
+  fill: PropTypes.bool,
 }
 
 type Props = InferProps<typeof propTypes>
 
-const Box: FC<Props> = ({ children, noPadding, title }) => {
-  const padding = noPadding ? '' : 'pa7'
+const Box: FC<Props> = ({ children, noPadding, title, fill }) => {
+  const boxClasses = classNames(
+    'styleguide__box bg-base t-body c-on-base br3 b--muted-4 ba',
+    {
+      pa7: !noPadding,
+      'h-100 w-100': fill,
+    }
+  )
   return (
-    <div
-      className={`styleguide__box bg-base t-body c-on-base ${padding} br3 b--muted-4 ba`}>
+    <div className={boxClasses}>
       {title && <h3 className="t-heading-4 mt0">{title}</h3>}
       {children}
     </div>
@@ -24,5 +32,8 @@ const Box: FC<Props> = ({ children, noPadding, title }) => {
 }
 
 Box.propTypes = propTypes
+Box.defaultProps = {
+  fill: false,
+}
 
 export default Box

--- a/react/components/Box/index.tsx
+++ b/react/components/Box/index.tsx
@@ -9,18 +9,19 @@ const propTypes = {
   noPadding: PropTypes.bool,
   /** Title to the box */
   title: PropTypes.string,
-  /** Defines if the Box should fill the parent element's height and width */
-  fill: PropTypes.bool,
+  /** Defines if and how the Box should fit the parent element */
+  fit: PropTypes.oneOf(['fill', 'fill-horizontal', 'fill-vertical', 'none']),
 }
 
 type Props = InferProps<typeof propTypes>
 
-const Box: FC<Props> = ({ children, noPadding, title, fill }) => {
+const Box: FC<Props> = ({ children, noPadding, title, fit }) => {
   const boxClasses = classNames(
     'styleguide__box bg-base t-body c-on-base br3 b--muted-4 ba',
     {
       pa7: !noPadding,
-      'h-100 w-100': fill,
+      'h-100': ['fill', 'fill-vertical'].includes(fit),
+      'w-100': ['fill', 'fill-horizontal'].includes(fit),
     }
   )
   return (
@@ -33,7 +34,7 @@ const Box: FC<Props> = ({ children, noPadding, title, fill }) => {
 
 Box.propTypes = propTypes
 Box.defaultProps = {
-  fill: false,
+  fit: 'none',
 }
 
 export default Box

--- a/react/components/PageBlock/index.js
+++ b/react/components/PageBlock/index.js
@@ -12,7 +12,8 @@ class PageBlock extends Component {
       variation,
       titleAside,
       testId,
-      boxProps,
+      boxProps: receivedBoxProps,
+      fill,
     } = this.props
     const isAnnotated = variation === 'annotated'
 
@@ -22,15 +23,35 @@ class PageBlock extends Component {
       'flex flex-column': isAnnotated && titleAside,
     })
 
-    let titleClasses = 'styleguide__pageBlock_title t-heading-3 mb3 ml5 ml3-ns '
-    titleClasses += titleAside ? 'mt0' : 'mt4'
+    const titleClasses = classNames(
+      'styleguide__pageBlock_title t-heading-3 mb3 ml5 ml3-ns',
+      {
+        mt0: titleAside,
+        mt4: !titleAside,
+      }
+    )
+
+    const containerClasses = classNames('styleguide__pageBlock flex', {
+      'flex-row': isAnnotated,
+      'flex-column': !isAnnotated,
+      'h-100 w-100': fill,
+    })
+
+    const boxesContainerClasses = classNames(
+      'flex flex-column flex-row-ns mb5-ns',
+      {
+        'w-two-thirds': isAnnotated,
+        'w-100 h-100': !isAnnotated && fill,
+      }
+    )
+
+    const boxProps = {
+      fill,
+      ...receivedBoxProps,
+    }
 
     return (
-      <div
-        className={`styleguide__pageBlock flex ${
-          isAnnotated ? 'flex-row' : 'flex-column'
-        }`}
-        data-testid={testId}>
+      <div className={containerClasses} data-testid={testId}>
         {/* Title, subtitle & aside */}
         {(title || subtitle) && (
           <div className={headerClasses}>
@@ -51,9 +72,7 @@ class PageBlock extends Component {
         )}
 
         {/* Boxes and the content itself */}
-        <div
-          className={`flex flex-column flex-row-ns ${isAnnotated &&
-            'w-two-thirds'}`}>
+        <div className={boxesContainerClasses}>
           {variation === 'half' ? (
             <Fragment>
               <div className="w-50-ns w-100 mr3-ns mb0-ns mb5">
@@ -61,7 +80,7 @@ class PageBlock extends Component {
                   {this.props.children && this.props.children[0]}
                 </Box>
               </div>
-              <div className="w-50-ns w-100 ml3-ns mb5">
+              <div className="w-50-ns w-100 ml3-ns mb0-ns mb5">
                 <Box {...boxProps}>
                   {this.props.children && this.props.children[1]}
                 </Box>
@@ -74,14 +93,14 @@ class PageBlock extends Component {
                   {this.props.children && this.props.children[0]}
                 </Box>
               </div>
-              <div className="w-third-ns w-100 ml3-ns mb5">
+              <div className="w-third-ns w-100 ml3-ns mb0-ns mb5">
                 <Box {...boxProps}>
                   {this.props.children && this.props.children[1]}
                 </Box>
               </div>
             </Fragment>
           ) : (
-            <div className="w-100 mb5">
+            <div className="w-100 mb0-ns mb5">
               <Box {...boxProps}>{this.props.children}</Box>
             </div>
           )}
@@ -93,6 +112,7 @@ class PageBlock extends Component {
 
 PageBlock.defaultProps = {
   variation: 'full',
+  fill: false,
 }
 
 PageBlock.propTypes = {
@@ -134,10 +154,13 @@ PageBlock.propTypes = {
       )
     }
   },
+  /** Box component props */
   boxProps: PropTypes.shape({
     noPadding: PropTypes.bool,
     title: PropTypes.string,
   }),
+  /** Determines if the PageBlock should fill the parent's element dimensions */
+  fill: PropTypes.bool,
 }
 
 export default PageBlock

--- a/react/components/PageBlock/index.js
+++ b/react/components/PageBlock/index.js
@@ -13,7 +13,7 @@ class PageBlock extends Component {
       titleAside,
       testId,
       boxProps: receivedBoxProps,
-      fill,
+      fit,
     } = this.props
     const isAnnotated = variation === 'annotated'
 
@@ -34,19 +34,20 @@ class PageBlock extends Component {
     const containerClasses = classNames('styleguide__pageBlock flex', {
       'flex-row': isAnnotated,
       'flex-column': !isAnnotated,
-      'h-100 w-100': fill,
+      'h-100': ['fill', 'fill-vertical'].includes(fit),
+      'w-100': ['fill', 'fill-horizontal'].includes(fit),
     })
 
     const boxesContainerClasses = classNames(
       'flex flex-column flex-row-ns mb5-ns',
       {
         'w-two-thirds': isAnnotated,
-        'w-100 h-100': !isAnnotated && fill,
+        'h-100': ['fill', 'fill-vertical'].includes(fit),
       }
     )
 
     const boxProps = {
-      fill,
+      fit,
       ...receivedBoxProps,
     }
 
@@ -112,7 +113,7 @@ class PageBlock extends Component {
 
 PageBlock.defaultProps = {
   variation: 'full',
-  fill: false,
+  fit: 'none',
 }
 
 PageBlock.propTypes = {
@@ -159,8 +160,8 @@ PageBlock.propTypes = {
     noPadding: PropTypes.bool,
     title: PropTypes.string,
   }),
-  /** Determines if the PageBlock should fill the parent's element dimensions */
-  fill: PropTypes.bool,
+  /** Determines if and how the PageBlock should fit the parent's element dimensions */
+  fit: PropTypes.oneOf(['fill', 'fill-horizontal', 'fill-vertical', 'none']),
 }
 
 export default PageBlock


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says... Fixes #1147 

#### What problem is this solving?

[Running workspace](https://refact--madeirasgasometro.myvtex.com/admin/app/vtexlog/reports/performance?month=1&quarter=false). You can see the boxes have the same height.

#### Screenshots or example usage

##### Before

![image](https://user-images.githubusercontent.com/15948386/78683809-218d7d80-78c6-11ea-9a99-9bdd996efb54.png)

##### After

![image](https://user-images.githubusercontent.com/15948386/78692098-c95b7900-78cf-11ea-9559-0f50d6be1880.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
