### PR TITLE
Remove ActionMenu and Menu default fixed width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- `ActionMenu` and `Menu` default fixed width.
+
 ## [9.114.0] - 2020-04-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `AutoCompleteInput` custom render example.
+- `ActionMenu` fixed width.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `AutoCompleteInput` custom render example.
-- `ActionMenu` fixed width.
 
 ### Added
 

--- a/react/components/ActionMenu/index.js
+++ b/react/components/ActionMenu/index.js
@@ -118,7 +118,6 @@ ActionMenu.defaultProps = {
   options: [],
   align: 'right',
   hideCaretIcon: false,
-  menuWidth: 292,
   shouldCloseOnClick: true,
   isGrouped: false,
   isFirstOfGroup: false,

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -5,7 +5,6 @@ import { Overlay } from 'react-overlays'
 import Toggle from '../Toggle'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
 
-const DEFAULT_WIDTH = 292
 const CONTAINER_MARGIN = 6
 const WINDOW_MARGIN = 10
 const DEFAULT_DOCUMENT_ELEMENT = {
@@ -152,7 +151,7 @@ class Menu extends Component {
                   [isRight ? 'right' : 'left']: isRight
                     ? clientWidth - right
                     : left + scrollLeft,
-                  width: width || DEFAULT_WIDTH,
+                  width,
                 }}
                 className={`absolute z-999 ba b--muted-4 br2 shadow-5 ${
                   isRight ? 'right-0' : 'left-0'

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -213,7 +213,7 @@ Menu.propTypes = {
   forwardedRef: refShape,
   /** Menu visibility (default is false) */
   open: PropTypes.bool,
-  /** Menu Box width (default is 292px) */
+  /** Menu Box width */
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Menu options */
   options: PropTypes.arrayOf(


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, these components have fixed default widths and that's not good at all.

#### What problem is this solving?

When all menu options have smaller widths than the default, the menu is weird.

#### How should this be manually tested?

[Running workspace](https://logistics--ambienteqa.myvtex.com/admin/shipping-strategy/warehouses/)

#### Screenshots or example usage

##### Before

![image](https://user-images.githubusercontent.com/15948386/80493202-79565c00-893b-11ea-9857-1dd17c5384df.png)


##### After

![image](https://user-images.githubusercontent.com/15948386/80493097-5461e900-893b-11ea-98e0-bdc67a35f473.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
