### PR TITLE
Fix the device detection in the `withDeviceHoc` that it not consistent when the application is SSR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Table.Sections.LoadedView` to export functionality of hiding the table's body when content is not loaded or is empty.
 - `EXPERIMENTAL_Table/Cell` style prop.
 - `content` render prop on `EXPERIMENTAL_Table/Row`.
+- `isMobile` and `device` properties in the `FilterBar` component for device verification in the `withDeviceHoc` HOC.
 
 ### Fixed
 

--- a/react/components/FilterBar/FilterTag.js
+++ b/react/components/FilterBar/FilterTag.js
@@ -143,6 +143,7 @@ class FilterTag extends PureComponent {
       submitFilterLabel,
       newFilterLabel,
       isMobile,
+      device,
       testIds,
       noOptionsMessage,
       disabled,
@@ -218,6 +219,8 @@ class FilterTag extends PureComponent {
             onBackgroundClick={this.handleCloseMenu}
             align="left"
             options={options[subject]}
+            isMobile={isMobile}
+            device={device}
             button={
               <button
                 data-testid={options[subject] && options[subject].testId}

--- a/react/components/FilterBar/index.js
+++ b/react/components/FilterBar/index.js
@@ -104,6 +104,8 @@ class FilterBar extends PureComponent {
       testIds,
       noOptionsMessage,
       disabled,
+      isMobile,
+      device,
     } = this.props
     const { visibleExtraOptions } = this.state
     const optionsKeys = Object.keys(options)
@@ -142,6 +144,8 @@ class FilterBar extends PureComponent {
                     onClickClear={() => this.handleFilterClear(subject)}
                     onSubmitFilterStatement={this.handleSubmitFilter}
                     disabled={disabled}
+                    isMobile={isMobile}
+                    device={device}
                   />
                 </div>
               )
@@ -167,6 +171,8 @@ class FilterBar extends PureComponent {
                 statements={[]}
                 onSubmitFilterStatement={this.handleMoreOptionsSelected}
                 disabled={disabled}
+                isMobile={isMobile}
+                device={device}
               />
             </div>
           )}
@@ -232,6 +238,10 @@ export const filterBarPropTypes = {
   noOptionsMessage: PropTypes.func,
   /** Disable all filters */
   disabled: PropTypes.boolean,
+  /** If the application is running in a mobile device (it is necessary in SSR applications) */
+  isMobile: PropTypes.boolean,
+  /** device type */
+  device: PropTypes.oneOf(['phone', 'desktop', 'tablet']),
   testIds: PropTypes.shape({
     moreOptionsButton: PropTypes.string,
     submitFiltersButton: PropTypes.string,

--- a/react/components/utils/withDeviceHoc.tsx
+++ b/react/components/utils/withDeviceHoc.tsx
@@ -8,18 +8,23 @@ export enum Device {
 }
 
 const withDevice = Component => {
-  function WithDevice(props) {
+  function WithDevice({
+    device: defaultIsDevice,
+    isMobile: defaultIsMobile,
+    ...props
+  }) {
     // Taken at https://github.com/vtex-apps/device-detector/blob/master/react/useDevice.tsx#L22
     const isScreenMedium = useMedia({ minWidth: '40rem' })
     const isScreenLarge = useMedia({ minWidth: '64.1rem' })
 
-    const device = isScreenLarge
-      ? Device.desktop
-      : isScreenMedium
-      ? Device.tablet
-      : Device.phone
+    const device =
+      defaultIsDevice ?? isScreenLarge
+        ? Device.desktop
+        : isScreenMedium
+        ? Device.tablet
+        : Device.phone
 
-    const isMobile = device.toLowerCase() === 'phone'
+    const isMobile = defaultIsMobile ?? device.toLowerCase() === 'phone'
 
     return <Component device={device} isMobile={isMobile} {...props} />
   }

--- a/react/components/utils/withDeviceHoc.tsx
+++ b/react/components/utils/withDeviceHoc.tsx
@@ -9,8 +9,8 @@ export enum Device {
 
 const withDevice = Component => {
   function WithDevice({
-    device: defaultIsDevice,
-    isMobile: defaultIsMobile,
+    device: customDevice,
+    isMobile: customIsMobile,
     ...props
   }) {
     // Taken at https://github.com/vtex-apps/device-detector/blob/master/react/useDevice.tsx#L22
@@ -18,13 +18,13 @@ const withDevice = Component => {
     const isScreenLarge = useMedia({ minWidth: '64.1rem' })
 
     const device =
-      defaultIsDevice ?? isScreenLarge
+      customDevice ?? isScreenLarge
         ? Device.desktop
         : isScreenMedium
         ? Device.tablet
         : Device.phone
 
-    const isMobile = defaultIsMobile ?? device.toLowerCase() === 'phone'
+    const isMobile = customIsMobile ?? device.toLowerCase() === 'phone'
 
     return <Component device={device} isMobile={isMobile} {...props} />
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Depends on https://github.com/vtex/admin-collections/pull/360
Fix the device detection in the `withDeviceHoc` that it not consistent when the application is SSR.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
[Running workspace](https://filtertags--cosmetics1.myvtex.com/admin/app/collections/7031?tab=add)
The `withDeviceHoc` HOC that detects the device is not consistent when the application is SSR, causing re-rendering with the wrong device type as prop. To resolve this, was added a option to pass this check as a prop in the`FilterBar` component.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
In the running workspace, switch from tab `Adicionar Produtos` to `Minha Coleção`
You can check an example of usage [here](https://github.com/vtex/admin-collections/blob/ca7ed3dec5bf7a620a9e62b813eb005600d3aeb6/react/components/CollectionView/ProductsContent/ProductsTable/OrganizerTable/components/FilterBar.tsx#L37-L52)
#### Screenshots or example usage
##### Before
![input2](https://user-images.githubusercontent.com/20579226/85035799-f5aa3600-b159-11ea-841c-a6eb24afe3f0.gif)
##### After
![input1](https://user-images.githubusercontent.com/20579226/85035767-eb883780-b159-11ea-9469-5be1eb764b55.gif)

##### Passing static props
- device: `phone` isMobile: `true`
![Captura de tela de 2020-06-18 12-30-43](https://user-images.githubusercontent.com/20579226/85040813-93543400-b15f-11ea-9588-3664b6ca7c06.png)
- device: `desktop` isMobile: `false`
![Captura de tela de 2020-06-18 12-31-36](https://user-images.githubusercontent.com/20579226/85040970-bf6fb500-b15f-11ea-91cb-d214c10aef89.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
