### PR TITLE
fix: 🐛 using indeterminate on checkbox when partial true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Spacing of last item in RadioGroup.
 - `Dropdown` duplicate optgroup with `preventTruncate` option.
+- Using indeterminate on checkbox when partial true
 
 ## [9.113.1] - 2020-04-09
 

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -7,6 +7,24 @@ import CheckPartial from '../icon/CheckPartial'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
 
 class Checkbox extends PureComponent {
+  constructor(props) {
+    super(props)
+    this.myCheckbox = React.createRef()
+  }
+
+  componentDidMount() {
+    this.myCheckbox.indeterminate = !this.props.checked && this.props.partial
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.partial !== this.props.partial ||
+      prevProps.checked !== this.props.checked
+    ) {
+      this.myCheckbox.indeterminate = !this.props.checked && this.props.partial
+    }
+  }
+
   handleChange = e =>
     this.props.onChange
       ? !this.props.disabled && this.props.onChange(e)
@@ -80,7 +98,7 @@ class Checkbox extends PureComponent {
           <input
             checked={checked}
             ref={elem => {
-              elem && (elem.indeterminate = !checked && partial)
+              elem && (this.myCheckbox = elem)
               forwardedRef && (forwardedRef.current = elem)
             }}
             className={classNames('h1 w1 absolute o-0', {

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -79,7 +79,10 @@ class Checkbox extends PureComponent {
           </div>
           <input
             checked={checked}
-            ref={forwardedRef}
+            ref={elem => {
+              elem && (elem.indeterminate = !checked && partial)
+              forwardedRef && (forwardedRef.current = elem)
+            }}
             className={classNames('h1 w1 absolute o-0', {
               pointer: !disabled,
             })}


### PR DESCRIPTION
#### What is the purpose of this pull request?

add value to indeterminate attribute

#### What problem is this solving?

✅ Closes: #1146

#### How should this be manually tested?

add this code on sandbox in the styleguide docs site

```js
class CheckboxWithRef extends React.Component {
  constructor() {
    super(); 
    this.state = { checked: false };
    this.reference = React.createRef();
  }

  render() {
    window.REFC = this.reference

    return (
    <Checkbox
      checked={this.state.checked}
      partial
      id="option-partial"
      label="Partial"
      ref={this.reference}
      name="default-checkbox-group"
      onChange={e => this.setState({ checked: !this.state.checked })}
      value="option-partial"
    />
    )
  }
}

;<CheckboxWithRef />
```

You can find element like this:

```js
t = document.querySelector("#option-partial")
t.indeterminate
// true
```

or using ref

```js
window.REFC.current.indeterminate
// true
```

#### Screenshots or example usage
<img width="958" alt="Screen Shot 2020-04-13 at 18 59 25" src="https://user-images.githubusercontent.com/10627086/79165152-e8b74200-7db8-11ea-994a-f4f745b77698.png">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
