### PR TITLE
Fix filter bar button font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `FilterTag` disabled style.
+- Filter bar button font
+
 
 ## [9.120.1] - 2020-06-05
 

--- a/react/components/FilterBar/FilterTag.js
+++ b/react/components/FilterBar/FilterTag.js
@@ -223,7 +223,7 @@ class FilterTag extends PureComponent {
                 data-testid={options[subject] && options[subject].testId}
                 type="button"
                 className={classNames(
-                  'bw1 ba br2 v-mid relative b--transparent w-100 outline-0',
+                  'bw1 ba br2 v-mid relative b--transparent w-100 t-body outline-0',
                   {
                     'bg-transparent c-action-primary pointer': !disabled,
                     'bg-disabled': disabled,


### PR DESCRIPTION
#### What is the purpose of this pull request?
As title says.

#### What problem is this solving?
Filter bar buttons were not rendering Fabriga font.

#### How should this be manually tested?
https://styleguide-git-fix-filter-bar-font.styleguide-core.vercel.app/#/Components/Display/Table

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/5256673/84828641-bfa36f80-affc-11ea-8be0-5bd8126bb5e6.png)
After:
![image](https://user-images.githubusercontent.com/5256673/84828669-c9c56e00-affc-11ea-9837-2a2ef9f0358a.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
