### PR TITLE
Multi select error props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `vtex-slider__values-container`, `vtex-slider__left-value`, `vtex-slider__right-value`, `vtex-slider__dash` handles.
 - `tabIndex` prop to `Button`.
+- `error` and `errorMessage` props to `MultiSelect` 
 
 ## [9.117.0] - 2020-05-13
 

--- a/react/components/MultiSelect/index.js
+++ b/react/components/MultiSelect/index.js
@@ -139,12 +139,20 @@ export default class MultiSelect extends Component {
   }
 
   render() {
-    const { disabled, error, errorMessage, label, loadingText, placeholder, selected } = this.props
+    const {
+      disabled,
+      error,
+      errorMessage,
+      label,
+      loadingText,
+      placeholder,
+      selected,
+    } = this.props
     const emptyState = this.props.emptyState(
       `<span className="fw5">${this.state.searchTerm}</span>`
     )
     const isDropdownVisible = this.state.active && this.state.searchTerm !== ''
-    const hasError = (error || errorMessage) 
+    const hasError = error || errorMessage
     const tags = selected.map((tag, index) => (
       <div className="mr2 mv1 flex" key={index}>
         <Tag
@@ -160,8 +168,14 @@ export default class MultiSelect extends Component {
     let classes = disabled ? ' bg-muted-5 c-muted-2 ' : ' bg-base c-on-base '
     classes += isDropdownVisible ? ' br--top ' : ''
     classes += hasError ? 'b--danger hover-b--danger ' : ''
-    classes += this.state.active ? ' b--muted-2 ' : (!hasError ? ' b--muted-4 ' : '')
-    classes += !(this.state.active || disabled || hasError) ? ' hover-b--muted-3 ' : ''
+    classes += this.state.active
+      ? ' b--muted-2 '
+      : !hasError
+      ? ' b--muted-4 '
+      : ''
+    classes += !(this.state.active || disabled || hasError)
+      ? ' hover-b--muted-3 '
+      : ''
 
     return (
       <div className="relative">

--- a/react/components/MultiSelect/index.js
+++ b/react/components/MultiSelect/index.js
@@ -139,11 +139,12 @@ export default class MultiSelect extends Component {
   }
 
   render() {
-    const { disabled, label, loadingText, placeholder, selected } = this.props
+    const { disabled, error, errorMessage, label, loadingText, placeholder, selected } = this.props
     const emptyState = this.props.emptyState(
       `<span className="fw5">${this.state.searchTerm}</span>`
     )
     const isDropdownVisible = this.state.active && this.state.searchTerm !== ''
+    const hasError = (error || errorMessage) 
     const tags = selected.map((tag, index) => (
       <div className="mr2 mv1 flex" key={index}>
         <Tag
@@ -158,8 +159,9 @@ export default class MultiSelect extends Component {
 
     let classes = disabled ? ' bg-muted-5 c-muted-2 ' : ' bg-base c-on-base '
     classes += isDropdownVisible ? ' br--top ' : ''
-    classes += this.state.active ? ' b--muted-2 ' : ' b--muted-4 '
-    classes += !this.state.active && !disabled ? ' hover-b--muted-3 ' : ''
+    classes += hasError ? 'b--danger hover-b--danger ' : ''
+    classes += this.state.active ? ' b--muted-2 ' : (!hasError ? ' b--muted-4 ' : '')
+    classes += !(this.state.active || disabled || hasError) ? ' hover-b--muted-3 ' : ''
 
     return (
       <div className="relative">
@@ -206,6 +208,9 @@ export default class MultiSelect extends Component {
           options={this.state.filteredOptions}
           isVisible={isDropdownVisible}
         />
+        {errorMessage && (
+          <div className="pt3 t-small c-danger">{errorMessage}</div>
+        )}
       </div>
     )
   }
@@ -213,6 +218,8 @@ export default class MultiSelect extends Component {
 
 MultiSelect.defaultProps = {
   disabled: false,
+  error: false,
+  errorMessage: '',
   emptyState: term => {
     return `No results found for "${term}".`
   },
@@ -222,6 +229,10 @@ MultiSelect.defaultProps = {
 }
 
 MultiSelect.propTypes = {
+  /** Error highlight */
+  error: PropTypes.bool,
+  /** Error message */
+  errorMessage: PropTypes.string,
   /** True if the component should be disabled */
   disabled: PropTypes.bool,
   /** Returns a string that will be shown if no results are found. Usage: emptyState(search term) */


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the props `error` and `errorMessage` to `<MultiSelect/>`.

#### What problem is this solving?
[Running workspace](https://seller3--sandboxintegracao.myvtex.com/admin/new-seller/custom/)

Currently, we are using the old component `Multiselect` since the new one does not meet our requirements (it breaks when being used in a modal outside the iframe). One feature that we need, is the error highlight that it's not implemented yet in our styleguide on the `<Multiselect/>` component.

#### How should this be manually tested?

1. Go to this [Running workspace](https://seller3--sandboxintegracao.myvtex.com/admin/new-seller/custom/)
2. Try to submit the form without filling out any field
3. Then check the error highlight on the input `Trade policies*`

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/36630479/81572100-2a67e800-9379-11ea-9255-94f2aa9265b6.png)
![image](https://user-images.githubusercontent.com/36630479/81572118-3358b980-9379-11ea-8fc6-6eba8e5eac11.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.