### PR TITLE
Add component to hide loading and empty tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `vtex-slider__base-internal` CSS handle.
+- `Table.Sections.LoadedView` to export functionality of hiding the table's body when content is not loaded or is empty.
 
 ### Fixed
 
 - `FilterTag` disabled style.
 - Filter bar button font
-
 
 ## [9.120.1] - 2020-06-05
 

--- a/react/components/EXPERIMENTAL_Table/Sections/LoadedView.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/LoadedView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, Fragment } from 'react'
+import React, { PropsWithChildren, Fragment } from 'react'
 
 import { useLoadingContext } from '../context/loading'
 

--- a/react/components/EXPERIMENTAL_Table/Sections/LoadedView.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/LoadedView.tsx
@@ -1,0 +1,12 @@
+import React, { FC, PropsWithChildren } from 'react'
+
+import { useLoadingContext } from '../context/loading'
+
+function LoadedView({ children }: PropsWithChildren<{}>) {
+  const { empty, loading } = useLoadingContext()
+  return !empty && !loading ? <>{children}</> : null
+}
+
+export type LoadedViewSection = FC
+
+export default LoadedView

--- a/react/components/EXPERIMENTAL_Table/Sections/LoadedView.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/LoadedView.tsx
@@ -1,12 +1,10 @@
-import React, { FC, PropsWithChildren } from 'react'
+import React, { FC, PropsWithChildren, Fragment } from 'react'
 
 import { useLoadingContext } from '../context/loading'
 
 function LoadedView({ children }: PropsWithChildren<{}>) {
   const { empty, loading } = useLoadingContext()
-  return !empty && !loading ? <>{children}</> : null
+  return !empty && !loading ? <Fragment>{children}</Fragment> : null
 }
-
-export type LoadedViewSection = FC
 
 export default LoadedView

--- a/react/components/EXPERIMENTAL_Table/Sections/Tbody.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Tbody.tsx
@@ -7,7 +7,7 @@ import { useTestingContext } from '../context/testing'
 import useTableMotion from '../hooks/useTableMotion'
 import Row, { ROW_TRANSITIONS, ComposableRow } from './Row'
 import { ComposableWithRef, RenderProps, NativeTableSection } from '../types'
