### PR TITLE
Feature/ Allow units multiplier in numeric stepper component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,9 +9,6 @@
         "ignore": ["^([a-zA-Z@]+[-\\.]?)+"]
       }
     ],
-    "prettier/prettier": ["error", {
-      "endOfLine":"auto"
-    }],
     // Rules that conflict with Prettier.
     // To verify conflicting rules, run:
     // $ npm run prettier-conflict-check

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,9 @@
         "ignore": ["^([a-zA-Z@]+[-\\.]?)+"]
       }
     ],
+    "prettier/prettier": ["error", {
+      "endOfLine":"auto"
+    }],
     // Rules that conflict with Prettier.
     // To verify conflicting rules, run:
     // $ npm run prettier-conflict-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- `AutoCompleteInput` custom render example 
+- `AutoCompleteInput` custom render example.
+
+### Added
+
+- `unitMultiplier`, `measurementUnit`, and `showMeasurementUnit` props.
+- Format display value with multiplier.
 
 ## [9.113.2] - 2020-04-16
 

--- a/react/components/NumericStepper/README.md
+++ b/react/components/NumericStepper/README.md
@@ -78,6 +78,34 @@ initialState = {
 </React.Fragment>
 ```
 
+Suffix and unit multiplier
+
+```js
+initialState = {
+  value1: 1,
+  value2: 2,
+}
+;<React.Fragment>
+  <div className="mb5">
+    <NumericStepper
+      label="Suffix"
+      value={state.value1}
+      suffix="kg"
+      onChange={event => setState({ value1: event.value })}
+    />
+  </div>
+  <div className="mb5">
+    <NumericStepper
+      label="Suffix and unit multiplier of 2.2"
+      unitMultiplier={2.2}
+      suffix="m²"
+      value={state.value2}
+      onChange={event => setState({ value2: event.value })}
+    />
+  </div>
+</React.Fragment>
+```
+
 Styling
 
 ```js

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -25,11 +25,24 @@ const validateValue = (value, min, max, defaultValue) => {
   return parseInt(value, 10)
 }
 
-const formattedDisplayValue = (value, unitMultiplier, showMeasurementUnit, measurementUnit) => {
-  return `${Math.round((value * unitMultiplier + Number.EPSILON) * 100) / 100} ${showMeasurementUnit ? measurementUnit : ''}`
+const formattedDisplayValue = (
+  value,
+  unitMultiplier,
+  showMeasurementUnit,
+  measurementUnit
+) => {
+  return `${Math.round((value * unitMultiplier + Number.EPSILON) * 100) /
+    100} ${showMeasurementUnit ? measurementUnit : ''}`
 }
 
-const validateDisplayValue = (value, min, max, showMeasurementUnit, measurementUnit, unitMultiplier) => {
+const validateDisplayValue = (
+  value,
+  min,
+  max,
+  showMeasurementUnit,
+  measurementUnit,
+  unitMultiplier
+) => {
   // This function validates the input as the user types
   // It allows for temporarily invalid values (namely, empty string and minus sign without a number following it)
   // However, it prevents values out of boundaries, and invalid characters, e.g. letters
@@ -40,11 +53,21 @@ const validateDisplayValue = (value, min, max, showMeasurementUnit, measurementU
   const parsedValue = parseFloat(value)
 
   if (value === '') {
-    return formattedDisplayValue(value, unitMultiplier, showMeasurementUnit, measurementUnit)
+    return formattedDisplayValue(
+      value,
+      unitMultiplier,
+      showMeasurementUnit,
+      measurementUnit
+    )
   }
   // Only allows typing the negative sign if negative values are allowed
   if (value === '-' && min < 0) {
-    return formattedDisplayValue(value, unitMultiplier, showMeasurementUnit, measurementUnit)
+    return formattedDisplayValue(
+      value,
+      unitMultiplier,
+      showMeasurementUnit,
+      measurementUnit
+    )
   }
   if (isNaN(parsedValue)) {
     return ''
@@ -52,12 +75,27 @@ const validateDisplayValue = (value, min, max, showMeasurementUnit, measurementU
   // Only limit by lower bounds if the min value is 1
   // Otherwise, it could prevent typing, for example, 10 if the min value is 2
   if (parsedValue < min && min === 1) {
-    return formattedDisplayValue(min, unitMultiplier, showMeasurementUnit, measurementUnit)
+    return formattedDisplayValue(
+      min,
+      unitMultiplier,
+      showMeasurementUnit,
+      measurementUnit
+    )
   }
   if (parsedValue > max) {
-    return formattedDisplayValue(max, unitMultiplier, showMeasurementUnit, measurementUnit)
+    return formattedDisplayValue(
+      max,
+      unitMultiplier,
+      showMeasurementUnit,
+      measurementUnit
+    )
   }
-  return formattedDisplayValue(parsedValue, unitMultiplier, showMeasurementUnit, measurementUnit)
+  return formattedDisplayValue(
+    parsedValue,
+    unitMultiplier,
+    showMeasurementUnit,
+    measurementUnit
+  )
 }
 
 class NumericStepper extends Component {
@@ -78,7 +116,15 @@ class NumericStepper extends Component {
   }
 
   static getDerivedStateFromProps(props, state) {
-    const { value, minValue, maxValue, defaultValue, showMeasurementUnit, measurementUnit, unitMultiplier } = props
+    const {
+      value,
+      minValue,
+      maxValue,
+      defaultValue,
+      showMeasurementUnit,
+      measurementUnit,
+      unitMultiplier,
+    } = props
 
     const validatedValue = validateValue(
       value,
@@ -90,7 +136,14 @@ class NumericStepper extends Component {
     return {
       value: validatedValue,
       ...(!state.inputFocused && {
-        displayValue: validateDisplayValue(value, minValue, maxValue, showMeasurementUnit, measurementUnit, unitMultiplier),
+        displayValue: validateDisplayValue(
+          value,
+          minValue,
+          maxValue,
+          showMeasurementUnit,
+          measurementUnit,
+          unitMultiplier
+        ),
       }),
     }
   }
@@ -99,7 +152,15 @@ class NumericStepper extends Component {
     const parsedValue = parseInt(value, 10)
     // const parsedValue = parseFloat(value)
 
-    const { minValue, maxValue, defaultValue, onChange, showMeasurementUnit, measurementUnit, unitMultiplier } = this.props
+    const {
+      minValue,
+      maxValue,
+      defaultValue,
+      onChange,
+      showMeasurementUnit,
+      measurementUnit,
+      unitMultiplier,
+    } = this.props
 
     const validatedValue = validateValue(
       parsedValue,
@@ -108,7 +169,14 @@ class NumericStepper extends Component {
       defaultValue
     )
 
-    const displayValue = validateDisplayValue(value, minValue, maxValue, showMeasurementUnit, measurementUnit, unitMultiplier)
+    const displayValue = validateDisplayValue(
+      value,
+      minValue,
+      maxValue,
+      showMeasurementUnit,
+      measurementUnit,
+      unitMultiplier
+    )
 
     this.setState({
       value: validatedValue,

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -48,7 +48,7 @@ const validateDisplayValue = (
 
   min = normalizeMin(min)
   max = normalizeMax(max)
-  // const parsedValue = parseInt(value, 10)
+  
   const parsedValue = parseFloat(value)
 
   if (value === '') {

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -24,49 +24,27 @@ const validateValue = (value, min, max, defaultValue) => {
   return parseInt(value, 10)
 }
 
-const formattedDisplayValue = (
-  value,
-  unitMultiplier,
-  showMeasurementUnit,
-  measurementUnit
-) => {
+const formattedDisplayValue = (value, unitMultiplier, suffix) => {
   return `${Math.round((value * unitMultiplier + Number.EPSILON) * 100) /
-    100} ${showMeasurementUnit ? measurementUnit : ''}`
+    100} ${suffix ? suffix : ''}`
 }
 
-const validateDisplayValue = (
-  value,
-  min,
-  max,
-  showMeasurementUnit,
-  measurementUnit,
-  unitMultiplier
-) => {
+const validateDisplayValue = (value, min, max, suffix, unitMultiplier) => {
   // This function validates the input as the user types
   // It allows for temporarily invalid values (namely, empty string and minus sign without a number following it)
   // However, it prevents values out of boundaries, and invalid characters, e.g. letters
 
   min = normalizeMin(min)
   max = normalizeMax(max)
-  
+
   const parsedValue = parseFloat(value)
 
   if (value === '') {
-    return formattedDisplayValue(
-      value,
-      unitMultiplier,
-      showMeasurementUnit,
-      measurementUnit
-    )
+    return formattedDisplayValue(value, unitMultiplier, suffix)
   }
   // Only allows typing the negative sign if negative values are allowed
   if (value === '-' && min < 0) {
-    return formattedDisplayValue(
-      value,
-      unitMultiplier,
-      showMeasurementUnit,
-      measurementUnit
-    )
+    return formattedDisplayValue(value, unitMultiplier, suffix)
   }
   if (isNaN(parsedValue)) {
     return ''
@@ -74,27 +52,12 @@ const validateDisplayValue = (
   // Only limit by lower bounds if the min value is 1
   // Otherwise, it could prevent typing, for example, 10 if the min value is 2
   if (parsedValue < min && min === 1) {
-    return formattedDisplayValue(
-      min,
-      unitMultiplier,
-      showMeasurementUnit,
-      measurementUnit
-    )
+    return formattedDisplayValue(min, unitMultiplier, suffix)
   }
   if (parsedValue > max) {
-    return formattedDisplayValue(
-      max,
-      unitMultiplier,
-      showMeasurementUnit,
-      measurementUnit
-    )
+    return formattedDisplayValue(max, unitMultiplier, suffix)
   }
-  return formattedDisplayValue(
-    parsedValue,
-    unitMultiplier,
-    showMeasurementUnit,
-    measurementUnit
-  )
+  return formattedDisplayValue(parsedValue, unitMultiplier, suffix)
 }
 
 class NumericStepper extends Component {
@@ -120,8 +83,7 @@ class NumericStepper extends Component {
       minValue,
       maxValue,
       defaultValue,
-      showMeasurementUnit,
-      measurementUnit,
+      suffix,
       unitMultiplier,
     } = props
 
@@ -139,8 +101,7 @@ class NumericStepper extends Component {
           value,
           minValue,
           maxValue,
-          showMeasurementUnit,
-          measurementUnit,
+          suffix,
           unitMultiplier
         ),
       }),
@@ -155,8 +116,7 @@ class NumericStepper extends Component {
       maxValue,
       defaultValue,
       onChange,
-      showMeasurementUnit,
-      measurementUnit,
+      suffix,
       unitMultiplier,
     } = this.props
 
@@ -171,8 +131,7 @@ class NumericStepper extends Component {
       value,
       minValue,
       maxValue,
-      showMeasurementUnit,
-      measurementUnit,
+      suffix,
       unitMultiplier
     )
 
@@ -391,10 +350,8 @@ NumericStepper.propTypes = {
   defaultValue: PropTypes.number,
   /** Multiplier value (e.g 1, 0.3) */
   unitMultiplier: PropTypes.number,
-  /** measurementUnit (e.g Kg, un) */
-  measurementUnit: PropTypes.string,
-  /** Show unit unitMultiplier label. Default is false */
-  showMeasurementUnit: PropTypes.bool,
+  /** Suffix (e.g Kg, un) */
+  suffix: PropTypes.string,
   /** Makes input readonly and disables buttons */
   readOnly: PropTypes.bool,
   /** Input size */
@@ -412,8 +369,7 @@ NumericStepper.defaultProps = {
   maxValue: Infinity,
   defaultValue: 0,
   unitMultiplier: 1,
-  measurementUnit: '',
-  showMeasurementUnit: false,
+  suffix: '',
   readOnly: false,
   size: 'regular',
   block: false,

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -149,7 +149,6 @@ class NumericStepper extends Component {
 
   changeValue = (value, event) => {
     const parsedValue = parseInt(value, 10)
-    // const parsedValue = parseFloat(value)
 
     const {
       minValue,

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -26,7 +26,7 @@ const validateValue = (value, min, max, defaultValue) => {
 }
 
 const formattedDisplayValue = (value, unitMultiplier, showMeasurementUnit, measurementUnit) => {
-  return `${(Math.round(((value * unitMultiplier) + Number.EPSILON) * 100) / 100)} ${showMeasurementUnit ? measurementUnit : ''}`
+  return `${Math.round((value * unitMultiplier + Number.EPSILON) * 100) / 100} ${showMeasurementUnit ? measurementUnit : ''}`
 }
 
 const validateDisplayValue = (value, min, max, showMeasurementUnit, measurementUnit, unitMultiplier) => {

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -21,7 +21,6 @@ const validateValue = (value, min, max, defaultValue) => {
   } else if (value > max) {
     return max
   }
-  // return parseFloat(value)
   return parseInt(value, 10)
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This allow to use the unitMultiplier and measurementUnit fields in the product quantity

<!--- Describe your changes in detail. -->
I added the following new properties to the Numeric Stepper component:
unitMultiplier: number (e.g: 0.3)
measurementUnit: string (e.g: Kg)
showMeasurementUnit: boolean (e.g: true)

And then, I formatted the displayValue in the input tag

#### What problem is this solving?
This allow to use the unitMultiplier and measurementUnit fields in the product quantity

[Running workspace](https://multiplier--cbyio.myvtex.com/)

<!--- What is the motivation and context for this change? -->
Most markets need this feature to sell in different units

#### How should this be manually tested?
Link this code version and use it in a store that has different multipliers. I maked another pull request in the product-quantity component: https://github.com/vtex-apps/product-quantity/pull/15
Link these two code and manually test

#### Screenshots or example usage
![Captura de Tela 2020-04-20 às 21 03 18](https://user-images.githubusercontent.com/38638226/79819785-1d9b3a00-8361-11ea-9c7b-0adb78092264.png)
![Captura de Tela 2020-04-20 às 22 51 07](https://user-images.githubusercontent.com/38638226/79819788-1e33d080-8361-11ea-9abf-cd3add129bfb.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
