### PR TITLE
Fix bug when trying to modify the entry when an option is selected in AutocompleteInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Update input value when I try to update with an option selected in the `AutocompleteInput` component
+
+### Fixed
+
 - `AutoCompleteInput` custom render example.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Update input value when I try to update with an option selected in the `AutocompleteInput` component
+- Value when user tries to update with an option selected in the `AutocompleteInput` component
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Value when user tries to update with an option selected in the `AutocompleteInput` component
-
 - `AutoCompleteInput` custom render example.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Value when user tries to update with an option selected in the `AutocompleteInput` component
 
-### Fixed
-
 - `AutoCompleteInput` custom render example.
 
 ### Added

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -146,11 +146,11 @@ const AutocompleteInput: React.FunctionComponent<PropTypes.InferProps<
     if (onChange) {
       onChange(newTerm)
     }
-    setSelectedOptionIndex(-1)
+    setSelectedOptionIndex(noSelectedOptionIndex)
   }
 
   const handleClear = () => {
-    setSelectedOptionIndex(-1)
+    setSelectedOptionIndex(noSelectedOptionIndex)
     setShowPopover(false)
 
     setTerm('')

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -146,9 +146,11 @@ const AutocompleteInput: React.FunctionComponent<PropTypes.InferProps<
     if (onChange) {
       onChange(newTerm)
     }
+    setSelectedOptionIndex(-1)
   }
 
   const handleClear = () => {
+    setSelectedOptionIndex(-1)
     setShowPopover(false)
 
     setTerm('')


### PR DESCRIPTION
#### What is the purpose of this pull request?
When one of the autocomplete options is selected, you cannot modify the entry term. This is because the input value varies between the term and the option, depending on the index of the option list, which was not being changed when a modification was made.

#### What problem is this solving?
To see the problem do [workspace](https://styleguidebefore--cosmetics1.myvtex.com/admin/collections/):
  1) Click on the input box;
  2) Type something or just select an autocomplete option using the arrowDown or arrowUp keys on 
       the keyboard (without pressing enter);
  3) Try to delete the input term.

#### How should this be manually tested?
Follow the same steps mentioned before in the [workspace](https://styleguidej--cosmetics1.myvtex.com/admin/collections/)

#### Screenshots or example usage
Before:
![before](https://user-images.githubusercontent.com/32712093/80512842-816ec580-8954-11ea-9a40-30cea7671fae.gif)

After:
![after](https://user-images.githubusercontent.com/32712093/80512859-892e6a00-8954-11ea-9cd1-6211b2a41230.gif)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
