### PR TITLE
Small updates to make TableV2 more flexible and reliable on Composable Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.117.0] - 2020-05-13
+
 ### Added
 
 - `hideColumns` & `showColumns` functions to `useTableVisibility`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `hideColumns` & `showColumns` functions to `useTableVisibility`
+- `bodyHeight` memo to `useTableMeasures`
+- `disableScroll` to `Table.Sections`
+
+### Fixed
+
+- `Table.Body.Cell` unstable heights
+
 ## [9.116.0] - 2020-05-07
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.116.0",
+  "version": "9.117.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.116.0",
+  "version": "9.117.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/EXPERIMENTAL_useTableContext.ts
+++ b/react/EXPERIMENTAL_useTableContext.ts
@@ -1,7 +1,0 @@
-import { useMeasuresContext as measures } from './components/EXPERIMENTAL_Table/context/measures'
-import { useBodyContext as body } from './components/EXPERIMENTAL_Table/context/body'
-import { useDataContext as data } from './components/EXPERIMENTAL_Table/context/data'
-import { useHeadContext as head } from './components/EXPERIMENTAL_Table/context/head'
-import { useLoadingContext as loading } from './components/EXPERIMENTAL_Table/context/loading'
-
-export default { measures, body, data, head, loading }

--- a/react/EXPERIMENTAL_useTableContext.ts
+++ b/react/EXPERIMENTAL_useTableContext.ts
@@ -1,0 +1,7 @@
+import { useMeasuresContext as measures } from './components/EXPERIMENTAL_Table/context/measures'
+import { useBodyContext as body } from './components/EXPERIMENTAL_Table/context/body'
+import { useDataContext as data } from './components/EXPERIMENTAL_Table/context/data'
+import { useHeadContext as head } from './components/EXPERIMENTAL_Table/context/head'
+import { useLoadingContext as loading } from './components/EXPERIMENTAL_Table/context/loading'
+
+export default { measures, body, data, head, loading }

