### PR TITLE
Fix Checkbox forwardedRef not accepting function refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Transparent background on Dropdown component when `error={true}`.
 - Border color of the Dropdown component not changing on focus.
 - `AutocompleteInput` disabled style.
+- `forwardedRef` of `Checkbox` not accepting functcion refs.
 
 ## [9.119.1] - 2020-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Transparent background on Dropdown component when `error={true}`.
 - Border color of the Dropdown component not changing on focus.
 - `AutocompleteInput` disabled style.
-- `forwardedRef` of `Checkbox` not accepting functcion refs.
+- `forwardedRef` of `Checkbox` not accepting function refs.
 
 ## [9.119.1] - 2020-06-02
 

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -99,7 +99,11 @@ class Checkbox extends PureComponent {
             checked={checked}
             ref={elem => {
               elem && (this.myCheckbox = elem)
-              forwardedRef && (forwardedRef.current = elem)
+              if (typeof forwardedRef === 'function') {
+                forwardedRef(elem)
+              } else if (typeof forwardedRef === 'object') {
+                forwardedRef.current = elem
+              }
             }}
             className={classNames('vtex-checkbox__input h1 w1 absolute o-0', {
               pointer: !disabled,

--- a/react/components/Checkbox/index.test.js
+++ b/react/components/Checkbox/index.test.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import Checkbox from '.'
+
+describe('Checkbox', () => {
+  it('should define the current attribute of the ref object', () => {
+    const refObj = {}
+
+    render(
+      <Checkbox
+        ref={refObj}
+        name="checkme"
+        id="my-checkbox"
+        onChange={() => {}}
+      />
+    )
+
+    const inputElement = document.querySelector('input')
+    expect(refObj.current).toBe(inputElement)
+  })
+
+  it('should accept a ref that is a function', () => {
+    const refSpy = jest.fn()
+    render(
+      <Checkbox
+        ref={refSpy}
+        name="checkme"
+        id="my-checkbox"
+        onChange={() => {}}
+      />
+    )
+    const inputElement = document.querySelector('input')
+
+    expect(refSpy).toBeCalledWith(inputElement)
+  })
+})


### PR DESCRIPTION
#### What is the purpose of this pull request?

`Checkbox`  wasn't accepting refs that had the type `function` and we need refs that work with functions (like https://github.com/vtex/styleguide/pull/1217)


#### What problem is this solving?
1. [Running workspace](https://klyngercheckbox--unileverb2b.myvtex.com/)
2. Click on `Registrar`
3. Scroll and click in the checkbox, it should work


#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
