### PR TITLE
Enable custom style on Cell & content render-prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+<<<<<<< HEAD
 - `vtex-slider__base-internal` CSS handle.
 - `Table.Sections.LoadedView` to export functionality of hiding the table's body when content is not loaded or is empty.
-- `EXPERIMENTAL_Table/Cell` style.
+- `EXPERIMENTAL_Table/Cell` style prop.
+- `content` render prop on `EXPERIMENTAL_Table/Row`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-<<<<<<< HEAD
 - `vtex-slider__base-internal` CSS handle.
 - `Table.Sections.LoadedView` to export functionality of hiding the table's body when content is not loaded or is empty.
 - `EXPERIMENTAL_Table/Cell` style prop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `vtex-slider__base-internal` CSS handle.
 - `Table.Sections.LoadedView` to export functionality of hiding the table's body when content is not loaded or is empty.
+- `EXPERIMENTAL_Table/Cell` style.
 
 ### Fixed
 

--- a/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
@@ -11,6 +11,7 @@ import React, {
   FC,
 } from 'react'
 import classNames from 'classnames'
+import omit from 'lodash/omit'
 
 import CaretDown from '../../icon/CaretDown/index.js'
 import CaretUp from '../../icon/CaretUp/index.js'
@@ -28,7 +29,7 @@ interface CellContainer
     HTMLAttributes<HTMLTableCellElement>,
     HTMLTableCellElement
   > {
-  tag: CellTag
+  tag?: CellTag
 }
 
 const HoverableCell = forwardRef<
@@ -58,7 +59,7 @@ const DefaultCell = forwardRef<
 
 DefaultCell.displayName = 'DefaultCell'
 
-type Props = PropsWithChildren<SpecificProps>
+type Props = PropsWithChildren<SpecificProps & CellContainer>
 
 function Cell(
   {
@@ -71,6 +72,8 @@ function Cell(
     sortable = false,
     sticky = false,
     header = false,
+    style = {},
+    ...props
   }: Props,
   ref: Ref<HTMLTableCellElement>
 ) {
@@ -91,7 +94,9 @@ function Cell(
       width,
       height,
       transition: 'width 500ms',
+      ...style,
     } as CSSProperties,
+    ...omit(props, ['ref']),
   }
 
   return (

--- a/react/components/EXPERIMENTAL_Table/docs/Advanced.md
+++ b/react/components/EXPERIMENTAL_Table/docs/Advanced.md
@@ -169,9 +169,9 @@ function BodyExample() {
         <Table.Sections.Body>
           {({ key, props }) => (
             <Table.Sections.Body.Row key={key} {...props}>
-              {({ key, props, data, column }) => (
+              {({ key, props, content }) => (
                 <Table.Sections.Body.Row.Cell key={key} {...props}>
-                  {data[column.id]}
+                  {content}
                 </Table.Sections.Body.Row.Cell>
               )}
             </Table.Sections.Body.Row>
@@ -247,13 +247,17 @@ As you can see in the "Customizing body" section sample, it's using the `<Table.
 ##### Sections Props
 
 | Property      | Type    | Required | Default | Description                              |
+<<<<<<< HEAD
 | ------------- | ------- | -------- | ------- | ---------------------------------------- |
+=======
+|---------------|---------|----------|---------|------------------------------------------|
+>>>>>>> Added cell content
 | disableScroll | boolean | 🚫       | false   | Disable scroll overflow of the container |
 
 ##### Cell Props
 
 | Property  | Type             | Required | Default | Description                                    |
-| --------- | ---------------- | -------- | ------- | ---------------------------------------------- |
+|-----------|------------------|----------|---------|------------------------------------------------|
 | width     | number or string | 🚫       | 🚫      | Cell width (variable by default)               |
 | height    | number or string | 🚫       | 🚫      | Cell height (variable by default)              |
 | className | string           | 🚫       | 🚫      | Custom classes                                 |
@@ -266,18 +270,19 @@ As you can see in the "Customizing body" section sample, it's using the `<Table.
 ##### Row Props
 
 | Property | Type                       | Required | Default | Description                |
-| -------- | -------------------------- | -------- | ------- | -------------------------- |
-| height   | number                     | ✅       | 🚫      | Row's height               |
+|----------|----------------------------|----------|---------|----------------------------|
+| height   | number                     | ✅        | 🚫      | Row's height               |
 | data     | unknown                    | 🚫       | 🚫      | Item that will be rendered |
 | motion   | return of `useTableMotion` | 🚫       | 🚫      | Current motion             |
 
 ##### Row Render Props (with composable render)
 
-| Property | Type                        | Required | Default | Description           |
-| -------- | --------------------------- | -------- | ------- | --------------------- |
-| props    | { width: number or string } | ✅       | 🚫      | Width of current cell |
-| key      | string                      | ✅       | 🚫      | Key of current cell   |
-| index    | number                      | ✅       | 🚫      | Index of current cell |
-| data     | unknown                     | ✅       | 🚫      | Data current cell     |
-| column   | Column                      | ✅       | 🚫      | current column        |
-| motion   | return of `useTableMotion`  | 🚫       | 🚫      | Current motion        |
+| Property            | Type                        | Required | Default | Description           |
+|---------------------|-----------------------------|----------|---------|-----------------------|
+| props               | { width: number or string } | ✅        | 🚫      | Width of current cell |
+| key                 | string                      | ✅        | 🚫      | Key of current cell   |
+| index               | number                      | ✅        | 🚫      | Index of current cell |
+| content             | unknown                     | ✅        | 🚫      | Current cell content  |
+| motion              | return of `useTableMotion`  | 🚫       | 🚫      | Current motion        |
+| [DEPRECATED] data   | unknown                     | ✅        | 🚫      | Data current cell     |
+| [DEPRECATED] column | Column                      | ✅        | 🚫      | current column        |

--- a/react/components/EXPERIMENTAL_Table/docs/Advanced.md
+++ b/react/components/EXPERIMENTAL_Table/docs/Advanced.md
@@ -247,11 +247,7 @@ As you can see in the "Customizing body" section sample, it's using the `<Table.
 ##### Sections Props
 
 | Property      | Type    | Required | Default | Description                              |
-<<<<<<< HEAD
-| ------------- | ------- | -------- | ------- | ---------------------------------------- |
-=======
 |---------------|---------|----------|---------|------------------------------------------|
->>>>>>> Added cell content
 | disableScroll | boolean | 🚫       | false   | Disable scroll overflow of the container |
 
 ##### Cell Props

--- a/react/components/Slider/index.js
+++ b/react/components/Slider/index.js
@@ -325,10 +325,13 @@ export default class Slider extends Component {
               top: '0.7rem',
             }}>
             <div
-              className={classNames('vtex-slider__base-internal absolute h-100', {
-                'bg-action-primary': !disabled,
-                'bg-muted-4': disabled,
-              })}
+              className={classNames(
+                'vtex-slider__base-internal absolute h-100',
+                {
+                  'bg-action-primary': !disabled,
+                  'bg-muted-4': disabled,
+                }
+              )}
               style={sliderSelectionStyle}
             />
           </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### What problem is this solving?

The devs must be able to use cells easily

#### How should this be manually tested?

Clone the repo and `yarn && yarn start`

#### Screenshots or example usage

No need

#### Types of changes

- [x] Bugfix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
