### PR TITLE
Add disabled prop to FilterBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `forwardedRef` prop to `Textarea`.
 - Add transition to table v2 cells width.
+- `disabled` prop to FilterBar component.
 
 ### Fixed
 

--- a/react/components/FilterBar/FilterTag.js
+++ b/react/components/FilterBar/FilterTag.js
@@ -145,6 +145,7 @@ class FilterTag extends PureComponent {
       isMobile,
       testIds,
       noOptionsMessage,
+      disabled,
     } = this.props
     const { isMenuOpen, virtualStatement } = this.state
 
@@ -198,15 +199,17 @@ class FilterTag extends PureComponent {
         style={{
           ...(isMenuOpen && OPEN_MENU_STYLE),
         }}
-        className={`br2 ba b--solid ${
-          isEmpty || isMoreOptions ? '' : 'pr4'
-        } pv1 dib ${
-          alwaysVisible && isEmpty
-            ? 'bg-transparent hover-bg-muted-5 b--muted-4'
-            : isMoreOptions
-            ? 'hover-bg-muted-5 b--muted-4'
-            : 'bg-action-secondary hover-bg-action-secondary b--action-secondary'
-        } c-on-base`}>
+        className={classNames('br2 ba b--solid pv1 dib c-on-base', {
+          pr4: !isEmpty && !isMoreOptions,
+          'hover-bg-muted-5 b--muted-4':
+            (alwaysVisible && isEmpty) || isMoreOptions,
+          'bg-action-secondary hover-bg-action-secondary b--action-secondary': !(
+            (alwaysVisible && isEmpty) ||
+            isMoreOptions
+          ),
+          'bg-transparent': !disabled && alwaysVisible && isEmpty,
+          'bg-disabled': disabled,
+        })}>
         <div className="flex items-stretch">
           <Menu
             open={isMenuOpen}
@@ -217,8 +220,15 @@ class FilterTag extends PureComponent {
               <button
                 data-testid={options[subject] && options[subject].testId}
                 type="button"
-                className="bw1 ba br2 v-mid relative bg-transparent b--transparent c-action-primary pointer w-100 outline-0"
-                onClick={isMenuOpen ? this.handleCloseMenu : this.openMenu}>
+                className={classNames(
+                  'bw1 ba br2 v-mid relative b--transparent w-100 outline-0',
+                  {
+                    'bg-transparent c-action-primary pointer': !disabled,
+                    'bg-disabled': disabled,
+                  }
+                )}
+                onClick={isMenuOpen ? this.handleCloseMenu : this.openMenu}
+                disabled={disabled}>
                 <div className="flex items-center justify-center h-100 ph3 ">
                   <span className="flex items-center nl1 nowrap">
                     {isMoreOptions ? (
@@ -325,6 +335,7 @@ FilterTag.defaultProps = {
   isMoreOptions: false,
   subjectPlaceholder: '…',
   newFilterLabel: 'New filter',
+  disabled: false,
 }
 
 FilterTag.propTypes = {
@@ -342,6 +353,7 @@ FilterTag.propTypes = {
   device: PropTypes.string,
   isMobile: PropTypes.bool,
   noOptionsMessage: PropTypes.func,
+  disabled: PropTypes.bool,
   testIds: PropTypes.shape({
     moreOptionsButton: PropTypes.string,
     submitFiltersButton: PropTypes.string,

--- a/react/components/FilterBar/README.md
+++ b/react/components/FilterBar/README.md
@@ -617,3 +617,86 @@ class MyOrdersFilter extends React.Component {
 }
 ;<MyOrdersFilter />
 ```
+
+FilterBar disabled example
+
+```js
+const Input = require('../Input').default
+
+function SimpleInputObject({ value, onChange }) {
+  return <Input value={value || ''} onChange={e => onChange(e.target.value)} />
+}
+
+class FilterBarDisabled extends React.Component {
+  constructor() {
+    super()
+    this.state = { statements: [] }
+    this.getSimpleVerbs = this.getSimpleVerbs.bind(this)
+    this.renderSimpleFilterLabel = this.renderSimpleFilterLabel.bind(this)
+  }
+
+  getSimpleVerbs() {
+    return [
+      {
+        label: 'is',
+        value: '=',
+        object: props => <SimpleInputObject {...props} />,
+      },
+      {
+        label: 'is not',
+        value: '!=',
+        object: props => <SimpleInputObject {...props} />,
+      },
+      {
+        label: 'contains',
+        value: 'contains',
+        object: props => <SimpleInputObject {...props} />,
+      },
+    ]
+  }
+
+  renderSimpleFilterLabel(statement) {
+    if (!statement || !statement.object) {
+      // you should treat empty object cases only for alwaysVisibleFilters
+      return 'Any'
+    }
+    return `${
+      statement.verb === '='
+        ? 'is'
+        : statement.verb === '!='
+        ? 'is not'
+        : 'contains'
+    } ${statement.object}`
+  }
+
+  render() {
+    return (
+      <FilterBar
+        alwaysVisibleFilters={['id', 'category', 'brand']}
+        statements={this.state.statements}
+        onChangeStatements={statements => this.setState({ statements })}
+        clearAllFiltersButtonLabel="Clear Filters"
+        disabled
+        options={{
+          id: {
+            label: 'ID',
+            renderFilterLabel: this.renderSimpleFilterLabel,
+            verbs: this.getSimpleVerbs(),
+          },
+          category: {
+            label: 'Category',
+            renderFilterLabel: this.renderSimpleFilterLabel,
+            verbs: this.getSimpleVerbs(),
+          },
+          brand: {
+            label: 'Brand',
+            renderFilterLabel: this.renderSimpleFilterLabel,
+            verbs: this.getSimpleVerbs(),
+          },
+        }}
+      />
+    )
+  }
+}
+;<FilterBarDisabled />
+```

--- a/react/components/FilterBar/index.js
+++ b/react/components/FilterBar/index.js
@@ -103,6 +103,7 @@ class FilterBar extends PureComponent {
       newFilterLabel,
       testIds,
       noOptionsMessage,
+      disabled,
     } = this.props
     const { visibleExtraOptions } = this.state
     const optionsKeys = Object.keys(options)
@@ -140,6 +141,7 @@ class FilterBar extends PureComponent {
                     statements={statements}
                     onClickClear={() => this.handleFilterClear(subject)}
                     onSubmitFilterStatement={this.handleSubmitFilter}
+                    disabled={disabled}
                   />
                 </div>
               )
@@ -164,6 +166,7 @@ class FilterBar extends PureComponent {
                 }}
                 statements={[]}
                 onSubmitFilterStatement={this.handleMoreOptionsSelected}
+                disabled={disabled}
               />
             </div>
           )}
@@ -203,6 +206,7 @@ FilterBar.defaultProps = {
   newFilterLabel: 'New Filter',
   statements: [],
   testIds: {},
+  disabled: false,
 }
 
 export const filterBarPropTypes = {
@@ -226,6 +230,8 @@ export const filterBarPropTypes = {
   newFilterLabel: PropTypes.string,
   /** Function to render the 'No options' when user input match no options in 'More options select'*/
   noOptionsMessage: PropTypes.func,
+  /** Disable all filters */
+  disabled: PropTypes.boolean,
   testIds: PropTypes.shape({
     moreOptionsButton: PropTypes.string,
     submitFiltersButton: PropTypes.string,


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
A missing prop to disable all filters.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
On the preview in the link below, check the disabled example.

#### Screenshots or example usage
![Screenshot from 2020-06-04 16-09-26](https://user-images.githubusercontent.com/6867958/83800438-d00f2e00-a67d-11ea-9b96-68feb29ac25a.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
