### PR TITLE
Fix dropdown background on error and border color on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `forwardedRef` prop to `Textarea`.
+
+### Fixed
+
+- Transparent background on Dropdown component when `error={true}`.
+- Border color of the Dropdown component not changing on focus.
+
 ## [9.119.1] - 2020-06-02
 
 ### Fixed
 - Remove trailing space from `numericStepper` when there isn't a suffix
-
-### Added
-
-- `forwardedRef` prop to `Textarea`.
 
 ## [9.119.0] - 2020-05-21
 

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -19,6 +19,10 @@ class Dropdown extends Component {
     // However, you can't select a null/undefined option, so nil values
     // are transformed to empty string.
     this.initialValue = ''
+
+    this.state = {
+      active: false,
+    }
   }
 
   handleChange = e => {
@@ -69,6 +73,14 @@ class Dropdown extends Component {
     return this.getOptionFromValue(this.props.value)
   }
 
+  handleFocus = () => {
+    this.setState({ active: true })
+  }
+
+  handleBlur = () => {
+    this.setState({ active: false })
+  }
+
   getValueLabel() {
     const selectedOption = this.getSelectedOption()
     return selectedOption ? selectedOption.label : this.getPlaceholder()
@@ -83,6 +95,7 @@ class Dropdown extends Component {
   }
 
   render() {
+    const { active } = this.state
     const {
       label,
       id,
@@ -133,21 +146,30 @@ class Dropdown extends Component {
       'vtex-dropdown--inline dib': isInline,
     })
 
-    const containerClasses = classNames(styles.container, 'br2 relative', {
-      bw1: !isInline || disabled,
-      ba: disabled || error || errorMessage,
-      'b--disabled bg-disabled': disabled,
-      'b--danger hover-b--danger': (error || errorMessage) && !disabled,
-      fw5: isInline && !error && !errorMessage && !disabled,
-      'bg-base hover-b--muted-3 ba b--muted-4':
-        !isInline && !error && !errorMessage && !disabled,
-      't-body': size !== 'small' && size !== 'x-large',
-      'h-auto': isInline && size !== 'x-large',
-      'h-small': !isInline && size === 'small',
-      'h-large': !isInline && size === 'large',
-      'h-regular':
-        !isInline && size !== 'small' && size !== 'large' && size !== 'x-large',
-    })
+    const containerClasses = classNames(
+      styles.container,
+      'bg-base br2 relative',
+      {
+        ba: !isInline,
+        bw1: !isInline || disabled,
+        'b--disabled bg-disabled': disabled,
+        'b--danger hover-b--danger': (error || errorMessage) && !disabled,
+        fw5: isInline && !error && !errorMessage && !disabled,
+        'b--muted-2':
+          active && !isInline && !error && !errorMessage && !disabled,
+        'hover-b--muted-3 b--muted-4':
+          !active && !isInline && !error && !errorMessage && !disabled,
+        't-body': size !== 'small' && size !== 'x-large',
+        'h-auto': isInline && size !== 'x-large',
+        'h-small': !isInline && size === 'small',
+        'h-large': !isInline && size === 'large',
+        'h-regular':
+          !isInline &&
+          size !== 'small' &&
+          size !== 'large' &&
+          size !== 'x-large',
+      }
+    )
 
     const selectClasses = classNames(
       'o-0 absolute top-0 left-0 h-100 w-100 bottom-0',
@@ -196,6 +218,8 @@ class Dropdown extends Component {
               disabled={disabled}
               className={selectClasses}
               onChange={this.handleChange}
+              onFocus={this.handleFocus}
+              onBlur={this.handleBlur}
               ref={this.props.forwardedRef}
               // Check the comment on the constructor regarding nil values
               value={value == null ? '' : value}

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -146,30 +146,23 @@ class Dropdown extends Component {
       'vtex-dropdown--inline dib': isInline,
     })
 
-    const containerClasses = classNames(
-      styles.container,
-      'bg-base br2 relative',
-      {
-        ba: !isInline,
-        bw1: !isInline || disabled,
-        'b--disabled bg-disabled': disabled,
-        'b--danger hover-b--danger': (error || errorMessage) && !disabled,
-        fw5: isInline && !error && !errorMessage && !disabled,
-        'b--muted-2':
-          active && !isInline && !error && !errorMessage && !disabled,
-        'hover-b--muted-3 b--muted-4':
-          !active && !isInline && !error && !errorMessage && !disabled,
-        't-body': size !== 'small' && size !== 'x-large',
-        'h-auto': isInline && size !== 'x-large',
-        'h-small': !isInline && size === 'small',
-        'h-large': !isInline && size === 'large',
-        'h-regular':
-          !isInline &&
-          size !== 'small' &&
-          size !== 'large' &&
-          size !== 'x-large',
-      }
-    )
+    const containerClasses = classNames(styles.container, 'br2 relative', {
+      'bg-base': !isInline,
+      ba: !isInline,
+      bw1: !isInline || disabled,
+      'b--disabled bg-disabled': disabled,
+      'b--danger hover-b--danger': (error || errorMessage) && !disabled,
+      fw5: isInline && !error && !errorMessage && !disabled,
+      'b--muted-2': active && !isInline && !error && !errorMessage && !disabled,
+      'hover-b--muted-3 b--muted-4':
+        !active && !isInline && !error && !errorMessage && !disabled,
+      't-body': size !== 'small' && size !== 'x-large',
+      'h-auto': isInline && size !== 'x-large',
+      'h-small': !isInline && size === 'small',
+      'h-large': !isInline && size === 'large',
+      'h-regular':
+        !isInline && size !== 'small' && size !== 'large' && size !== 'x-large',
+    })
 
     const selectClasses = classNames(
       'o-0 absolute top-0 left-0 h-100 w-100 bottom-0',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixes #1219. Also this fixes the border color of the dropdown when it is focused to match the same as the input component.

#### Screenshots or example usage

Issue:
![image](https://user-images.githubusercontent.com/10223856/82936430-f7227d00-9f64-11ea-9545-e7854082e4d7.png)
![May-26-2020 15-28-35](https://user-images.githubusercontent.com/10223856/82936909-a8c1ae00-9f65-11ea-8cf9-57b98a2bbb08.gif)

With this PR changes:
![image](https://user-images.githubusercontent.com/10223856/82936578-2f29c000-9f65-11ea-952c-5594e3f8af50.png)
![May-26-2020 15-28-10](https://user-images.githubusercontent.com/10223856/82936940-b119e900-9f65-11ea-95c3-3e054ad0e077.gif)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
