### PR TITLE
Add 'tabIndex' prop to 'Button'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `vtex-slider__values-container`, `vtex-slider__left-value`, `vtex-slider__right-value`, `vtex-slider__dash` handles.
+- `tabIndex` prop to `Button`.
 
 ## [9.117.0] - 2020-05-13
 
@@ -27,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `error` and `errorMessage` props to `RadioGroup` 
+- `error` and `errorMessage` props to `RadioGroup`.
 
 ## [9.115.0] - 2020-04-30
 

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -46,6 +46,7 @@ class Button extends Component {
       download,
       noUpperCase,
       noWrap,
+      tabIndex,
     } = this.props
 
     const disabled = this.props.disabled || isLoading
@@ -220,7 +221,7 @@ class Button extends Component {
         disabled={iconOnly ? undefined : this.props.disabled}
         name={iconOnly ? undefined : this.props.name}
         value={iconOnly ? undefined : this.props.value}
-        tabIndex={0}
+        tabIndex={tabIndex}
         className={classes}
         href={href}
         onClick={this.handleClick}
@@ -276,6 +277,7 @@ Button.defaultProps = {
   isFirstOfGroup: false,
   isLastOfGroup: false,
   isActiveOfGroup: false,
+  tabIndex: 0,
 }
 
 Button.propTypes = {
@@ -340,6 +342,8 @@ Button.propTypes = {
   onFocus: PropTypes.func,
   /** onBlur event */
   onBlur: PropTypes.func,
+  /** tabIndex attribute of HTML */
+  tabIndex: PropTypes.number,
   /** @ignore deprecated
    * Cancels out left padding */
   collapseLeft: PropTypes.bool,


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### What problem is this solving?

In the workspace we have this modal and every row of the modal is a button that has the styleguide button inside, so what we want when press tab is to just focus the rows, but not the `Add` button
![image](https://user-images.githubusercontent.com/8517023/81741414-e954fe00-9474-11ea-944e-90f795a70c08.png)


#### How should this be manually tested?

1. [Running workspace](https://linebutton--storecomponents.myvtex.com/admin/app/new-cms/edit/new)
2. Click on the plus button below the page details
3. Use tab to navigate between elements and see that the button `Add` is not focused

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
