### PR TITLE
Fix filterBar clear icon disabled style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `FilterBar` clear icon disabled style.
+
 ## [9.121.0] - 2020-06-19
 
 ### Added

--- a/react/components/FilterBar/FilterTag.js
+++ b/react/components/FilterBar/FilterTag.js
@@ -229,7 +229,7 @@ class FilterTag extends PureComponent {
                   'bw1 ba br2 v-mid relative b--transparent w-100 t-body outline-0',
                   {
                     'bg-transparent c-action-primary pointer': !disabled,
-                    'bg-disabled': disabled,
+                    'bg-disabled c-on-disabled': disabled,
                   }
                 )}
                 onClick={isMenuOpen ? this.handleCloseMenu : this.openMenu}
@@ -322,7 +322,7 @@ class FilterTag extends PureComponent {
             <div
               className={classNames('flex items-center', {
                 'c-link hover-c-link pointer': !disabled,
-                'bg-disabled': disabled,
+                'bg-disabled c-disabled ': disabled,
               })}
               onClick={() => {
                 if (disabled) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.
<!--- Describe your changes in detail. -->

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
`yarn && yarn styleguide` or check [here](https://styleguide-git-fix-filtertag-icon-disabled-style.styleguide-core.vercel.app/#/Components/Display/FilterBar)
Check the disabled example.

#### Screenshots or example usage
**Before**
![Screenshot from 2020-06-19 14-05-11](https://user-images.githubusercontent.com/6867958/85161287-ed272d80-b235-11ea-9d33-67ddf9d1a097.png)

**After**
![Screenshot from 2020-06-19 14-04-27](https://user-images.githubusercontent.com/6867958/85161224-d54fa980-b235-11ea-95c8-95cae9d3d0db.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
