### PR TITLE
Fix AutocompleteInput disabled style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Transparent background on Dropdown component when `error={true}`.
 - Border color of the Dropdown component not changing on focus.
+- `AutocompleteInput` disabled style.
 
 ## [9.119.1] - 2020-06-02
 
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [9.119.0] - 2020-05-21
 
 ### Added
+
 - Make screen readers anounce `Alert` content when it pops up in the screen
 - Allow developers to choose to direct focus to the `Alert` when it pops up in the screen by using the `focusOnOpen` property
 - `vtex-checkbox__box-wrapper`, `vtex-checkbox__box`, and `vtex-checkbox__input` handles.

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -68,6 +68,8 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     'b--muted-3': focused,
     'b--muted-4': !focused,
     'br--top': !roundedBottom,
+    'bg-disabled': disabled,
+    'bg-base': !disabled,
   })
 
   const buttonClasses = classNames(
@@ -83,7 +85,7 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     <div className="flex flex-row">
       <div className="relative w-100">
         <input
-          className={`${activeClass} w-100 ma0 border-box bw1 br2 ba outline-0 bg-base c-on-base t-body h-regular ph5 pr8 br--left`}
+          className={`${activeClass} w-100 ma0 border-box bw1 br2 ba outline-0 c-on-base t-body h-regular ph5 pr8 br--left`}
           value={value}
           onFocus={handleFocus}
           onBlur={handleBlur}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a disabled background when the `AutocompleteInput` is disabled

#### How should this be manually tested?
`yarn && yarn styleguide`
Change disabled to `true` in an AutocompleteInput example.

#### Screenshots or example usage
**Before**
![Screenshot from 2020-05-26 16-07-35](https://user-images.githubusercontent.com/6867958/82941732-42408e00-9f6d-11ea-9dde-debbc0b6beb5.png)

**After**
![Screenshot from 2020-05-26 16-24-04](https://user-images.githubusercontent.com/6867958/82941788-5a181200-9f6d-11ea-9fbe-27dbff040ea0.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
