### PR TITLE
Make alert accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Make screen readers anounce `Alert` content when it pops up in the screen
+- Allow developers to choose to direct focus to the `Alert` when it pops up in the screen by using the `focusOnOpen` property
+
 ## [9.118.0] - 2020-05-14
 
 ### Added

--- a/react/components/Alert/index.js
+++ b/react/components/Alert/index.js
@@ -9,18 +9,37 @@ import Button from '../Button'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
 
 class Alert extends Component {
+  constructor(props) {
+    super(props)
+    this.firstElementRef = React.createRef()
+  }
+
   componentDidMount() {
     if (this.props.autoClose && this.props.onClose) {
       this.timeout = setTimeout(this.props.onClose, this.props.autoClose)
+    }
+
+    if (this.props.focusOnOpen) {
+      this.firstElementRef.current && this.firstElementRef.current.focus()
     }
   }
 
   componentWillUnmount() {
     clearTimeout(this.timeout)
+
+    if (this.props.focusAfterClosed && this.props.focusAfterClosed.current) {
+      this.props.focusAfterClosed.current.focus()
+    }
   }
 
   render() {
-    const { type, onClose, action, forwardedRef } = this.props
+    const {
+      type,
+      onClose,
+      action,
+      forwardedRef,
+      closeIconLabel = 'Close',
+    } = this.props
     const innerVerticalPadding = 'pv3'
     let classes = 'ph5 pv4 br2 '
     let showIcon = false
@@ -57,6 +76,7 @@ class Alert extends Component {
     return (
       <div
         ref={forwardedRef}
+        role="alert"
         className={`vtex-alert flex justify-between t-body c-on-base ${classes}`}>
         <div className="flex-ns flex-wrap flex-grow-1 items-start">
           <div
@@ -76,7 +96,10 @@ class Alert extends Component {
             <div
               className={`flex flex-grow-1 justify-end ${innerVerticalPadding}`}>
               <div className="nt4-ns nb4">
-                <Button variation="tertiary" onClick={handleActionClick}>
+                <Button
+                  ref={this.firstElementRef}
+                  variation="tertiary"
+                  onClick={handleActionClick}>
                   {action.label}
                 </Button>
               </div>
@@ -85,13 +108,18 @@ class Alert extends Component {
         </div>
 
         {onClose && (
-          <div
-            title="Close"
-            className={`vtex-alert__close-icon pointer pv2 c-on-base ph3 ${innerVerticalPadding}`}
+          <button
+            className={`vtex-alert__close-icon pointer c-on-base ph3 bg-transparent bn ${innerVerticalPadding}`}
+            ref={displayAction ? undefined : this.firstElementRef}
             onClick={onClose}
             tabIndex={0}>
-            <CloseIcon block color="currentColor" size={16} />
-          </div>
+            <CloseIcon
+              title={closeIconLabel}
+              block
+              color="currentColor"
+              size={16}
+            />
+          </button>
         )}
       </div>
     )
@@ -109,11 +137,17 @@ Alert.propTypes = {
   onClose: PropTypes.func,
   /** Time in ms to auto close the alert */
   autoClose: PropTypes.number,
+  /** Set focus to the first focusable element inside alert, which should be the "action" when available or the "close" button */
+  focusOnOpen: PropTypes.bool,
+  /** Define element to be focused when the alert is dimissed */
+  focusAfterClosed: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   /** If this object is defined, an action button will appear on the right side of the alert. */
   action: PropTypes.shape({
     onClick: PropTypes.func.isRequired,
     label: PropTypes.node.isRequired,
   }),
+  /** Defines the title used for hover and accessibility feedback **/
+  closeIconLabel: PropTypes.string,
 }
 
 export default withForwardedRef(Alert)

--- a/react/components/Alert/index.js
+++ b/react/components/Alert/index.js
@@ -26,10 +26,6 @@ class Alert extends Component {
 
   componentWillUnmount() {
     clearTimeout(this.timeout)
-
-    if (this.props.focusAfterClosed && this.props.focusAfterClosed.current) {
-      this.props.focusAfterClosed.current.focus()
-    }
   }
 
   render() {
@@ -139,8 +135,6 @@ Alert.propTypes = {
   autoClose: PropTypes.number,
   /** Set focus to the first focusable element inside alert, which should be the "action" when available or the "close" button */
   focusOnOpen: PropTypes.bool,
-  /** Define element to be focused when the alert is dimissed */
-  focusAfterClosed: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   /** If this object is defined, an action button will appear on the right side of the alert. */
   action: PropTypes.shape({
     onClick: PropTypes.func.isRequired,

--- a/react/components/icon/Close/index.js
+++ b/react/components/icon/Close/index.js
@@ -11,11 +11,12 @@ const iconBase = {
 
 class Close extends PureComponent {
   render() {
-    const { color, size, block } = this.props
+    const { color, size, block, title } = this.props
     const newSize = calcIconSize(iconBase, size)
 
     return (
       <Svg name="close" size={newSize} block={block} viewBox="0 0 18 18">
+        {title && <title>{title}</title>}
         <g fill={color}>
           <path d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z" />
         </g>
@@ -34,6 +35,7 @@ Close.propTypes = {
   color: PropTypes.string,
   size: PropTypes.number,
   block: PropTypes.bool,
+  title: PropTypes.string,
 }
 
 export default Close


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is a non-breaking change to add some accessibility features to the alert.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
[Running workspace](https://accessibility--content.myvtex.com/admin/app/new-cms/edit/new)

1- Allow developers to use `focusOnOpen` property to make the cursor focus change to either the action or dismiss buttons
2- Make screen readers announce the alert error as soon as it pops up in the screen


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
You can go to the workspace link above and try saving a document without filling any information. This will trigger an error. Then you should try repeating the action and, in the second time, dismissing the alert.

You should be able to do all this using just your keyboard.

If you have voice over activated, you should be able to hear the entire experience seamlessly.

#### Screenshots or example usage
![alert](https://user-images.githubusercontent.com/1354492/82239671-8699b180-990f-11ea-9fbf-04e608e1d285.gif)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