-import Hideable from './LoadedView'
+import LoadedView from './LoadedView'
 
 interface BodyRenderProps {
   props: {
@@ -32,7 +32,7 @@ function Tbody(
   const motion = useTableMotion(ROW_TRANSITIONS)
 
   return (
-    <Hideable>
+    <LoadedView>
       <tbody ref={ref} {...rest} data-testid={`${testId}__body`}>
         {items?.map((data, index) => {
           const key = rowKey({ rowData: data })
@@ -53,7 +53,7 @@ function Tbody(
           )
         })}
       </tbody>
-    </Hideable>
+    </LoadedView>
   )
 }
 

--- a/react/components/EXPERIMENTAL_Table/Sections/Tbody.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Tbody.tsx
@@ -4,10 +4,10 @@ import { useBodyContext } from '../context/body'
 import { useDataContext } from '../context/data'
 import { useMeasuresContext } from '../context/measures'
 import { useTestingContext } from '../context/testing'
-import { useLoadingContext } from '../context/loading'
 import useTableMotion from '../hooks/useTableMotion'
 import Row, { ROW_TRANSITIONS, ComposableRow } from './Row'
 import { ComposableWithRef, RenderProps, NativeTableSection } from '../types'
+import Hideable from './LoadedView'
 
 interface BodyRenderProps {
   props: {
@@ -28,32 +28,33 @@ function Tbody(
   const { items } = useDataContext()
   const { rowHeight } = useMeasuresContext()
   const { rowKey } = useBodyContext()
-  const { empty, loading } = useLoadingContext()
   const { testId } = useTestingContext()
   const motion = useTableMotion(ROW_TRANSITIONS)
 
-  return !empty && !loading ? (
-    <tbody ref={ref} {...rest} data-testid={`${testId}__body`}>
-      {items.map((data, index) => {
-        const key = rowKey({ rowData: data })
-        const props = {
-          data,
-          motion,
-          height: rowHeight,
-        }
+  return (
+    <Hideable>
+      <tbody ref={ref} {...rest} data-testid={`${testId}__body`}>
+        {items?.map((data, index) => {
+          const key = rowKey({ rowData: data })
+          const props = {
+            data,
+            motion,
+            height: rowHeight,
+          }
 
-        return children ? (
-          children({
-            props,
-            key,
-            index,
-          })
-        ) : (
-          <Row key={key} {...props} />
-        )
-      })}
-    </tbody>
-  ) : null
+          return children ? (
+            children({
+              props,
+              key,
+              index,
+            })
+          ) : (
+            <Row key={key} {...props} />
+          )
+        })}
+      </tbody>
+    </Hideable>
+  )
 }
 
 interface Composites {

--- a/react/components/EXPERIMENTAL_Table/Sections/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, Ref, PropsWithChildren } from 'react'
+import React, { forwardRef, Ref, PropsWithChildren, FC } from 'react'
 import classNames from 'classnames'
 
 import EmptyState from '../../EmptyState/index.js'
@@ -16,7 +16,7 @@ import { useTestingContext } from '../context/testing'
 import { useLoadingContext } from '../context/loading'
 import Tbody, { ComposableTbody } from './Tbody'
 import Thead, { ComposableThead } from './Thead'
-import LoadedView, { LoadedViewSection } from './LoadedView'
+import LoadedView from './LoadedView'
 
 type Props = PropsWithChildren<
   E2ETestable & HasMotion & NativeTable & { disableScroll?: boolean }
@@ -65,7 +65,7 @@ function Sections(
 interface Composites {
   Head?: ComposableThead
   Body?: ComposableTbody
-  LoadedView?: LoadedViewSection
+  LoadedView?: FC
 }
 
 export type ComposableSections = ComposableWithRef<

--- a/react/components/EXPERIMENTAL_Table/Sections/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/index.tsx
@@ -65,7 +65,7 @@ function Sections(
 interface Composites {
   Head?: ComposableThead
   Body?: ComposableTbody
-  Hideable?: LoadedViewSection
+  LoadedView?: LoadedViewSection
 }
 
 export type ComposableSections = ComposableWithRef<
@@ -78,6 +78,6 @@ const FowardedSections: ComposableSections = forwardRef(Sections)
 
 FowardedSections.Head = Thead
 FowardedSections.Body = Tbody
-FowardedSections.Hideable = LoadedView
+FowardedSections.LoadedView = LoadedView
 
 export default FowardedSections

--- a/react/components/EXPERIMENTAL_Table/Sections/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/index.tsx
@@ -16,6 +16,7 @@ import { useTestingContext } from '../context/testing'
 import { useLoadingContext } from '../context/loading'
 import Tbody, { ComposableTbody } from './Tbody'
 import Thead, { ComposableThead } from './Thead'
+import LoadedView, { LoadedViewSection } from './LoadedView'
 
 type Props = PropsWithChildren<
   E2ETestable & HasMotion & NativeTable & { disableScroll?: boolean }
@@ -64,6 +65,7 @@ function Sections(
 interface Composites {
   Head?: ComposableThead
   Body?: ComposableTbody
+  Hideable?: LoadedViewSection
 }
 
 export type ComposableSections = ComposableWithRef<
@@ -76,5 +78,6 @@ const FowardedSections: ComposableSections = forwardRef(Sections)
 
 FowardedSections.Head = Thead
 FowardedSections.Body = Tbody
+FowardedSections.Hideable = LoadedView
 
 export default FowardedSections

--- a/react/components/EXPERIMENTAL_Table/docs/Advanced.md
+++ b/react/components/EXPERIMENTAL_Table/docs/Advanced.md
@@ -255,7 +255,7 @@ As you can see in the "Customizing body" section sample, it's using the `<Table.
 | Property  | Type             | Required | Default | Description                                    |
 | --------- | ---------------- | -------- | ------- | ---------------------------------------------- |
 | width     | number or string | 🚫       | 🚫      | Cell width (variable by default)               |
-| heigth    | number or string | 🚫       | 🚫      | Cell height (variable by default)              |
+| height    | number or string | 🚫       | 🚫      | Cell height (variable by default)              |
 | className | string           | 🚫       | 🚫      | Custom classes                                 |
 | onClick   | `() => void`     | 🚫       | 🚫      | Action to dispatch on click                    |
 | sortable  | boolean          | 🚫       | false   | If is sortable or not                          |

--- a/react/components/EXPERIMENTAL_Table/docs/Advanced.md
+++ b/react/components/EXPERIMENTAL_Table/docs/Advanced.md
@@ -185,18 +185,77 @@ function BodyExample() {
 ;<BodyExample />
 ```
 
+##### Customizing body
+
+If you want to have full control of you `<tbody>` tag, you can do as the example below:
+
+```js
+import Table from '../index'
+import useTableMeasures from '../hooks/useTableMeasures'
+import { customers } from './sampleData'
+
+const items = customers.slice(0, 5)
+
+function CustomBodyExample() {
+  const measures = useTableMeasures({ size: items })
+
+  return (
+    <Table
+      measures={measures}
+      columns={[
+        {
+          id: 'name',
+          title: 'Name',
+        },
+        {
+          id: 'location',
+          title: 'Location',
+        },
+      ]}
+      items={items}
+      composableSections>
+      <Table.Sections>
+        <Table.Sections.Head />
+        <Table.Sections.LoadedView>
+          <tbody>
+            {items.map((data, key) => (
+              <Table.Sections.Body.Row
+                key={key}
+                data={data}
+                height={measures.rowHeight}>
+                {({ key, props, data, column }) => (
+                  <Table.Sections.Body.Row.Cell key={key} {...props}>
+                    {data[column.id]}
+                  </Table.Sections.Body.Row.Cell>
+                )}
+              </Table.Sections.Body.Row>
+            ))}
+          </tbody>
+        </Table.Sections.LoadedView>
+      </Table.Sections>
+    </Table>
+  )
+}
+
+;<CustomBodyExample />
+```
+
+##### Loaded View
+
+As you can see in the "Customizing body" section sample, it's using the `<Table.Sections.LoadedView>` component, this is used there to hide something from your table when its data is not loaded or it's empty, it's highly recommended to use when customizing the default table components to avoid browser compatibility issues.
+
 ##### Sections Props
 
-| Property | Type | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| disableScroll | boolean | 🚫 | false | Disable scroll overflow of the container |
+| Property      | Type    | Required | Default | Description                              |
+| ------------- | ------- | -------- | ------- | ---------------------------------------- |
+| disableScroll | boolean | 🚫       | false   | Disable scroll overflow of the container |
 
 ##### Cell Props
 
 | Property  | Type             | Required | Default | Description                                    |
 | --------- | ---------------- | -------- | ------- | ---------------------------------------------- |
 | width     | number or string | 🚫       | 🚫      | Cell width (variable by default)               |
-| heigth    | number or string | 🚫       | 🚫     | Cell height (variable by default)               |
+| heigth    | number or string | 🚫       | 🚫      | Cell height (variable by default)              |
 | className | string           | 🚫       | 🚫      | Custom classes                                 |
 | onClick   | `() => void`     | 🚫       | 🚫      | Action to dispatch on click                    |
 | sortable  | boolean          | 🚫       | false   | If is sortable or not                          |

--- a/react/components/EXPERIMENTAL_Table/docs/Advanced.md
+++ b/react/components/EXPERIMENTAL_Table/docs/Advanced.md
@@ -242,7 +242,7 @@ function CustomBodyExample() {
 
 ##### Loaded View
 
-As you can see in the "Customizing body" section sample, it's using the `<Table.Sections.LoadedView>` component, this is used there to hide something from your table when its data is not loaded or it's empty, it's highly recommended to use when customizing the default table components to avoid browser compatibility issues.
+As you can see in the "Customizing body" section sample, it's using the `<Table.Sections.LoadedView>` component, which serves there to hide something from your table when its data is not loaded or is empty. It's highly recommended to use it when customizing the default table components to avoid browser compatibility issues.
 
 ##### Sections Props
 

--- a/react/components/EXPERIMENTAL_Table/docs/Advanced.md
+++ b/react/components/EXPERIMENTAL_Table/docs/Advanced.md
@@ -187,7 +187,7 @@ function BodyExample() {
 
 ##### Customizing body
 
-If you want to have full control of you `<tbody>` tag, you can do as the example below:
+If you want to have full control of your `<tbody>` tag, you can do as the example below:
 
 ```js
 import Table from '../index'


### PR DESCRIPTION
#### What is the purpose of this pull request?

Export the feature of hiding the table's body when the table is not loaded or is empty to be used in tables with custom body

#### What problem is this solving?

If you open [this workspace](https://oldjoserenan--cosmetics1.myvtex.com/admin/app/collections/6268) on firefox and click on "My collection" tab, you will see that the empty state label will be shown at the bottom of the page, if you open it on chrome, it will be in the right position, but if you check on the inspector, will see that the table's tbody is being rendered, that's because we use a custom tbody instead of the styleguide default.

[This workspace](https://joserenan--cosmetics1.myvtex.com/admin/app/collections/6268) uses the component created (`Table.Sections.LoadedView`) wrapping the custom tbody, solving the problem

#### How should this be manually tested?

`yarn && yarn styleguide`

#### Screenshots or example usage

Empty state on firefox before the change
![image](https://user-images.githubusercontent.com/11728746/83918797-d1109000-a74f-11ea-96d6-eb33b8ce7e57.png)

DOM before the change:
![image](https://user-images.githubusercontent.com/11728746/83918980-2056c080-a750-11ea-9060-2019f6003abe.png)

Empty state on firefox after the change, using the new component `Table.Sections.LoadedView` as a wrapper for the custom body:
![image](https://user-images.githubusercontent.com/11728746/83919070-45e3ca00-a750-11ea-93e5-4aa7ff340ac6.png)

DOM after the change:
![image](https://user-images.githubusercontent.com/11728746/83919103-55631300-a750-11ea-87b0-46df8d82f611.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
