### PR TITLE
#trivial Disable tslint & eslint issues of useCheckboxTree

### DIFF
--- a/react/components/EXPERIMENTAL_useCheckboxTree/__tests__/util.test.ts
+++ b/react/components/EXPERIMENTAL_useCheckboxTree/__tests__/util.test.ts
@@ -1,7 +1,10 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { getFlat, getToggledState } from '../util'
 
 const props = ['children', 'related', 'friends']
-const comparator = item => candidate => item.name === candidate.name
+const comparator = (item: { name: any }) => (candidate: { name: any }) =>
+  item.name === candidate.name
 
 describe('CheckboxTree util tests', () => {
   it('should flat the tree correctly', () => {
@@ -14,9 +17,11 @@ describe('CheckboxTree util tests', () => {
   it('should toggle state correctly on a item without chidren', () => {
     props.forEach(prop => {
       expect(
+        // @ts-ignore
         getToggledState([], { name: 'Alok' }, prop, comparator, () => false)
       ).toEqual([{ name: 'Alok' }])
       expect(
+        // @ts-ignore
         getToggledState([], { name: 'KVSH' }, prop, comparator, () => false)
       ).toEqual([{ name: 'KVSH' }])
     })
@@ -37,6 +42,7 @@ describe('CheckboxTree util tests', () => {
             ],
           },
           prop,
+          // @ts-ignore
           comparator,
           () => false
         )

--- a/react/components/EXPERIMENTAL_useCheckboxTree/index.tsx
+++ b/react/components/EXPERIMENTAL_useCheckboxTree/index.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable no-shadow */
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+/* eslint-disable vtex/prefer-early-return */
 import { useMemo, useCallback, useEffect, useReducer, useState } from 'react'
 import PropTypes from 'prop-types'
 import isEmpty from 'lodash/isEmpty'
@@ -12,6 +15,7 @@ export default function useCheckboxTree<T>({
   onToggle,
   nodesKey = 'children',
   checked = [],
+  // @ts-ignore
   comparator = defaultComparatorCurry,
   isDisabled = (_: T | Tree<T>) => false,
 }: useCheckboxesInput<T>) {
@@ -31,9 +35,12 @@ export default function useCheckboxTree<T>({
       if (!isDisabled(item)) {
         dispatch({
           type: ActionType.Toggle,
+          // @ts-ignore
           itemToToggle: { item, nodesKey, comparator },
+          // @ts-ignore
           isDisabled,
         })
+        // @ts-ignore
         setLastToggledItem(item)
       }
     },
@@ -41,6 +48,7 @@ export default function useCheckboxTree<T>({
   )
 
   useEffect(() => {
+    // @ts-ignore
     onToggle?.({ checkedItems, disabledItems, item: lastToggledItem })
   }, [checkedItems, disabledItems, lastToggledItem, onToggle, toggle])
 
@@ -50,6 +58,7 @@ export default function useCheckboxTree<T>({
 
   useEffect(() => {
     const shake = (tree: Tree<T>) => {
+      // @ts-ignore
       const childNodes = tree[nodesKey] as T[]
 
       if (!childNodes || isEmpty(childNodes)) return
@@ -66,6 +75,7 @@ export default function useCheckboxTree<T>({
       if (!childrenChecked && rootChecked)
         dispatch({
           type: ActionType.Uncheck,
+          // @ts-ignore
           itemToToggle: { item: tree, comparator },
         })
 
@@ -76,6 +86,7 @@ export default function useCheckboxTree<T>({
 
   const isChecked = useCallback(
     (item: T | Tree<T>) => {
+      // @ts-ignore
       const children = item[nodesKey]
       const onCheckedList = (item: T | Tree<T>) =>
         checkedItems.some(comparator(item))
@@ -95,6 +106,7 @@ export default function useCheckboxTree<T>({
     (item: T | Tree<T>) => {
       return (
         !isDisabled(item) &&
+        // @ts-ignore
         item[nodesKey] &&
         getFlat(item, [], nodesKey)
           .slice(1)
@@ -120,7 +132,9 @@ export default function useCheckboxTree<T>({
     if (!isDisabled(item))
       dispatch({
         type: ActionType.BulkCheck,
+        // @ts-ignore
         itemToToggle: { item, comparator, nodesKey },
+        // @ts-ignore
         isDisabled,
       })
   }
@@ -132,6 +146,7 @@ export default function useCheckboxTree<T>({
       if (!isDisabled(item))
         dispatch({
           type: ActionType.BulkUncheck,
+          // @ts-ignore
           itemToToggle: { item, comparator, nodesKey },
         })
     },
@@ -142,6 +157,7 @@ export default function useCheckboxTree<T>({
     uncheck(itemTree)
   }, [itemTree, uncheck])
 
+  // @ts-ignore
   const setChecked = (checked: T[]) => {
     dispatch({ type: ActionType.SetChecked, checked })
   }

--- a/react/components/EXPERIMENTAL_useCheckboxTree/reducer.ts
+++ b/react/components/EXPERIMENTAL_useCheckboxTree/reducer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
 import { getBulkChecked, getBulkUnchecked, getToggledState } from './util'
 import { comparatorCurry, Tree } from './types'
 
@@ -9,6 +10,7 @@ export default function reducer<T>(state: T[], action: Action<T>) {
     }
     case ActionType.Uncheck: {
       const {
+        // @ts-ignore
         itemToToggle: { item, comparator },
       } = action
       const rowFilter = (row: T) => !comparator(row)(item)
@@ -18,18 +20,21 @@ export default function reducer<T>(state: T[], action: Action<T>) {
       const { itemToToggle, isDisabled } = action
       if (!itemToToggle) return state
       const { item, nodesKey, comparator } = itemToToggle
+      // @ts-ignore
       return getBulkChecked(state, item, nodesKey, comparator, isDisabled)
     }
     case ActionType.BulkUncheck: {
       const { itemToToggle } = action
       if (!itemToToggle) return state
       const { item, nodesKey, comparator } = itemToToggle
+      // @ts-ignore
       return getBulkUnchecked(state, item, nodesKey, comparator)
     }
     case ActionType.Toggle: {
       const { itemToToggle, isDisabled } = action
       if (!itemToToggle) return state
       const { item, nodesKey, comparator } = itemToToggle
+      // @ts-ignore
       return getToggledState(state, item, nodesKey, comparator, isDisabled)
     }
     case ActionType.SetChecked: {

--- a/react/components/EXPERIMENTAL_useCheckboxTree/util.ts
+++ b/react/components/EXPERIMENTAL_useCheckboxTree/util.ts
@@ -1,3 +1,8 @@
+/* eslint-disable no-shadow */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/default-param-last */
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+/* eslint-disable max-params */
 import { comparatorCurry, Tree } from './types'
 
 /**
@@ -18,6 +23,7 @@ export function getBulkChecked<T>(
   return [...checked, ...getFlat(item, [], nodesKey)]
     .filter(notDisabled)
     .reduce(
+      // @ts-ignore
       (acc: Array<Tree<T>>, item: T) =>
         acc.some(comparator(item)) ? acc : [...acc, item],
       []
@@ -40,7 +46,7 @@ export function getBulkUnchecked<T>(
   const flatCurry = (item: T, nodesKey: string) => getFlat(item, [], nodesKey)
   const flat = flatCurry(item, nodesKey)
   const bulkFilter = (row: T) => !flat.some(comparator(row))
-  return checked.filter(bulkFilter)
+  return checked.filter(bulkFilter as any)
 }
 
 /**
@@ -59,10 +65,12 @@ export function getToggledState<T>(
   const filter = (row: T) => !comparator(row)(item)
 
   if (stateIncludesItem) {
+    // @ts-ignore
     return item[nodesKey]
       ? getBulkUnchecked<T>(state, item, nodesKey, comparator)
-      : state.filter(filter)
+      : state.filter(filter as any)
   }
+  // @ts-ignore
   return item[nodesKey]
     ? getBulkChecked<T>(state, item, nodesKey, comparator, isDisabled)
     : ([...state, item] as Array<Tree<T>>)
@@ -77,7 +85,9 @@ export function getFlat<T>(
   nodesKey = 'children'
 ): T[] {
   arr.push(tree)
+  // @ts-ignore
   if (tree[nodesKey])
+    // @ts-ignore
     (tree[nodesKey] as Array<Tree<T>>).forEach(child =>
       getFlat(child, arr, nodesKey)
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix es/ts lint issues by skipping then. This is done because the component needs refactoring before leave experimental. (Huge fixes would be lost)

Related issue #1082 

#### Types of changes

- [x] Bugfix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
