### PR TITLE
Feature/cell transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `forwardedRef` prop to `Textarea`.
+- Add transition to table v2 cells width.
 
 ### Fixed
 
@@ -17,10 +18,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Border color of the Dropdown component not changing on focus.
 - `AutocompleteInput` disabled style.
 - `forwardedRef` of `Checkbox` not accepting function refs.
+- Padding when table v2 cell has 0 width.
 
 ## [9.119.1] - 2020-06-02
 
 ### Fixed
+
 - Remove trailing space from `numericStepper` when there isn't a suffix
 
 ## [9.119.0] - 2020-05-21

--- a/react/components/EXPERIMENTAL_Table/BulkActions/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/BulkActions/index.tsx
@@ -48,7 +48,7 @@ const BulkActions: FC<BulkActionsProps> & Composites = ({
       )}
       style={{
         height: active ? BULK_ACTIONS_HEIGHT : 0,
-        overflow: active ? 'auto' : 'hidden',
+        overflow: 'hidden',
         ...motion,
       }}
       noMargin>

--- a/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
@@ -79,7 +79,7 @@ function Cell(
     onClick,
     tag: header ? CellTag.Th : CellTag.Td,
     className: classNames('v-mid pv0 tl bb b--muted-4', classNameProp, {
-      ph3: width !== "0%",
+      ph3: width !== '0%',
       pointer: onClick,
       'c-on-base': sorting,
       'bg-base bt': header,

--- a/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
@@ -78,7 +78,8 @@ function Cell(
   const containerProps = {
     onClick,
     tag: header ? CellTag.Th : CellTag.Td,
-    className: classNames('v-mid ph3 pv0 tl bb b--muted-4', classNameProp, {
+    className: classNames('v-mid pv0 tl bb b--muted-4', classNameProp, {
+      ph3: width !== "0%",
       pointer: onClick,
       'c-on-base': sorting,
       'bg-base bt': header,
@@ -89,6 +90,7 @@ function Cell(
       position: sticky ? 'sticky' : 'static',
       width,
       height,
+      transition: 'width 500ms',
     } as CSSProperties,
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add transition to cell width.

#### What problem is this solving?
This allows me to add a softer animation when hidding showing a column.

#### How should this be manually tested?
[Running workspace](https://softhide--cosmetics1.myvtex.com/admin/app/collections/4908/)

#### Screenshots or example usage
Before
![chrome-capture](https://user-images.githubusercontent.com/4912690/83781806-64b96200-a665-11ea-97e0-dd910d9d8aa9.gif)
After
![chrome-capture (1)](https://user-images.githubusercontent.com/4912690/83781822-6d119d00-a665-11ea-87e8-2a84b2709dcd.gif)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
