### PR TITLE
Add TrapFocus component in Modal and fix Input autoFocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Size prop to Modal.
 - `aria-label`, `aria-labelledby`, and `aria-describedby` prop to Modal.
 - `FocusTrap` in modal.
-- `initialFocusRef` prop to Modal.
 
 ### Fixed
 
 - `centered` Modal prop when `false` did not changed.
 - ModalDialog documentation didn't informed the required props.
+- `autoFocus` prop in Input blocking navigation.
 
 ## [9.112.27] - 2020-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Utilities section in docs.
 - Size prop to Modal.
 - `aria-label`, `aria-labelledby`, and `aria-describedby` prop to Modal.
+- `FocusTrap` in modal.
+- `initialFocusRef` prop to Modal.
 
 ### Fixed
 

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -88,10 +88,6 @@ class Input extends Component {
     this.handleAutoFocus()
   }
 
-  componentDidUpdate() {
-    this.handleAutoFocus()
-  }
-
   render() {
     const {
       errorMessage,

--- a/react/components/Modal/FocusTrap.tsx
+++ b/react/components/Modal/FocusTrap.tsx
@@ -31,10 +31,9 @@ const focusFirstElement = (element: HTMLElement) => {
 
 interface Props {
   children?: React.ReactNode
-  initialFocusRef?: React.RefObject<HTMLElement> | null
 }
 
-const FocusTrap: FC<Props> = ({ children, initialFocusRef }) => {
+const FocusTrap: FC<Props> = ({ children }) => {
   const focusContainer = useRef<HTMLDivElement>(null)
 
   const handleFocusIn = (event: FocusEvent) => {
@@ -92,12 +91,11 @@ const FocusTrap: FC<Props> = ({ children, initialFocusRef }) => {
     if (!focusContainer.current) {
       return
     }
-    if (initialFocusRef) {
-      initialFocusRef?.current?.focus()
-      return
-    }
-    focusFirstElement(focusContainer.current)
-  }, [focusContainer, initialFocusRef])
+    const alreadyHasFocus =
+      focusContainer.current &&
+      focusContainer.current.contains(document.activeElement)
+    if (!alreadyHasFocus) focusFirstElement(focusContainer.current)
+  }, [focusContainer])
 
   return (
     <>

--- a/react/components/Modal/FocusTrap.tsx
+++ b/react/components/Modal/FocusTrap.tsx
@@ -1,0 +1,100 @@
+import React, { FC, useEffect, useRef } from 'react'
+
+enum Key {
+  TAB = 9,
+  SHIFT = 16,
+}
+
+const FOCUSABLE_SELECTOR =
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]:not([tabindex="-1"])'
+
+const findFirstFocusable = (element: HTMLElement): HTMLElement | null => {
+  if (element.matches && element.matches(FOCUSABLE_SELECTOR)) {
+    return element
+  }
+
+  return element.querySelector(FOCUSABLE_SELECTOR)
+}
+
+const findLastFocusable = (element: HTMLElement): HTMLElement | null => {
+  if (element.matches && element.matches(FOCUSABLE_SELECTOR)) {
+    return element
+  }
+  const focusableElements = element.querySelectorAll(FOCUSABLE_SELECTOR)
+  return focusableElements[focusableElements.length - 1] as HTMLElement | null
+}
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  children?: React.ReactNode
+}
+
+const FocusTrap: FC<Props> = ({ children, ...props }) => {
+  const focusContainer = useRef<HTMLDivElement>(null)
+
+  const handleFocusIn = (event: FocusEvent) => {
+    const alreadyHasFocus =
+      focusContainer.current &&
+      focusContainer.current.contains(document.activeElement)
+    if (
+      !focusContainer.current ||
+      alreadyHasFocus ||
+      !(
+        event.target instanceof HTMLElement &&
+        focusContainer.current !== event.target &&
+        !focusContainer.current.contains(event.target)
+      )
+    ) {
+      return
+    }
+    const firstFocusableElement = findFirstFocusable(focusContainer.current)
+    firstFocusableElement?.focus()
+  }
+
+  const handleTab = (event: KeyboardEvent) => {
+    if (!focusContainer.current) {
+      return
+    }
+
+    const firstFocusableElement = findFirstFocusable(focusContainer.current)
+    const lastFocusableElement = findLastFocusable(focusContainer.current)
+
+    if (event.target === firstFocusableElement && event.shiftKey) {
+      event.preventDefault()
+      lastFocusableElement?.focus()
+    } else if (event.target === lastFocusableElement && !event.shiftKey) {
+      event.preventDefault()
+      firstFocusableElement?.focus()
+    }
+  }
+
+  const handleKeyEvent = (event: KeyboardEvent) => {
+    if (event.keyCode === Key.TAB) {
+      handleTab(event)
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyEvent)
+    document.addEventListener('focusin', handleFocusIn)
+    return () => {
+      document.removeEventListener('keydown', handleKeyEvent)
+      document.removeEventListener('focusin', handleFocusIn)
+    }
+  })
+
+  useEffect(() => {
+    if (!focusContainer.current) {
+      return
+    }
+    const firstFocusableElement = findFirstFocusable(focusContainer.current)
+    firstFocusableElement?.focus()
+  }, [focusContainer])
+
+  return (
+    <div ref={focusContainer} {...props}>
+      {children}
+    </div>
+  )
+}
+
+export default FocusTrap

--- a/react/components/Modal/FocusTrap.tsx
+++ b/react/components/Modal/FocusTrap.tsx
@@ -29,12 +29,12 @@ const focusFirstElement = (element: HTMLElement) => {
   firstElement?.focus()
 }
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
+interface Props {
   children?: React.ReactNode
   initialFocusRef?: React.RefObject<HTMLElement> | null
 }
 
-const FocusTrap: FC<Props> = ({ children, initialFocusRef, ...props }) => {
+const FocusTrap: FC<Props> = ({ children, initialFocusRef }) => {
   const focusContainer = useRef<HTMLDivElement>(null)
 
   const handleFocusIn = (event: FocusEvent) => {
@@ -100,9 +100,13 @@ const FocusTrap: FC<Props> = ({ children, initialFocusRef, ...props }) => {
   }, [focusContainer, initialFocusRef])
 
   return (
-    <div ref={focusContainer} {...props}>
-      {children}
-    </div>
+    <>
+      {children
+        ? React.cloneElement(children as React.ReactElement, {
+            ref: focusContainer,
+          })
+        : children}
+    </>
   )
 }
 

--- a/react/components/Modal/FocusTrap.tsx
+++ b/react/components/Modal/FocusTrap.tsx
@@ -24,11 +24,17 @@ const findLastFocusable = (element: HTMLElement): HTMLElement | null => {
   return focusableElements[focusableElements.length - 1] as HTMLElement | null
 }
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
-  children?: React.ReactNode
+const focusFirstElement = (element: HTMLElement) => {
+  const firstElement = findFirstFocusable(element)
+  firstElement?.focus()
 }
 
-const FocusTrap: FC<Props> = ({ children, ...props }) => {
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  children?: React.ReactNode
+  initialFocusRef?: React.RefObject<HTMLElement> | null
+}
+
+const FocusTrap: FC<Props> = ({ children, initialFocusRef, ...props }) => {
   const focusContainer = useRef<HTMLDivElement>(null)
 
   const handleFocusIn = (event: FocusEvent) => {
@@ -46,8 +52,8 @@ const FocusTrap: FC<Props> = ({ children, ...props }) => {
     ) {
       return
     }
-    const firstFocusableElement = findFirstFocusable(focusContainer.current)
-    firstFocusableElement?.focus()
+
+    focusFirstElement(focusContainer.current)
   }
 
   const handleTab = (event: KeyboardEvent) => {
@@ -86,9 +92,12 @@ const FocusTrap: FC<Props> = ({ children, ...props }) => {
     if (!focusContainer.current) {
       return
     }
-    const firstFocusableElement = findFirstFocusable(focusContainer.current)
-    firstFocusableElement?.focus()
-  }, [focusContainer])
+    if (initialFocusRef) {
+      initialFocusRef?.current?.focus()
+      return
+    }
+    focusFirstElement(focusContainer.current)
+  }, [focusContainer, initialFocusRef])
 
   return (
     <div ref={focusContainer} {...props}>

--- a/react/components/Modal/FocusTrap.tsx
+++ b/react/components/Modal/FocusTrap.tsx
@@ -36,25 +36,6 @@ interface Props {
 const FocusTrap: FC<Props> = ({ children }) => {
   const focusContainer = useRef<HTMLDivElement>(null)
 
-  const handleFocusIn = (event: FocusEvent) => {
-    const alreadyHasFocus =
-      focusContainer.current &&
-      focusContainer.current.contains(document.activeElement)
-    if (
-      !focusContainer.current ||
-      alreadyHasFocus ||
-      !(
-        event.target instanceof HTMLElement &&
-        focusContainer.current !== event.target &&
-        !focusContainer.current.contains(event.target)
-      )
-    ) {
-      return
-    }
-
-    focusFirstElement(focusContainer.current)
-  }
-
   const handleTab = (event: KeyboardEvent) => {
     if (!focusContainer.current) {
       return
@@ -80,10 +61,8 @@ const FocusTrap: FC<Props> = ({ children }) => {
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyEvent)
-    document.addEventListener('focusin', handleFocusIn)
     return () => {
       document.removeEventListener('keydown', handleKeyEvent)
-      document.removeEventListener('focusin', handleFocusIn)
     }
   })
 

--- a/react/components/Modal/README.md
+++ b/react/components/Modal/README.md
@@ -35,7 +35,6 @@
 | aria-label              | `string`  | 🚫       |                     | Acessible Modal name. If this name is visible on the screen, prefer to use aria-labelledby                                                                  |
 | aria-labelledby         | `string`  | 🚫       | `vtex-modal__title` | ID of the element that provides the Modal an accessible name. If aria-label and aria-albelledby is not defined, the default here will be the title element. |
 | aria-describedby        | `string`  | 🚫       |                     | ID of the element that provides the Modal an accessible description                                                                                         |
-| initialFocusRef         | `ref`     | 🚫       |                     | Element to be focused first when Modal is open. The default is the first Modal element.                                                                     |
 
 ## Examples
 
@@ -342,17 +341,26 @@ const ModalExample = () => {
 
 #### Custom Initial Focus
 
-By default the first focusable element will be focused but you can customize by providing a `ref`.
+By default the first focusable element will be focused but you can customize.
 
 ```js
 const Modal = require('.').default
+const Input = require('../Input').default
+const Button = require('../Button').default
 
 import { useDisclosure } from '../../utilities'
 
 const ModalExample = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
 
-  return null
+  return (
+    <>
+      <Button onClick={onOpen}>Open modal</Button>
+      <Modal isOpen={isOpen} onClose={onClose} title="Custom Initial Focus">
+        <Input autoFocus placeholder="Focus on me!" />
+      </Modal>
+    </>
+  )
 }
 ;<ModalExample />
 ```
@@ -362,4 +370,4 @@ const ModalExample = () => {
 > WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#dialog_modal
 
 - If you don't provide a string title to the Modal, be sure to provide `aria-labelledby="id..."` if the label is visible or a string to `aria-label="..."` if it's not visible. Additionaly you can give a description for the Modal with `aria-describedby="id..`.
-- Use `initialFocusRef` to the first element you want the user to intereact with it, examples: Form, Confirm Button, Link etc.
+- If necessary, change the initial focus to the component you want the user intereact with first. Examples: Form, Confirm Button, Link etc.

--- a/react/components/Modal/README.md
+++ b/react/components/Modal/README.md
@@ -35,6 +35,7 @@
 | aria-label              | `string`  | 🚫       |                     | Acessible Modal name. If this name is visible on the screen, prefer to use aria-labelledby                                                                  |
 | aria-labelledby         | `string`  | 🚫       | `vtex-modal__title` | ID of the element that provides the Modal an accessible name. If aria-label and aria-albelledby is not defined, the default here will be the title element. |
 | aria-describedby        | `string`  | 🚫       |                     | ID of the element that provides the Modal an accessible description                                                                                         |
+| initialFocusRef         | `ref`     | 🚫       |                     | Element to be focused first when Modal is open. The default is the first Modal element.                                                                     |
 
 ## Examples
 

--- a/react/components/Modal/__snapshots__/index.test.tsx.snap
+++ b/react/components/Modal/__snapshots__/index.test.tsx.snap
@@ -8,51 +8,49 @@ exports[`Modal CSS API centered 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div>
+    <div
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
+    >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
-        >
-          Foo
-        </div>
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
+      >
+        Foo
       </div>
     </div>
   </div>
@@ -67,51 +65,49 @@ exports[`Modal CSS API default 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div>
+    <div
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
+    >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
-        >
-          Foo
-        </div>
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
+      >
+        Foo
       </div>
     </div>
   </div>
@@ -126,51 +122,49 @@ exports[`Modal CSS API responsiveFullScreen true 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div>
+    <div
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined h-100 h-auto-ns vw-100"
+      data-testid="modal__modal"
+      role="dialog"
+    >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined h-100 h-auto-ns vw-100"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6 pt6"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6 pt6"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
-        >
-          Foo
-        </div>
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
+      >
+        Foo
       </div>
     </div>
   </div>
@@ -185,51 +179,49 @@ exports[`Modal CSS API showBottomBarBorder false 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div>
+    <div
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
+    >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
-        >
-          Foo
-        </div>
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
+      >
+        Foo
       </div>
     </div>
   </div>
@@ -244,51 +236,49 @@ exports[`Modal CSS API showTopBar false 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div>
+    <div
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
+    >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
-        >
-          Foo
-        </div>
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
+      >
+        Foo
       </div>
     </div>
   </div>
@@ -303,58 +293,56 @@ exports[`Modal bottomBar should render bottomBar 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div>
+    <div
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
+    >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined mb3"
-        >
-          Foo
-        </div>
-        <div
-          class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph6 mt3 bt b--muted-4"
-        >
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined mb3"
+      >
+        Foo
+      </div>
+      <div
+        class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph6 mt3 bt b--muted-4"
+      >
+        <div>
           <div>
-            <div>
-              Bar
-            </div>
+            Bar
           </div>
         </div>
       </div>
@@ -371,51 +359,49 @@ exports[`Modal container should render modal inside it 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div>
+    <div
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
+    >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
-        >
-          Foo
-        </div>
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
+      >
+        Foo
       </div>
     </div>
   </div>
@@ -430,51 +416,49 @@ exports[`Modal isOpen Should show modal when isOpen is true and hide when is fal
     role="presentation"
     tabindex="-1"
   >
-    <div>
+    <div
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
+    >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
-        >
-          Foo
-        </div>
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
+      >
+        Foo
       </div>
     </div>
   </div>
@@ -489,51 +473,49 @@ exports[`Modal isOpen Should show modal when isOpen is true and hide when is fal
     role="presentation"
     tabindex="-1"
   >
-    <div>
+    <div
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
+    >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
-        >
-          Foo
-        </div>
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
+      >
+        Foo
       </div>
     </div>
   </div>
@@ -548,61 +530,59 @@ exports[`Modal title should render title prop 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div>
+    <div
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
+    >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
-          <span
-            class="t-heading-4 ml8-ns ml6"
-          >
-            <div
-              class="undefined"
-              id="vtex-modal__title"
-            >
-              modal title
-            </div>
-          </span>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
+        <span
+          class="t-heading-4 ml8-ns ml6"
         >
-          Foo
-        </div>
+          <div
+            class="undefined"
+            id="vtex-modal__title"
+          >
+            modal title
+          </div>
+        </span>
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined pb8-ns"
+      >
+        Foo
       </div>
     </div>
   </div>

--- a/react/components/Modal/__snapshots__/index.test.tsx.snap
+++ b/react/components/Modal/__snapshots__/index.test.tsx.snap
@@ -8,19 +8,7 @@ exports[`Modal CSS API centered 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
         aria-labelledby="vtex-modal__title"
         aria-modal="true"
@@ -67,11 +55,6 @@ exports[`Modal CSS API centered 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -84,19 +67,7 @@ exports[`Modal CSS API default 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
         aria-labelledby="vtex-modal__title"
         aria-modal="true"
@@ -143,11 +114,6 @@ exports[`Modal CSS API default 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -160,19 +126,7 @@ exports[`Modal CSS API responsiveFullScreen true 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
         aria-labelledby="vtex-modal__title"
         aria-modal="true"
@@ -219,11 +173,6 @@ exports[`Modal CSS API responsiveFullScreen true 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -236,19 +185,7 @@ exports[`Modal CSS API showBottomBarBorder false 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
         aria-labelledby="vtex-modal__title"
         aria-modal="true"
@@ -295,11 +232,6 @@ exports[`Modal CSS API showBottomBarBorder false 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -312,19 +244,7 @@ exports[`Modal CSS API showTopBar false 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
         aria-labelledby="vtex-modal__title"
         aria-modal="true"
@@ -371,11 +291,6 @@ exports[`Modal CSS API showTopBar false 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -388,19 +303,7 @@ exports[`Modal bottomBar should render bottomBar 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
         aria-labelledby="vtex-modal__title"
         aria-modal="true"
@@ -456,11 +359,6 @@ exports[`Modal bottomBar should render bottomBar 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -473,19 +371,7 @@ exports[`Modal container should render modal inside it 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
         aria-labelledby="vtex-modal__title"
         aria-modal="true"
@@ -532,11 +418,6 @@ exports[`Modal container should render modal inside it 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -549,19 +430,7 @@ exports[`Modal isOpen Should show modal when isOpen is true and hide when is fal
     role="presentation"
     tabindex="-1"
   >
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
         aria-labelledby="vtex-modal__title"
         aria-modal="true"
@@ -608,11 +477,6 @@ exports[`Modal isOpen Should show modal when isOpen is true and hide when is fal
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -625,19 +489,7 @@ exports[`Modal isOpen Should show modal when isOpen is true and hide when is fal
     role="presentation"
     tabindex="-1"
   >
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
         aria-labelledby="vtex-modal__title"
         aria-modal="true"
@@ -684,11 +536,6 @@ exports[`Modal isOpen Should show modal when isOpen is true and hide when is fal
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -701,19 +548,7 @@ exports[`Modal title should render title prop 1`] = `
     role="presentation"
     tabindex="-1"
   >
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
         aria-labelledby="vtex-modal__title"
         aria-modal="true"
@@ -770,11 +605,6 @@ exports[`Modal title should render title prop 1`] = `
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;

--- a/react/components/Modal/index.test.tsx
+++ b/react/components/Modal/index.test.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { render, fireEvent } from '@testing-library/react'
 
 import Modal from '.'
+import Input from '../Input'
 
 describe('Modal', () => {
   jest.spyOn(window, 'scroll').mockImplementation()
@@ -252,6 +253,37 @@ describe('Modal', () => {
       )
 
       expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('initialFocusRef', () => {
+    it('to focus correctly', () => {
+      const containerModal = document.createElement('div')
+      const onClose = jest.fn()
+
+      const Component = () => {
+        const initialFocusRef = useRef<HTMLDivElement>(null)
+
+        return (
+          <Modal
+            isOpen
+            onClose={onClose}
+            container={containerModal}
+            initialFocusRef={initialFocusRef}
+          >
+            <Input
+              placeholder="Type your name..."
+              size="small"
+              ref={initialFocusRef}
+            />
+          </Modal>
+        )
+      }
+      render(<Component />, { container: containerModal })
+
+      const currentFocused = document.activeElement
+
+      expect(currentFocused).toBe(document.querySelector('input'))
     })
   })
 })

--- a/react/components/Modal/index.test.tsx
+++ b/react/components/Modal/index.test.tsx
@@ -1,4 +1,5 @@
-import React, { useRef } from 'react'
+/* eslint-disable jsx-a11y/no-autofocus */
+import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 
 import Modal from '.'
@@ -256,30 +257,17 @@ describe('Modal', () => {
     })
   })
 
-  describe('initialFocusRef', () => {
-    it('to focus correctly', () => {
+  describe('Focus', () => {
+    it('Should respect focus controlled outside Modal', () => {
       const containerModal = document.createElement('div')
       const onClose = jest.fn()
 
-      const Component = () => {
-        const initialFocusRef = useRef<HTMLDivElement>(null)
-
-        return (
-          <Modal
-            isOpen
-            onClose={onClose}
-            container={containerModal}
-            initialFocusRef={initialFocusRef}
-          >
-            <Input
-              placeholder="Type your name..."
-              size="small"
-              ref={initialFocusRef}
-            />
-          </Modal>
-        )
-      }
-      render(<Component />, { container: containerModal })
+      render(
+        <Modal isOpen onClose={onClose} container={containerModal}>
+          <Input autoFocus placeholder="Type your name..." size="small" />
+        </Modal>,
+        { container: containerModal }
+      )
 
       const currentFocused = document.activeElement
 

--- a/react/components/Modal/index.tsx
+++ b/react/components/Modal/index.tsx
@@ -1,12 +1,12 @@
 import React, { FC, forwardRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import classNames from 'classnames'
-import FocusLock from 'react-focus-lock'
 
 import TopBar from './TopBar'
 import BottomBar from './BottomBar'
 import styles from './modal.css'
 import { useEnhancedEffect } from './utils'
+import FocusTrap from './FocusTrap'
 
 export interface Props
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
@@ -99,7 +99,7 @@ export const ModalOverlay: FC<OverlayProps> = ({
           data-testid="modal__overlay"
           role="presentation"
         >
-          <FocusLock className={styles.contents}>{children}</FocusLock>
+          <FocusTrap className={styles.contents}>{children}</FocusTrap>
         </div>,
         container ?? document.body
       )

--- a/react/components/Modal/index.tsx
+++ b/react/components/Modal/index.tsx
@@ -25,13 +25,12 @@ export interface Props
   centered?: boolean
   size?: 'small' | 'medium' | 'large'
   responsiveFullScreen?: boolean
-  initialFocusRef?: React.RefObject<HTMLElement> | null
 }
 
 type OverlayProps = Required<
   Pick<Props, 'isOpen' | 'centered' | 'closeOnOverlayClick' | 'onClose'>
 > &
-  Pick<Props, 'onCloseTransitionFinish' | 'container' | 'initialFocusRef'>
+  Pick<Props, 'onCloseTransitionFinish' | 'container'>
 
 type ContentProps = Required<
   Pick<
@@ -56,7 +55,6 @@ export const ModalOverlay: FC<OverlayProps> = ({
   container,
   closeOnOverlayClick,
   onCloseTransitionFinish,
-  initialFocusRef,
   children,
 }) => {
   const [showPortal, setShowPortal] = useState(isOpen)
@@ -101,7 +99,7 @@ export const ModalOverlay: FC<OverlayProps> = ({
           data-testid="modal__overlay"
           role="presentation"
         >
-          <FocusTrap initialFocusRef={initialFocusRef}>{children}</FocusTrap>
+          <FocusTrap>{children}</FocusTrap>
         </div>,
         container ?? document.body
       )
@@ -202,7 +200,6 @@ function Modal(
     size = 'medium',
     showTopBar = true,
     showBottomBarBorder = true,
-    initialFocusRef,
     ...props
   }: Props,
   forwardedRef: React.Ref<HTMLDivElement>
@@ -215,7 +212,6 @@ function Modal(
       centered={centered}
       closeOnOverlayClick={closeOnOverlayClick}
       onCloseTransitionFinish={onCloseTransitionFinish}
-      initialFocusRef={initialFocusRef}
     >
       <ModalContent
         title={title}

--- a/react/components/Modal/index.tsx
+++ b/react/components/Modal/index.tsx
@@ -25,12 +25,13 @@ export interface Props
   centered?: boolean
   size?: 'small' | 'medium' | 'large'
   responsiveFullScreen?: boolean
+  initialFocusRef?: React.RefObject<HTMLElement> | null
 }
 
 type OverlayProps = Required<
   Pick<Props, 'isOpen' | 'centered' | 'closeOnOverlayClick' | 'onClose'>
 > &
-  Pick<Props, 'onCloseTransitionFinish' | 'container'>
+  Pick<Props, 'onCloseTransitionFinish' | 'container' | 'initialFocusRef'>
 
 type ContentProps = Required<
   Pick<
@@ -55,6 +56,7 @@ export const ModalOverlay: FC<OverlayProps> = ({
   container,
   closeOnOverlayClick,
   onCloseTransitionFinish,
+  initialFocusRef,
   children,
 }) => {
   const [showPortal, setShowPortal] = useState(isOpen)
@@ -99,7 +101,12 @@ export const ModalOverlay: FC<OverlayProps> = ({
           data-testid="modal__overlay"
           role="presentation"
         >
-          <FocusTrap className={styles.contents}>{children}</FocusTrap>
+          <FocusTrap
+            className={styles.contents}
+            initialFocusRef={initialFocusRef}
+          >
+            {children}
+          </FocusTrap>
         </div>,
         container ?? document.body
       )
@@ -200,6 +207,7 @@ function Modal(
     size = 'medium',
     showTopBar = true,
     showBottomBarBorder = true,
+    initialFocusRef,
     ...props
   }: Props,
   forwardedRef: React.Ref<HTMLDivElement>
@@ -212,6 +220,7 @@ function Modal(
       centered={centered}
       closeOnOverlayClick={closeOnOverlayClick}
       onCloseTransitionFinish={onCloseTransitionFinish}
+      initialFocusRef={initialFocusRef}
     >
       <ModalContent
         title={title}

--- a/react/components/Modal/index.tsx
+++ b/react/components/Modal/index.tsx
@@ -101,12 +101,7 @@ export const ModalOverlay: FC<OverlayProps> = ({
           data-testid="modal__overlay"
           role="presentation"
         >
-          <FocusTrap
-            className={styles.contents}
-            initialFocusRef={initialFocusRef}
-          >
-            {children}
-          </FocusTrap>
+          <FocusTrap initialFocusRef={initialFocusRef}>{children}</FocusTrap>
         </div>,
         container ?? document.body
       )

--- a/react/components/Modal/modal.stories.tsx
+++ b/react/components/Modal/modal.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-handler-names */
-import React, { useRef, useEffect } from 'react'
+import React from 'react'
 import { withA11y } from '@storybook/addon-a11y'
 import { withKnobs, boolean, select } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'

--- a/react/components/Modal/modal.stories.tsx
+++ b/react/components/Modal/modal.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-handler-names */
-import React from 'react'
+import React, { useRef } from 'react'
 import { withA11y } from '@storybook/addon-a11y'
 import { withKnobs, boolean, select } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
@@ -20,6 +20,9 @@ const sizes: Size[] = ['small', 'medium', 'large']
 
 export const Default = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
+  const initialFocusRef = useRef<HTMLDivElement>(null)
+
+  const withInitialInputFocus = boolean('Initial Focus in Input', true)
 
   return (
     <>
@@ -39,6 +42,7 @@ export const Default = () => {
         centered={boolean('Centered', true)}
         showBottomBarBorder={boolean('Show Bottom Bar Border', true)}
         closeOnOverlayClick={boolean('Close On Overlay Click', true)}
+        initialFocusRef={withInitialInputFocus ? initialFocusRef : null}
         bottomBar={
           <>
             <Button
@@ -64,7 +68,11 @@ export const Default = () => {
         This is a simple customizable Modal to ask your name! Please try change
         my props below in the Knobs and see how I react!
         <div className="mt6 mb5">
-          <Input placeholder="Type your name..." size="small" />
+          <Input
+            placeholder="Type your name..."
+            size="small"
+            ref={initialFocusRef}
+          />
         </div>
       </Modal>
     </>

--- a/react/components/Modal/modal.stories.tsx
+++ b/react/components/Modal/modal.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-handler-names */
-import React, { useRef } from 'react'
+import React, { useRef, useEffect } from 'react'
 import { withA11y } from '@storybook/addon-a11y'
 import { withKnobs, boolean, select } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
@@ -20,7 +20,6 @@ const sizes: Size[] = ['small', 'medium', 'large']
 
 export const Default = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const initialFocusRef = useRef<HTMLDivElement>(null)
 
   const withInitialInputFocus = boolean('Initial Focus in Input', true)
 
@@ -42,7 +41,6 @@ export const Default = () => {
         centered={boolean('Centered', true)}
         showBottomBarBorder={boolean('Show Bottom Bar Border', true)}
         closeOnOverlayClick={boolean('Close On Overlay Click', true)}
-        initialFocusRef={withInitialInputFocus ? initialFocusRef : null}
         bottomBar={
           <>
             <Button
@@ -69,9 +67,10 @@ export const Default = () => {
         my props below in the Knobs and see how I react!
         <div className="mt6 mb5">
           <Input
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus={withInitialInputFocus}
             placeholder="Type your name..."
             size="small"
-            ref={initialFocusRef}
           />
         </div>
       </Modal>

--- a/react/components/ModalDialog/__snapshots__/index.test.tsx.snap
+++ b/react/components/ModalDialog/__snapshots__/index.test.tsx.snap
@@ -9,101 +9,82 @@ exports[`ModalDialog cancelation should render label 1`] = `
     tabindex="-1"
   >
     <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
     >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined mb3"
-        >
-          Foo
-        </div>
-        <div
-          class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph6 mt3 bt b--muted-4"
-        >
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined mb3"
+      >
+        Foo
+      </div>
+      <div
+        class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph6 mt3 bt b--muted-4"
+      >
+        <div>
           <div>
-            <div>
-              <button
-                class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-transparent b--transparent c-action-primary hover-b--transparent hover-bg-action-secondary hover-b--action-secondary pointer "
-                tabindex="0"
-                type="button"
+            <button
+              class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-transparent b--transparent c-action-primary hover-b--transparent hover-bg-action-secondary hover-b--action-secondary pointer "
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="vtex-button__label flex items-center justify-center h-100 ph5 "
+                style="padding-top: .25em; padding-bottom: .32em;"
               >
-                <div
-                  class="vtex-button__label flex items-center justify-center h-100 ph5 "
-                  style="padding-top: .25em; padding-bottom: .32em;"
-                >
-                  cancel
-                </div>
-              </button>
-              <button
-                class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-action-primary b--action-primary c-on-action-primary hover-bg-action-primary hover-b--action-primary hover-c-on-action-primary pointer "
-                tabindex="0"
-                type="button"
+                cancel
+              </div>
+            </button>
+            <button
+              class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-action-primary b--action-primary c-on-action-primary hover-bg-action-primary hover-b--action-primary hover-c-on-action-primary pointer "
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="vtex-button__label flex items-center justify-center h-100 ph5 "
+                style="padding-top: .25em; padding-bottom: .32em;"
               >
-                <div
-                  class="vtex-button__label flex items-center justify-center h-100 ph5 "
-                  style="padding-top: .25em; padding-bottom: .32em;"
-                >
-                  confirm
-                </div>
-              </button>
-            </div>
+                confirm
+              </div>
+            </button>
           </div>
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -117,101 +98,82 @@ exports[`ModalDialog confirmation isDangerous CSS 1`] = `
     tabindex="-1"
   >
     <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
     >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined mb3"
-        >
-          Foo
-        </div>
-        <div
-          class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph6 mt3 bt b--muted-4"
-        >
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined mb3"
+      >
+        Foo
+      </div>
+      <div
+        class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph6 mt3 bt b--muted-4"
+      >
+        <div>
           <div>
-            <div>
-              <button
-                class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-transparent b--transparent c-action-primary hover-b--transparent hover-bg-action-secondary hover-b--action-secondary pointer "
-                tabindex="0"
-                type="button"
+            <button
+              class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-transparent b--transparent c-action-primary hover-b--transparent hover-bg-action-secondary hover-b--action-secondary pointer "
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="vtex-button__label flex items-center justify-center h-100 ph5 "
+                style="padding-top: .25em; padding-bottom: .32em;"
               >
-                <div
-                  class="vtex-button__label flex items-center justify-center h-100 ph5 "
-                  style="padding-top: .25em; padding-bottom: .32em;"
-                >
-                  cancel
-                </div>
-              </button>
-              <button
-                class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-danger b--danger c-on-danger hover-bg-danger hover-b--danger hover-c-on-danger pointer "
-                tabindex="0"
-                type="button"
+                cancel
+              </div>
+            </button>
+            <button
+              class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-danger b--danger c-on-danger hover-bg-danger hover-b--danger hover-c-on-danger pointer "
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="vtex-button__label flex items-center justify-center h-100 ph5 "
+                style="padding-top: .25em; padding-bottom: .32em;"
               >
-                <div
-                  class="vtex-button__label flex items-center justify-center h-100 ph5 "
-                  style="padding-top: .25em; padding-bottom: .32em;"
-                >
-                  cancel
-                </div>
-              </button>
-            </div>
+                cancel
+              </div>
+            </button>
           </div>
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -225,101 +187,82 @@ exports[`ModalDialog confirmation should render label 1`] = `
     tabindex="-1"
   >
     <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
     >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined mb3"
-        >
-          Foo
-        </div>
-        <div
-          class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph6 mt3 bt b--muted-4"
-        >
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined mb3"
+      >
+        Foo
+      </div>
+      <div
+        class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph6 mt3 bt b--muted-4"
+      >
+        <div>
           <div>
-            <div>
-              <button
-                class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-transparent b--transparent c-action-primary hover-b--transparent hover-bg-action-secondary hover-b--action-secondary pointer "
-                tabindex="0"
-                type="button"
+            <button
+              class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-transparent b--transparent c-action-primary hover-b--transparent hover-bg-action-secondary hover-b--action-secondary pointer "
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="vtex-button__label flex items-center justify-center h-100 ph5 "
+                style="padding-top: .25em; padding-bottom: .32em;"
               >
-                <div
-                  class="vtex-button__label flex items-center justify-center h-100 ph5 "
-                  style="padding-top: .25em; padding-bottom: .32em;"
-                >
-                  cancel
-                </div>
-              </button>
-              <button
-                class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-action-primary b--action-primary c-on-action-primary hover-bg-action-primary hover-b--action-primary hover-c-on-action-primary pointer "
-                tabindex="0"
-                type="button"
+                cancel
+              </div>
+            </button>
+            <button
+              class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-action-primary b--action-primary c-on-action-primary hover-bg-action-primary hover-b--action-primary hover-c-on-action-primary pointer "
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="vtex-button__label flex items-center justify-center h-100 ph5 "
+                style="padding-top: .25em; padding-bottom: .32em;"
               >
-                <div
-                  class="vtex-button__label flex items-center justify-center h-100 ph5 "
-                  style="padding-top: .25em; padding-bottom: .32em;"
-                >
-                  confirm
-                </div>
-              </button>
-            </div>
+                confirm
+              </div>
+            </button>
           </div>
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -333,98 +276,85 @@ exports[`ModalDialog loading CSS 1`] = `
     tabindex="-1"
   >
     <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
+      aria-labelledby="vtex-modal__title"
+      aria-modal="true"
+      class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
+      data-testid="modal__modal"
+      role="dialog"
     >
       <div
-        aria-labelledby="vtex-modal__title"
-        aria-modal="true"
-        class="flex flex-column relative bg-white shadow-5 center mv9 undefined vw-90"
-        data-testid="modal__modal"
-        role="dialog"
+        class="mb5"
       >
         <div
-          class="mb5"
+          class="min-h-small min-h-large-ns pl6 pl8-ns"
         >
           <div
-            class="min-h-small min-h-large-ns pl6 pl8-ns"
+            aria-label="Modal Close Button"
+            class="fr pointer pr6-ns pt6-ns pr5 pt5"
+            role="button"
+            tabindex="0"
           >
-            <div
-              aria-label="Modal Close Button"
-              class="fr pointer pr6-ns pt6-ns pr5 pt5"
-              role="button"
-              tabindex="0"
+            <svg
+              class="vtex__icon-close  "
+              fill="none"
+              height="16"
+              viewBox="0 0 18 18"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
             >
-              <svg
-                class="vtex__icon-close  "
-                fill="none"
-                height="16"
-                viewBox="0 0 18 18"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
+              <g
+                fill="black"
               >
-                <g
-                  fill="black"
-                >
-                  <path
-                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                />
+              </g>
+            </svg>
           </div>
         </div>
-        <div
-          class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined mb3"
-        >
-          Foo
-        </div>
-        <div
-          class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph6 mt3 bt b--muted-4"
-        >
+      </div>
+      <div
+        class="ph6 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined mb3"
+      >
+        Foo
+      </div>
+      <div
+        class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph6 mt3 bt b--muted-4"
+      >
+        <div>
           <div>
-            <div>
-              <button
-                class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-transparent b--transparent c-disabled "
-                disabled=""
-                tabindex="0"
-                type="button"
+            <button
+              class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-transparent b--transparent c-disabled "
+              disabled=""
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="vtex-button__label flex items-center justify-center h-100 ph5 "
+                style="padding-top: .25em; padding-bottom: .32em;"
               >
-                <div
-                  class="vtex-button__label flex items-center justify-center h-100 ph5 "
-                  style="padding-top: .25em; padding-bottom: .32em;"
-                >
-                  cancel
-                </div>
-              </button>
-              <button
-                class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-disabled b--muted-5 c-on-disabled "
-                tabindex="0"
-                type="button"
+                cancel
+              </div>
+            </button>
+            <button
+              class="vtex-button bw1 ba fw5 v-mid relative pa0 lh-solid br2 min-h-small t-action--small bg-disabled b--muted-5 c-on-disabled "
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="vtex-button__spinner-container top-0 left-0 w-100 h-100 absolute flex justify-center items-center"
               >
-                <span
-                  class="vtex-button__spinner-container top-0 left-0 w-100 h-100 absolute flex justify-center items-center"
+                <svg
+                  class="vtex__icon-spinner  c-action-primary"
+                  height="15"
+                  preserveAspectRatio="xMidYMid"
+                  viewBox="0 0 100 100"
+                  width="15"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    class="vtex__icon-spinner  c-action-primary"
-                    height="15"
-                    preserveAspectRatio="xMidYMid"
-                    viewBox="0 0 100 100"
-                    width="15"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <style>
-                      
+                  <style>
+                    
             @keyframes vtex-spinner-rotate {
               from {
                 transform-origin: 50% 50%;
@@ -452,37 +382,31 @@ exports[`ModalDialog loading CSS 1`] = `
               animation: vtex-spinner-fill 1.25s infinite cubic-bezier(0.455, 0.030, 0.515, 0.955), vtex-spinner-rotate 0.625s infinite linear;
             }
           
-                    </style>
-                    <circle
-                      class="vtex-spinner_circle"
-                      cx="50"
-                      cy="50"
-                      fill="none"
-                      r="40"
-                      stroke="currentColor"
-                      stroke-dasharray="0 0 188.49555921538757 251.32741228718345"
-                      stroke-dashoffset="1"
-                      stroke-linecap="round"
-                      stroke-width="10"
-                    />
-                  </svg>
-                </span>
-                <span
-                  class="vtex-button__label flex items-center justify-center h-100 ph5  o-0"
-                >
-                  confirm
-                </span>
-              </button>
-            </div>
+                  </style>
+                  <circle
+                    class="vtex-spinner_circle"
+                    cx="50"
+                    cy="50"
+                    fill="none"
+                    r="40"
+                    stroke="currentColor"
+                    stroke-dasharray="0 0 188.49555921538757 251.32741228718345"
+                    stroke-dashoffset="1"
+                    stroke-linecap="round"
+                    stroke-width="10"
+                  />
+                </svg>
+              </span>
+              <span
+                class="vtex-button__label flex items-center justify-center h-100 ph5  o-0"
+              >
+                confirm
+              </span>
+            </button>
           </div>
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;


### PR DESCRIPTION
#### What is the purpose of this pull request?
Implement our own solution to trap focus in Modal.

#### What problem is this solving?
Dialogs must have focus trapped inside.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
`yarn && yarn storybook`

1. Go to http://localhost:6006/?path=/story/components-modal--default
2. Navigate through Modal with `TAB` and `SHIFT+TAB` and check if it is trapped inside modal.

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
