### PR TITLE
Add forwardedRef to Textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Remove trailing space from `numericStepper` when there isn't a suffix
 
+### Added
+
+- `forwardedRef` prop to `Textarea`.
+
 ## [9.119.0] - 2020-05-21
 
 ### Added

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
+import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
+
 class Textarea extends Component {
   constructor(props) {
     super(props)
@@ -117,6 +119,7 @@ class Textarea extends Component {
           maxLength={this.props.maxLength}
           minLength={this.props.minLength}
           name={this.props.name}
+          ref={this.props.forwardedRef}
           placeholder={this.props.placeholder}
           readOnly={this.props.readOnly}
           required={this.props.required}
@@ -188,6 +191,8 @@ Textarea.propTypes = {
   autoFocus: PropTypes.bool,
   /** Spec attribute */
   disabled: PropTypes.bool,
+  /** @ignore Forwarded Ref */
+  forwardedRef: refShape,
   /** Spec attribute */
   id: PropTypes.string,
   /** If defined, the textarea will have a character countdown at the bottom right */
@@ -222,4 +227,4 @@ Textarea.propTypes = {
   characterCountdownText: PropTypes.string,
 }
 
-export default Textarea
+export default withForwardedRef(Textarea)


### PR DESCRIPTION
#### What is the purpose of this pull request?

We need to have the ref of `Textarea` in order to use [react-hook-form-jsonschema](https://github.com/vtex/react-hook-form-jsonschema)

#### What problem is this solving?
[Running workspace](https://textarea--miriadeit.myvtex.com/contact-us?__bindingAddress=www.miriade.com/it)

[Worksapce with the problem](https://nolink--miriadeit.myvtex.com/contact-us?__bindingAddress=www.miriade.com/it)
![image](https://user-images.githubusercontent.com/8517023/82911914-d3e6d600-9f42-11ea-914d-7cf139b771eb.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
