### PR TITLE
Fix autocomplete input custom option example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `AutoCompleteInput` custom render example 
+
 ## [9.113.2] - 2020-04-16
 
 ### Fixed

--- a/react/components/AutocompleteInput/README.md
+++ b/react/components/AutocompleteInput/README.md
@@ -152,7 +152,7 @@ const allUsers = [
 ]
 
 const CustomOption = props => {
-  const { roundedBottom, searchTerm, value, key, selected, onClick } = props
+  const { roundedBottom, searchTerm, value, selected, onClick } = props
   const [highlightOption, setHighlightOption] = useState(false)
 
   const renderOptionHighlightedText = () => {
@@ -184,7 +184,6 @@ const CustomOption = props => {
   // --- This is a good practice. Use <button />.
   return (
     <button
-      key={key}
       className={buttonClasses}
       onFocus={() => setHighlightOption(true)}
       onMouseEnter={() => setHighlightOption(true)}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the example in our style guide page

#### What problem is this solving?

The code snippet showing how to create a custom component to render the autocomplete input options it's passing down a useless prop to the `<button/>` component and showing a warning on browser console when used.

#### How should this be manually tested?

Check [here](https://github.com/vtex/styleguide/tree/1eed4dd68607760c035e7883160e2f722245d0d1/react/components/AutocompleteInput) under the section `Custom option rendering`.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/36630479/80024833-0883ef80-84b6-11ea-877b-847fb15d8260.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.