### PR TITLE
Remove trailing space from numericStepper when suffix doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove trailing space from `numericStepper` when there isn't a suffix
 
 ## [9.119.0] - 2020-05-21
 

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -25,8 +25,9 @@ const validateValue = (value, min, max, defaultValue) => {
 }
 
 const formattedDisplayValue = (value, unitMultiplier, suffix) => {
+  const parsedSuffix = suffix ? ` ${suffix}` : suffix
   return `${Math.round((value * unitMultiplier + Number.EPSILON) * 100) /
-    100} ${suffix ? suffix : ''}`
+    100}${parsedSuffix}`
 }
 
 const validateDisplayValue = (value, min, max, suffix, unitMultiplier) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
`NumericStepper` has a weird behavior when there isn't a suffix. This contribution tries to fix it.

<!--- Describe your changes in detail. -->
I've parsed the suffix variable to check and see if there is any. In which case it puts whitespace between the number and the suffix, otherwise, it adds no space.

#### What problem is this solving?
You can check the behavior here https://www.als.com/edelws-cord-bulk-per-foot/p

<!--- What is the motivation and context for this change? -->
Shoppers that want to put a high quantity in their carts are having trouble.

#### How should this be manually tested?
Just run `yarn styleguide`
 
#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
