### PR TITLE
fix: 🐛 padding on the last item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Spacing of last item in RadioGroup.
+
 ## [9.113.1] - 2020-04-09
 
 ### Changed

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -60,7 +60,7 @@ class RadioGroup extends React.Component {
                     borderBottomRightRadius: 0,
                   }),
                 }}>
-                <div className={classNames({ mt3: !hideBorder })}>
+                <div className={classNames({ mv3: !hideBorder })}>
                   <Radio
                     id={id}
                     isLast={isLast}


### PR DESCRIPTION
✅ Closes: #1159

#### What is the purpose of this pull request?

add padding on the last item

#### What problem is this solving?
[Running workspace](http://styleguide.vtex.com/#/Components/Forms/RadioGroup)


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
