### PR TITLE
Fix FilterTag disabled style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `vtex-slider__base-internal` CSS handle.
 
+### Fixed
+
+- `FilterTag` disabled style.
+
 ## [9.120.1] - 2020-06-05
 
 ### Fixed

--- a/react/components/FilterBar/FilterTag.js
+++ b/react/components/FilterBar/FilterTag.js
@@ -203,12 +203,14 @@ class FilterTag extends PureComponent {
           pr4: !isEmpty && !isMoreOptions,
           'hover-bg-muted-5 b--muted-4':
             (alwaysVisible && isEmpty) || isMoreOptions,
-          'bg-action-secondary hover-bg-action-secondary b--action-secondary': !(
+          'bg-action-secondary b--action-secondary': !(
             (alwaysVisible && isEmpty) ||
             isMoreOptions
           ),
+          'hover-bg-action-secondary':
+            (alwaysVisible && isEmpty) || (isMoreOptions && !disabled),
           'bg-transparent': !disabled && alwaysVisible && isEmpty,
-          'bg-disabled': disabled,
+          'bg-disabled hover-bg-disabled': disabled,
         })}>
         <div className="flex items-stretch">
           <Menu
@@ -315,8 +317,14 @@ class FilterTag extends PureComponent {
           </Menu>
           {!isEmpty && !isMoreOptions && (
             <div
-              className="flex items-center c-link hover-c-link pointer"
+              className={classNames('flex items-center', {
+                'c-link hover-c-link pointer': !disabled,
+                'bg-disabled': disabled,
+              })}
               onClick={() => {
+                if (disabled) {
+                  return
+                }
                 this.resetVirtualStatement()
                 onClickClear()
                 this.handleCloseMenu()

--- a/react/components/FilterBar/README.md
+++ b/react/components/FilterBar/README.md
@@ -630,7 +630,11 @@ function SimpleInputObject({ value, onChange }) {
 class FilterBarDisabled extends React.Component {
   constructor() {
     super()
-    this.state = { statements: [] }
+    this.state = {
+      statements: [
+        { object: 'category 1', subject: 'category', verb: '=', error: null },
+      ],
+    }
     this.getSimpleVerbs = this.getSimpleVerbs.bind(this)
     this.renderSimpleFilterLabel = this.renderSimpleFilterLabel.bind(this)
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix FilterTag disabled style when there is a statement selected.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
`IconClose` being active even through the filter tag is disabled

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
`yarn && yarn styleguide`

#### Screenshots or example usage
**Before**
![Screenshot from 2020-06-12 16-58-44](https://user-images.githubusercontent.com/6867958/84541541-011ade80-acce-11ea-9f41-87e6c0c816b7.png)

**After**
![Screenshot from 2020-06-12 16-58-05](https://user-images.githubusercontent.com/6867958/84541550-04ae6580-acce-11ea-982f-46439046e723.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
