### PR TITLE
Add container prop to Tooltip component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ActionMenu` and `Menu` default fixed width.
 - `Tooltip` popup `max-height`.
 
+### Fixed
+
+- Value when user tries to update with an option selected in the `AutocompleteInput` component
+
 ## [9.114.0] - 2020-04-28
 
 ### Fixed
 
-- Value when user tries to update with an option selected in the `AutocompleteInput` component
 - `AutoCompleteInput` custom render example.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `container` prop to `Tooltip`.
+
 ### Removed
 
 - `ActionMenu` and `Menu` default fixed width.

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -21,6 +21,8 @@ function getChildRefPropType() {
 }
 
 const propTypes = {
+  /** Container element for Portal */
+  container: PropTypes.node,
   /** Tooltip content */
   label: PropTypes.node.isRequired,
   /** Tooltip position */
@@ -58,6 +60,7 @@ const defaultProps = {
 }
 
 const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
+  container,
   position,
   size,
   fallbackPosition,
@@ -100,7 +103,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   )
 
   return (
-    <Portal>
+    <Portal container={container}>
       <div
         role="tooltip"
         className={popupClasses}

--- a/react/components/Tooltip/index.tsx
+++ b/react/components/Tooltip/index.tsx
@@ -5,6 +5,8 @@ import TooltipPopup, { Position, Size } from './TooltipPopup'
 import { useTooltip, Trigger } from './hooks'
 
 const propTypes = {
+  /** Container element for the popup's portal to be rendered (default: document.body) */
+  container: PropTypes.node,
   /** Label to be shown. As element, can be a string, number...*/
   label: PropTypes.node.isRequired,
   /** Tooltip position */


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, add a container prop so the Tooltip be rendered, for example, in the `window.top` document.

#### What problem is this solving?

It could not be rendered outside the `document.body` (the default container element).

#### How should this be manually tested?

[Running workspace](https://tooltip--ambienteqa.myvtex.com/admin/shipping-strategy/shipping-policies). Click to delete any shipping policy and in the Modal (located in `window.top`) put the cursor in the title (⚠️ please do not delete the policy 😅 ).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/80741957-e828e600-8af0-11ea-92ca-2236e7522a35.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
