### PR TITLE
Radio group error props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `error` and `errorMessage` props to `RadioGroup` 
+
 ## [9.115.0] - 2020-04-30
 
 ### Added

--- a/react/components/RadioGroup/README.md
+++ b/react/components/RadioGroup/README.md
@@ -108,3 +108,24 @@ With optional border
   onChange={() => {}}
 />
 ```
+
+With error highlight
+
+```js
+initialState = { value: '', error: true, errorMessage: 'This field is mandatory' }
+
+<RadioGroup
+  error={state.error},
+  errorMessage={state.error &&},
+  name="radioGroupExample4"
+  options={[
+    { value: 'value1', label: 'Hue' },
+    { value: 'value2', label: 'Saturation' },
+    { value: 'value3', label: 'Value' },
+  ]}
+  value={state.value}
+  onChange={({ target: { value } }) => 
+    setState({ value, error: false, errorMessage: '' })
+  }
+/>
+```

--- a/react/components/RadioGroup/README.md
+++ b/react/components/RadioGroup/README.md
@@ -112,11 +112,11 @@ With optional border
 With error highlight
 
 ```js
-initialState = { value: '', error: true, errorMessage: 'This field is mandatory' }
+initialState = { value: '', error: true, errorMessage: 'This field is mandatory' };
 
 <RadioGroup
-  error={state.error},
-  errorMessage={state.error &&},
+  error={state.error}
+  errorMessage={state.error && state.errorMessage}
   name="radioGroupExample4"
   options={[
     { value: 'value1', label: 'Hue' },

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -24,7 +24,7 @@ class RadioGroup extends React.Component {
     } = this.props
 
     const large = size === 'large'
-    const borderColor = (error || errorMessage) ? 'b--danger hover-b--danger' : 'b--muted-4'
+    const errorHighlight = error || errorMessage
 
     return (
       <div>
@@ -47,8 +47,10 @@ class RadioGroup extends React.Component {
             const id = `${name}-${i}`
             return (
               <label
-                className={`db br3 ${borderColor} ${classNames({
+                className={`db br3 ${classNames({
                   'ba pv2 ph4': !hideBorder,
+                  'b--danger hover-b--danger': errorHighlight,
+                  'b--muted-4': !errorHighlight,
                   pointer: !isDisabled,
                 })}`}
                 key={id}

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -47,12 +47,12 @@ class RadioGroup extends React.Component {
             const id = `${name}-${i}`
             return (
               <label
-                className={`${classNames('db br3', {
+                className={classNames('db br3', {
                   'ba pv2 ph4': !hideBorder,
                   'b--danger hover-b--danger': errorHighlight,
                   'b--muted-4': !error && !errorMessage,
                   pointer: !isDisabled,
-                })}`}
+                })}
                 key={id}
                 style={{
                   ...(!isFirst && {

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -47,10 +47,10 @@ class RadioGroup extends React.Component {
             const id = `${name}-${i}`
             return (
               <label
-                className={`db br3 ${classNames({
+                className={`${classNames('db br3', {
                   'ba pv2 ph4': !hideBorder,
                   'b--danger hover-b--danger': errorHighlight,
-                  'b--muted-4': !errorHighlight,
+                  'b--muted-4': !error && !errorMessage,
                   pointer: !isDisabled,
                 })}`}
                 key={id}

--- a/react/components/RadioGroup/index.js
+++ b/react/components/RadioGroup/index.js
@@ -19,9 +19,12 @@ class RadioGroup extends React.Component {
       label,
       testId,
       size,
+      error,
+      errorMessage,
     } = this.props
 
     const large = size === 'large'
+    const borderColor = (error || errorMessage) ? 'b--danger hover-b--danger' : 'b--muted-4'
 
     return (
       <div>
@@ -44,8 +47,8 @@ class RadioGroup extends React.Component {
             const id = `${name}-${i}`
             return (
               <label
-                className={`db br3 ${classNames({
-                  'b--muted-4 ba pv2 ph4': !hideBorder,
+                className={`db br3 ${borderColor} ${classNames({
+                  'ba pv2 ph4': !hideBorder,
                   pointer: !isDisabled,
                 })}`}
                 key={id}
@@ -75,6 +78,9 @@ class RadioGroup extends React.Component {
               </label>
             )
           })}
+          {errorMessage && (
+            <div className="c-danger t-small mt3 lh-title">{errorMessage}</div>
+          )}
         </fieldset>
       </div>
     )
@@ -91,6 +97,10 @@ RadioGroup.propTypes = {
       disabled: PropTypes.bool,
     })
   ).isRequired,
+  /** Error highlight */
+  error: PropTypes.bool,
+  /** Error message */
+  errorMessage: PropTypes.string,
   /** Name attribute for the radio inputs, which will also be used to generate ids */
   name: PropTypes.string.isRequired,
   /** Current selected value */


### PR DESCRIPTION
#### What is the purpose of this pull request?

Highlight the radio group border according to the state(whether there is an error or not).

#### What problem is this solving?
[Running workspace](https://seller3--sandboxintegracao.myvtex.com/admin/new-seller/custom/)

The `<RadioGroup>` component does not have props that indicate errors. We are developing a product and when the user does not fill the field(RadioGroup in this case), we need to change the border color to red indicating that an error happened. To solve this problem we will add two props, `error` and `errorMessage` that indicate respectively whether there is an error or not and the error message itself.

#### How should this be manually tested?

1. Go to this [running workspace](https://seller3--sandboxintegracao.myvtex.com/admin/new-seller/custom/)
2. Then press the button `Continue`;
3. Then you should see the error displayed on the field `Type *`.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/36630479/81234711-ad7eec00-8fcf-11ea-82b7-d9b227ee3824.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.