--- a/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
@@ -77,7 +77,7 @@ function Cell(
   const containerProps = {
     onClick,
     tag: header ? CellTag.Th : CellTag.Td,
-    className: classNames('v-mid ph3 pv0 tl bb b--muted-4', classNameProp, {
+    className: classNames('v-mid ph3 pv0 tl', classNameProp, {
       pointer: onClick,
       'c-on-base': sorting,
       'bg-base': header,

--- a/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
@@ -63,9 +63,10 @@ type Props = PropsWithChildren<SpecificProps>
 function Cell(
   {
     children,
-    width,
     onClick,
     className: classNameProp,
+    width = 0,
+    height = 0,
     sorting = false,
     sortable = false,
     sticky = false,
@@ -77,16 +78,17 @@ function Cell(
   const containerProps = {
     onClick,
     tag: header ? CellTag.Th : CellTag.Td,
-    className: classNames('v-mid ph3 pv0 tl', classNameProp, {
+    className: classNames('v-mid ph3 pv0 tl bb b--muted-4', classNameProp, {
       pointer: onClick,
       'c-on-base': sorting,
-      'bg-base': header,
+      'bg-base bt': header,
       'top-0 z3': sticky && header,
       z1: !sticky,
     }),
     style: {
       position: sticky ? 'sticky' : 'static',
       width,
+      height,
     } as CSSProperties,
   }
 
@@ -145,6 +147,7 @@ interface Composites {
 
 interface SpecificProps {
   width?: number | string | React.ReactText
+  height?: number
   className?: string
   onClick?: () => void
   sortable?: boolean

--- a/react/components/EXPERIMENTAL_Table/Sections/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Row.tsx
@@ -35,11 +35,11 @@ function Row(
   ref: Ref<HTMLTableRowElement>
 ) {
   const LIGHT_BLUE = '#DBE9FD'
-  const { rowHeight, density } = useMeasuresContext()
+  const { density } = useMeasuresContext()
   const { columns } = useDataContext()
   const { highlightOnHover, isRowActive, onRowClick } = useBodyContext()
   const className = classNames(
-    'w-100 truncate overflow-x-hidden bb b--muted-4',
+    'w-100 truncate overflow-x-hidden',
     {
       'pointer hover-c-link': !header && onRowClick,
       'hover-bg-muted-5': !header && (highlightOnHover || !!onRowClick),
@@ -92,13 +92,13 @@ function Row(
         const content = cellRenderer
           ? cellRenderer({
               data: cellData,
-              rowHeight,
+              rowHeight: height,
               density,
               motion,
             })
           : cellData
         return (
-          <Cell key={id} width={width}>
+          <Cell key={id} width={width} height={height}>
             {content}
           </Cell>
         )

--- a/react/components/EXPERIMENTAL_Table/Sections/Row.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Row.tsx
@@ -38,10 +38,14 @@ function Row(
   const { rowHeight, density } = useMeasuresContext()
   const { columns } = useDataContext()
   const { highlightOnHover, isRowActive, onRowClick } = useBodyContext()
-  const className = classNames('w-100 truncate overflow-x-hidden', {
-    'pointer hover-c-link': !header && onRowClick,
-    'hover-bg-muted-5': !header && (highlightOnHover || !!onRowClick),
-  })
+  const className = classNames(
+    'w-100 truncate overflow-x-hidden bb b--muted-4',
+    {
+      'pointer hover-c-link': !header && onRowClick,
+      'hover-bg-muted-5': !header && (highlightOnHover || !!onRowClick),
+    },
+    props.className
+  )
   const rowColor =
     data && isRowActive && isRowActive(data)
       ? { backgroundColor: LIGHT_BLUE }

--- a/react/components/EXPERIMENTAL_Table/Sections/Thead.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Thead.tsx
@@ -42,7 +42,7 @@ function Thead(
       data-testid={`${testId}__header`}
       className={`w-100 ph4 truncate overflow-x-hidden c-muted-2 f6 ${className}`}
       {...restProps}>
-      <Row height={TABLE_HEADER_HEIGHT} header className="bt">
+      <Row height={TABLE_HEADER_HEIGHT} header>
         {({ column, props: receivedProps }) => {
           const { id, title, sortable } = column
           const currentlySorting =

--- a/react/components/EXPERIMENTAL_Table/Sections/Thead.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Thead.tsx
@@ -42,7 +42,7 @@ function Thead(
       data-testid={`${testId}__header`}
       className={`w-100 ph4 truncate overflow-x-hidden c-muted-2 f6 ${className}`}
       {...restProps}>
-      <Row height={TABLE_HEADER_HEIGHT} header>
+      <Row height={TABLE_HEADER_HEIGHT} header className="bt">
         {({ column, props: receivedProps }) => {
           const { id, title, sortable } = column
           const currentlySorting =
@@ -56,7 +56,7 @@ function Thead(
           const props = {
             ...receivedProps,
             ...clickable,
-            className: classNames('bt normal', { pointer: sortable }),
+            className: classNames('normal', { pointer: sortable }),
             sorting: currentlySorting,
             sortable,
             sticky,

--- a/react/components/EXPERIMENTAL_Table/Sections/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/index.tsx
@@ -17,10 +17,14 @@ import { useLoadingContext } from '../context/loading'
 import Tbody, { ComposableTbody } from './Tbody'
 import Thead, { ComposableThead } from './Thead'
 
-type Props = PropsWithChildren<E2ETestable & HasMotion & NativeTable>
+type Props = PropsWithChildren<
+  E2ETestable &
+    HasMotion &
+    NativeTable & { disableScroll?: boolean; noContainer?: boolean }
+>
 
 function Sections(
-  { children, className, motion }: Props,
+  { children, className, motion, disableScroll = false }: Props,
   ref: Ref<HTMLTableElement>
 ) {
   const { emptyState, empty, loading } = useLoadingContext()
@@ -30,15 +34,14 @@ function Sections(
   return (
     <div
       style={{ height: tableHeight, ...motion }}
-      className={classNames(
-        'order-1 mw-100 overflow-x-auto overflow-y-auto overflow-hidden',
-        ORDER_CLASSNAMES.TABLE
-      )}>
+      className={classNames('mw-100', ORDER_CLASSNAMES.TABLE, {
+        'overflow-x-auto overflow-y-auto overflow-hidden': !disableScroll,
+      })}>
       <table
         ref={ref}
         data-testid={testId}
-        className={`w-100 ${className}`}
-        style={{ borderSpacing: 0 }}>
+        className={classNames('w-100', className)}
+        style={{ borderCollapse: 'collapse' }}>
         {children}
       </table>
       {!empty && loading && (

--- a/react/components/EXPERIMENTAL_Table/Sections/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/index.tsx
@@ -18,9 +18,7 @@ import Tbody, { ComposableTbody } from './Tbody'
 import Thead, { ComposableThead } from './Thead'
 
 type Props = PropsWithChildren<
-  E2ETestable &
-    HasMotion &
-    NativeTable & { disableScroll?: boolean; noContainer?: boolean }
+  E2ETestable & HasMotion & NativeTable & { disableScroll?: boolean }
 >
 
 function Sections(
@@ -41,7 +39,7 @@ function Sections(
         ref={ref}
         data-testid={testId}
         className={classNames('w-100', className)}
-        style={{ borderCollapse: 'collapse' }}>
+        style={{ borderCollapse: 'separate', borderSpacing: 0 }}>
         {children}
       </table>
       {!empty && loading && (

--- a/react/components/EXPERIMENTAL_Table/docs/Advanced.md
+++ b/react/components/EXPERIMENTAL_Table/docs/Advanced.md
@@ -185,11 +185,18 @@ function BodyExample() {
 ;<BodyExample />
 ```
 
+##### Sections Props
+
+| Property | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| disableScroll | boolean | 🚫 | false | Disable scroll overflow of the container |
+
 ##### Cell Props
 
 | Property  | Type             | Required | Default | Description                                    |
 | --------- | ---------------- | -------- | ------- | ---------------------------------------------- |
 | width     | number or string | 🚫       | 🚫      | Cell width (variable by default)               |
+| heigth    | number or string | 🚫       | 🚫     | Cell height (variable by default)               |
 | className | string           | 🚫       | 🚫      | Custom classes                                 |
 | onClick   | `() => void`     | 🚫       | 🚫      | Action to dispatch on click                    |
 | sortable  | boolean          | 🚫       | false   | If is sortable or not                          |

--- a/react/components/EXPERIMENTAL_Table/docs/Features.md
+++ b/react/components/EXPERIMENTAL_Table/docs/Features.md
@@ -25,6 +25,7 @@ enum Density {
 | currentDensity    | Density                    | The table current density |
 | rowHeight         | number                     | The height of each row    |
 | tableHeight       | number                     | Table's full height       |
+| bodyHeight        | number                     | Table's body height       |
 | setCurrentDensity | (density: Density) => void | Sets the current density  |
 
 ##### Example
@@ -170,6 +171,8 @@ The column's visibility can be toggled using `useTableVisibility`. This is usefu
 | visibleColumns | Column[]             | Columns that are visible         |
 | hiddenColumns  | string[]             | Columns that are hidden          |
 | toggleColumn   | (id: string) => void | Toggle a column visibility by id |
+| showColumn     | (id: string) => void | Show a column visibility by id   |
+| hideColumn     | (id: string) => void | Hide a column visibility by id   |
 | showAllColumns | () => void           | Make all columns visible         |
 | hideAllColumns | () => void           | Make all columns hidden          |
 

--- a/react/components/EXPERIMENTAL_Table/hooks/__tests__/useTableMeasures.test.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/__tests__/useTableMeasures.test.ts
@@ -35,24 +35,24 @@ describe('Table V2 @ hooks/useTableMeasures spec', () => {
   it('calculates tableHeight correctly', () => {
     const { result } = renderHook(() => useTableMeasures({ size: TABLE_SIZE }))
 
-    expect(result.current.tableHeight).toBe(276)
+    expect(result.current.tableHeight).toBe(276 + TABLE_SIZE)
 
     act(() => {
       result.current.setDensity(Density.Comfortable)
     })
 
-    expect(result.current.tableHeight).toBe(416)
+    expect(result.current.tableHeight).toBe(416 + TABLE_SIZE)
 
     act(() => {
       result.current.setDensity(Density.Compact)
     })
 
-    expect(result.current.tableHeight).toBe(196)
+    expect(result.current.tableHeight).toBe(196 + TABLE_SIZE)
 
     act(() => {
       result.current.setDensity(Density.Regular)
     })
 
-    expect(result.current.tableHeight).toBe(276)
+    expect(result.current.tableHeight).toBe(276 + TABLE_SIZE)
   })
 })

--- a/react/components/EXPERIMENTAL_Table/hooks/__tests__/useTableVisibility.test.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/__tests__/useTableVisibility.test.ts
@@ -42,6 +42,42 @@ describe('Table V2 @ hooks/useTableVisibility spec', () => {
     expect(result.current.visibleColumns).toEqual([{ id: 'name' }])
   })
 
+  it('shows a column correctly', () => {
+    const { result } = renderHook(() =>
+      useTableVisibility({ columns, hiddenColumns: ['name'] })
+    )
+
+    expect(result.current.visibleColumns).toEqual([
+      { id: 'location' },
+      { id: 'company' },
+    ])
+
+    act(() => {
+      result.current.showColumn('name')
+    })
+
+    expect(result.current.hiddenColumns).toEqual([])
+    expect(result.current.visibleColumns).toEqual(columns)
+  })
+
+  it('hides a column correctly', () => {
+    const { result } = renderHook(() =>
+      useTableVisibility({ columns, hiddenColumns: ['name'] })
+    )
+
+    expect(result.current.visibleColumns).toEqual([
+      { id: 'location' },
+      { id: 'company' },
+    ])
+
+    act(() => {
+      result.current.hideColumn('location')
+    })
+
+    expect(result.current.hiddenColumns).toEqual(['name', 'location'])
+    expect(result.current.visibleColumns).toEqual([{ id: 'company' }])
+  })
+
   it('hiddes all columns', () => {
     const { result } = renderHook(() => useTableVisibility({ columns }))
 

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableMeasures.tsx
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableMeasures.tsx
@@ -13,14 +13,20 @@ export default function useTableMeasures({
   const rowHeight = useMemo(() => getRowHeight(density), [density])
 
   const tableHeight = useMemo(
-    () => calculateTableHeight(rowHeight, size, headless),
+    () => calculateTableHeight(rowHeight, size, headless) + size,
     [headless, rowHeight, size]
+  )
+
+  const bodyHeight = useMemo(
+    () => calculateTableHeight(rowHeight, size, true),
+    [rowHeight, size]
   )
 
   return {
     density,
     rowHeight,
     tableHeight,
+    bodyHeight,
     setDensity,
   }
 }

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableVisibility.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableVisibility.ts
@@ -21,6 +21,16 @@ export default function useTableVisibility({
     )
   }, [])
 
+  const showColumn = useCallback((id: string) => {
+    setHiddenColumns(col =>
+      col.includes(id) ? col.filter(col => col !== id) : col
+    )
+  }, [])
+
+  const hideColumn = useCallback((id: string) => {
+    setHiddenColumns(col => (col.includes(id) ? col : [...col, id]))
+  }, [])
+
   const showAllColumns = useCallback(() => {
     setHiddenColumns([])
   }, [])
@@ -33,6 +43,8 @@ export default function useTableVisibility({
     columns,
     visibleColumns,
     hiddenColumns,
+    showColumn,
+    hideColumn,
     toggleColumn,
     showAllColumns,
     hideAllColumns,


### PR DESCRIPTION
#### What is the purpose of this pull request?

➕ `hideColumns` & `showColumns` functions to `useTableVisibility`
➕ `bodyHeight` memo to `useTableMeasures`
➕`disableScroll` to `Table.Sections`

🛠`Table.Body.Cell` unstable heights

#### What problem is this solving?
These changes make D&D (not Dungeons and Dragons 🐉) possible:

[Running workspace](https://organizerdnd--cosmetics1.myvtex.com/admin/app/collections/4882)

#### How should this be manually tested?

You must clone the repository, install de dependencies, and start the app. Then, navigate to the Table section.

#### Types of changes

- [x] Bugfix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
