### PR TITLE
Adjust react-select style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `FilterBar` clear icon disabled style.
 - `AutocompleteInput` disabled style.
 - Filters hidden for existing statements.
+- `EXPERIMENTAL_Select` style.
 
 ### Added
 

--- a/react/components/EXPERIMENTAL_Select/colors.js
+++ b/react/components/EXPERIMENTAL_Select/colors.js
@@ -3,6 +3,8 @@ export default {
   blue: '#134cd8',
   gray: '#979899',
   lightGray: '#f2f4f5',
-  'muted-4': '#E3E4E6',
+  'muted-2': '#979899',
+  'muted-3': '#cacbcc',
+  'muted-4': '#e3e4e6',
   red: '#ff4c4c',
 }

--- a/react/components/EXPERIMENTAL_Select/colors.js
+++ b/react/components/EXPERIMENTAL_Select/colors.js
@@ -3,6 +3,8 @@ export default {
   blue: '#134cd8',
   gray: '#979899',
   lightGray: '#f2f4f5',
+  'c-on-base': '#3f3f40',
+  'muted-1': '#727273',
   'muted-2': '#979899',
   'muted-3': '#cacbcc',
   'muted-4': '#e3e4e6',

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -75,9 +75,7 @@ class Select extends Component {
       defaultMenuIsOpen,
       ref: forwardedRef,
       autoFocus,
-      className: `pointer b--danger bw1 ${getFontClassNameFromSize(size)} ${
-        errorMessage ? 'b--danger bw1' : ''
-      }`,
+      className: `pointer bw1 ${getFontClassNameFromSize(size)}`,
       components: {
         ClearIndicator,
         Control: function Control(props) {
@@ -181,15 +179,14 @@ class Select extends Component {
           maxHeight: `${valuesMaxHeight}px`,
           overflowY: 'auto',
         }),
-        theme: theme => ({
-          ...theme,
-          colors: {
-            ...theme.colors,
-            primary: COLORS.gray,
-            primary25: COLORS.lightGray,
-          },
-        }),
       },
+      theme: theme => ({
+        ...theme,
+        spacing: {
+          ...theme.spacing,
+          controlHeight: getControlHeightFromSize(size),
+        },
+      }),
       value,
     }
 

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -121,14 +121,24 @@ class Select extends Component {
       options,
       placeholder,
       styles: {
-        control: style => {
-          const errorStyle = errorMessage ? { borderColor: COLORS.red } : {}
+        control: (style, state) => {
+          const { isFocused } = state
 
           return {
             ...style,
-            ...errorStyle,
-            borderColor: COLORS['muted-4'],
-            minHeight: getControlHeightFromSize(size),
+            '&:hover': {
+              borderColor: errorMessage
+                ? COLORS.red
+                : isFocused
+                ? COLORS['muted-2']
+                : COLORS['muted-3'],
+            },
+            boxShadow: 'none',
+            borderColor: errorMessage
+              ? COLORS.red
+              : isFocused
+              ? COLORS['muted-2']
+              : COLORS['muted-4'],
             borderWidth: '.125rem',
           }
         },

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -10,7 +10,11 @@ import DropdownIndicatorComponent from './DropdownIndicator'
 import MultiValueRemove from './MultiValueRemove'
 import Placeholder from './Placeholder'
 import ControlComponent from './Control'
-import { getFontClassNameFromSize, getTagPaddingFromSize } from './styles'
+import {
+  getFontClassNameFromSize,
+  getTagPaddingFromSize,
+  getControlHeightFromSize,
+} from './styles'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
 
 const getOptionValue = option => {
@@ -123,6 +127,8 @@ class Select extends Component {
           return {
             ...style,
             ...errorStyle,
+            borderColor: COLORS['muted-4'],
+            minHeight: getControlHeightFromSize(size),
             borderWidth: '.125rem',
           }
         },
@@ -139,6 +145,7 @@ class Select extends Component {
         }),
         multiValueLabel: (style, state) => ({
           ...style,
+          padding: '0.125rem',
           paddingRight: 0,
           fontWeight: 500,
           color: state.isDisabled ? COLORS.gray : COLORS.blue,
@@ -152,7 +159,6 @@ class Select extends Component {
           },
         }),
         option: style => ({ ...style, cursor: 'pointer' }),
-        placeholder: style => ({ ...style, padding: 10 }),
         valueContainer: (style, state) => ({
           ...style,
           cursor: 'pointer',

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -158,6 +158,7 @@ class Select extends Component {
           padding: '0.125rem',
           paddingRight: 0,
           fontWeight: 500,
+          fontSize: size === 'large' ? '100%' : style.fontSize,
           color: state.isDisabled ? COLORS.gray : COLORS.blue,
         }),
         multiValueRemove: style => ({

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -173,7 +173,8 @@ class Select extends Component {
         valueContainer: (style, state) => ({
           ...style,
           cursor: 'pointer',
-          paddingLeft: '1rem',
+          paddingLeft: state.isMulti && state.hasValue ? '.25rem' : '1rem',
+          paddingRight: '.25rem',
           backgroundColor: state.isDisabled
             ? COLORS.lightGray
             : style.backgroundColor,

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -148,7 +148,6 @@ class Select extends Component {
             : COLORS.aliceBlue,
           borderRadius: 100,
           padding: getTagPaddingFromSize(size),
-          color: state.isDisabled ? COLORS.gray : COLORS.blue,
           position: 'relative',
         }),
         multiValueLabel: (style, state) => ({
@@ -157,14 +156,14 @@ class Select extends Component {
           paddingRight: 0,
           fontWeight: 500,
           fontSize: size === 'large' ? '100%' : style.fontSize,
-          color: state.isDisabled ? COLORS.gray : COLORS.blue,
+          color: state.isDisabled ? COLORS.gray : COLORS['c-on-base'],
         }),
-        multiValueRemove: style => ({
+        multiValueRemove: (style, state) => ({
           ...style,
-          colors: 'inherit',
+          color: state.isDisabled ? COLORS.gray : COLORS['muted-1'],
           ':hover': {
             backgroundColor: 'transparent',
-            color: COLORS.red,
+            color: COLORS.blue,
           },
         }),
         option: style => ({ ...style, cursor: 'pointer' }),

--- a/react/components/EXPERIMENTAL_Select/styles.js
+++ b/react/components/EXPERIMENTAL_Select/styles.js
@@ -1,10 +1,10 @@
 export const getFontClassNameFromSize = size => {
   switch (size) {
-    case 'large':
-      return 't-body'
     case 'small':
-    default:
       return 't-small'
+    case 'large':
+    default:
+      return 't-body'
   }
 }
 
@@ -16,5 +16,16 @@ export const getTagPaddingFromSize = size => {
       return '0 .125rem' // pv0 ph1
     default:
       return '.25rem .5rem' // pv2 ph3
+  }
+}
+
+export const getControlHeightFromSize = size => {
+  switch (size) {
+    case 'large':
+      return '3rem'
+    case 'small':
+      return '2rem'
+    default:
+      return '2.5rem'
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add some custom styles to react-select in order to correspond to our design system style.

#### What problem is this solving?
Since height, padding and font size from select were different from other inputs, they use to get unaligned when together:
![image](https://user-images.githubusercontent.com/5256673/84812643-143af080-afe5-11ea-8c2a-6282e60b61a7.png)
Placeholder font size:
![image](https://user-images.githubusercontent.com/5256673/84812787-519f7e00-afe5-11ea-8198-9a1427a3010c.png)


#### How should this be manually tested?
[Running workspace](https://vlauxbeta--pricingqa.myvtex.com/admin/promotions/1a18dd71-26ae-428b-a425-af6d816af784/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/5256673/84812717-359bdc80-afe5-11ea-9f59-a5419884e9f6.png)

![image](https://user-images.githubusercontent.com/5256673/84812737-3fbddb00-afe5-11ea-9090-b626a2192faa.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
