### PR TITLE
Fix AutocompleteInput disabled style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `FilterBar` clear icon disabled style.
+- `AutocompleteInput` disabled style.
 
 ## [9.121.0] - 2020-06-19
 
@@ -24,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `FilterTag` disabled style.
-- Filter bar button font
+- Filter bar button font.
 
 ## [9.120.1] - 2020-06-05
 

--- a/react/components/AutocompleteInput/README.md
+++ b/react/components/AutocompleteInput/README.md
@@ -179,7 +179,8 @@ const CustomOption = props => {
     roundedBottom ? 'br2 br--bottom' : ''
   } ${highlightOption || selected ? 'bg-muted-5' : 'bg-base'}`
 
-  const icon = typeof value === 'string' ? <Search size={14} /> : <User size={14} />
+  const icon =
+    typeof value === 'string' ? <Search size={14} /> : <User size={14} />
 
   // --- This is a good practice. Use <button />.
   return (
@@ -251,4 +252,24 @@ const UsersAutocomplete = () => {
 }
 
 ;<UsersAutocomplete />
+```
+
+#### Disabled AutocompleteInput
+
+```jsx
+import { useState, useRef } from 'react'
+
+const DisabledAutocompleteInput = () => (
+  <AutocompleteInput
+    input={{
+      value: 'Ana Luiza',
+      disabled: true,
+    }}
+    options={{
+      value: [],
+    }}
+  />
+)
+
+;<DisabledAutocompleteInput />
 ```

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -68,8 +68,8 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     'b--muted-3': focused,
     'b--muted-4': !focused,
     'br--top': !roundedBottom,
-    'bg-disabled': disabled,
-    'bg-base': !disabled,
+    'bg-disabled c-disabled': disabled,
+    'bg-base c-on-base': !disabled,
   })
 
   const buttonClasses = classNames(
@@ -85,7 +85,7 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     <div className="flex flex-row">
       <div className="relative w-100">
         <input
-          className={`${activeClass} w-100 ma0 border-box bw1 br2 ba outline-0 c-on-base t-body h-regular ph5 pr8 br--left`}
+          className={`${activeClass} w-100 ma0 border-box bw1 br2 ba outline-0 t-body h-regular ph5 pr8 br--left`}
           value={value}
           onFocus={handleFocus}
           onBlur={handleBlur}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change `AutocompleteInput` value color when is disabled.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
The value inside AutocompleteInput doesn't change color when it is disabled.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
`yarn && yarn styleguide` or check the preview below.

Check the disabled example.

#### Screenshots or example usage
**Before**
![Screenshot from 2020-06-19 14-42-03](https://user-images.githubusercontent.com/6867958/85164667-0f6f7a00-b23b-11ea-9ce0-d9c1f16e9c1c.png)

**After**
![Screenshot from 2020-06-19 14-42-27](https://user-images.githubusercontent.com/6867958/85164711-1dbd9600-b23b-11ea-8c5d-6fe7cd15caa0.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
