### PR TITLE
Remove tooltip popup max-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 - `ActionMenu` and `Menu` default fixed width.
+- `Tooltip` popup `max-height`.
 
 ## [9.114.0] - 2020-04-28
 

--- a/react/components/Tooltip/tooltip.css
+++ b/react/components/Tooltip/tooltip.css
@@ -1,5 +1,4 @@
 .popup {
-  max-height: 11rem;
   will-change: transform;
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, it's `max-height` should be removed. We had a [discussion](https://vtex.slack.com/archives/C1MCRG7CK/p1588169123243900) about this and it doesn't make sense for the Styleguide to guess what's the ideal tooltip's `max-height`.

#### What problem is this solving?

Before that, some information could not be shown if the content's height was greater than the `max-height`.

#### How should this be manually tested?

[Running workspace](https://logistics--ambienteqa.myvtex.com/admin/shipping-strategy/loading-docks/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/80739385-c0378380-8aec-11ea-8df1-2777725ce929.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
