### PR TITLE
Conditions layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for `react-select` custom components
 - Initial state of `useTableSorting` hook can now be set by its client.
 
+### Changed
+
+- Condition's statement layout for long inputs
+
 ## [9.112.27] - 2020-03-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Condition's statement layout for long inputs
+
 ## [9.113.0] - 2020-04-07
 
 ### Added
@@ -26,10 +30,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Totalizer` testids.
 - Support for `react-select` custom components
 - Initial state of `useTableSorting` hook can now be set by its client.
-
-### Changed
-
-- Condition's statement layout for long inputs
 
 ## [9.112.27] - 2020-03-26
 

--- a/react/components/Conditions/index.tsx
+++ b/react/components/Conditions/index.tsx
@@ -101,7 +101,7 @@ const Conditions: React.FC<Props> = ({
         </div>
       )}
 
-      <div className="t-body c-on-base ph5 mt4 br3 b--muted-4 ba">
+      <div className="t-body c-on-base ph5 pt3 mt4 br3 b--muted-4 ba">
         {statements.length === 0 ? (
           <div className="flex-grow-1 mv6">
             <Statement
@@ -153,7 +153,7 @@ const Conditions: React.FC<Props> = ({
                   (!isFullWidth ? (
                     <div
                       key="2"
-                      className="ma3 c-muted-2 pointer hover-c-danger"
+                      className="mh3 pb3 c-muted-2 pointer hover-c-danger"
                       onClick={() => handleRemoveStatement(statementIndex)}>
                       <IconClose size={25} />
                     </div>

--- a/react/components/Statement/Atoms/ObjectAtom.tsx
+++ b/react/components/Statement/Atoms/ObjectAtom.tsx
@@ -24,7 +24,7 @@ type Props = {
 }
 
 const EmptyObjectAtom = () => (
-  <div className="flex-auto mh3">
+  <div className="flex-auto mh3 pb3">
     <Input disabled />
   </div>
 )
@@ -41,7 +41,7 @@ const ObjectAtom: React.FC<Props> = ({
   }
 
   return (
-    <div className="mh3 flex-auto">
+    <div className="flex-auto mh3 pb3">
       {renderObject({
         error,
         onChange,

--- a/react/components/Statement/Atoms/SubjectAtom.tsx
+++ b/react/components/Statement/Atoms/SubjectAtom.tsx
@@ -78,9 +78,7 @@ const SubjectAtom: React.FC<Props> = ({
   }, undefined)
 
   return (
-    <div
-      className={`mh3 ${isFullWidth ? 'pb3' : ''}`}
-      style={{ minWidth: ATOM_COMPONENT_MIN_WIDTH }}>
+    <div className="mh3 pb3" style={{ minWidth: ATOM_COMPONENT_MIN_WIDTH }}>
       <Select
         clearable={false}
         multi={false}

--- a/react/components/Statement/Atoms/SubjectAtom.tsx
+++ b/react/components/Statement/Atoms/SubjectAtom.tsx
@@ -20,7 +20,6 @@ type Props = {
   onChange: (string) => void
   options: SubjectOptions
   placeholder: string
-  isFullWidth: boolean
 }
 
 const groupOptions = options => {
@@ -50,7 +49,6 @@ const groupOptions = options => {
 }
 
 const SubjectAtom: React.FC<Props> = ({
-  isFullWidth,
   onChange,
   options,
   placeholder,

--- a/react/components/Statement/Atoms/VerbAtom.tsx
+++ b/react/components/Statement/Atoms/VerbAtom.tsx
@@ -28,7 +28,7 @@ const VerbAtom: React.FC<Props> = ({
 
   return (
     <div
-      className={`mh3 ${isFullWidth ? 'pb3' : ''} flex items-center`}
+      className="mh3 pb3 flex items-center"
       style={verbOptions.length !== 1 ? { minWidth: '20%' } : {}}>
       {verbOptions.length !== 1 ? (
         <div className="flex-auto">

--- a/react/components/Statement/Atoms/VerbAtom.tsx
+++ b/react/components/Statement/Atoms/VerbAtom.tsx
@@ -41,7 +41,7 @@ const VerbAtom: React.FC<Props> = ({
           />
         </div>
       ) : (
-        <span>{value.label}</span>
+        <span className="pt3">{value.label}</span>
       )}
     </div>
   )

--- a/react/components/Statement/Atoms/VerbAtom.tsx
+++ b/react/components/Statement/Atoms/VerbAtom.tsx
@@ -11,7 +11,6 @@ export type VerbOption = {
 
 type Props = {
   disabled?: boolean
-  isFullWidth?: boolean
   verb?: string
   verbOptions: VerbOption[]
   onChange: (string) => void
@@ -19,7 +18,6 @@ type Props = {
 
 const VerbAtom: React.FC<Props> = ({
   disabled,
-  isFullWidth,
   onChange,
   verb,
   verbOptions,

--- a/react/components/Statement/index.tsx
+++ b/react/components/Statement/index.tsx
@@ -91,7 +91,7 @@ const Statement: React.FC<Props> = ({
   return (
     <div className="flex-column w-100 mv6 mv3-ns">
       <div
-        className={`flex w-100 items-start ${
+        className={`flex items-start flex-wrap ${
           isFullWidth ? 'flex-column items-stretch' : ''
         }`}>
         {isRtl ? statementAtoms.reverse() : statementAtoms}

--- a/react/components/Statement/index.tsx
+++ b/react/components/Statement/index.tsx
@@ -37,7 +37,6 @@ const Statement: React.FC<Props> = ({
     !omitSubject && (
       <SubjectAtom
         key="subject"
-        isFullWidth={isFullWidth}
         onChange={subject => {
           const newStatement = {
             ...statement,
@@ -57,7 +56,6 @@ const Statement: React.FC<Props> = ({
       <VerbAtom
         key="verb"
         disabled={!statement.subject}
-        isFullWidth={isFullWidth}
         onChange={verb => {
           const newStatement = {
             ...statement,


### PR DESCRIPTION
#### What is the purpose of this pull request?
To enhance Conditions component layout with long object inputs.
In a scenario where the object component is a MultiSelect, for example, it is usually hard to show more then 2 or 3 options without having some scrollbars

![image](https://user-images.githubusercontent.com/5256673/78690054-5d781100-78cd-11ea-9042-c7bf9ba847d0.png)
or some other small troubles 😝 
![image](https://user-images.githubusercontent.com/5256673/78690061-5f41d480-78cd-11ea-828a-b547c88c84fd.png)

As previously discussed in the design meeting, it was agreed that wrap components could be a god solution.
I've also made some margin/padding adjustments to keep consistency.

#### What problem is this solving?
As described before.

#### How should this be manually tested?
[Running workspace](https://vlauxtst--sandboxintegracao.myvtex.com/admin/promotions/new/)
Select "Price Effect"
Affected Items -> Specific Products
And there you see the conditions component.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5256673/78690674-248c6c00-78ce-11ea-9851-5c12b735cb76.png)

Using Styleguidist (docs) example
![image](https://user-images.githubusercontent.com/5256673/78690803-4ede2980-78ce-11ea-847d-9bc611c37590.png)


#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
