### PR TITLE
Show hidden filters for existing statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `FilterBar` clear icon disabled style.
 - `AutocompleteInput` disabled style.
+- Filters hidden for existing statements.
 
 ## [9.121.0] - 2020-06-19
 

--- a/react/components/FilterBar/index.js
+++ b/react/components/FilterBar/index.js
@@ -37,6 +37,18 @@ class FilterBar extends PureComponent {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const { statements, alwaysVisibleFilters } = this.props
+
+    if (statements !== prevProps.statements) {
+      this.setState({
+        visibleExtraOptions: statements
+          .filter(st => !alwaysVisibleFilters.includes(st.subject))
+          .map(st => st.subject),
+      })
+    }
+  }
+
   toggleExtraFilterOption = key => {
     const { visibleExtraOptions } = this.state
     const newVisibleExtraOptions = [


### PR DESCRIPTION
#### What is the purpose of this pull request?
To update visible filter options when statements change.

#### What problem is this solving?
We recently changed the `admin-promotions` app to save filters/pagination/search state during navigation (this was an old feature requested by designers and users). It worked smoothly, except for the last filter (trade policies), which is hidden by default (under "more" options). When restoring its state, the filter kept hidden and unavailable, even though the "clear filters" was enabled. This PR aims to fix this issue, considering filter statements changes on the hidden filters evaluation.

#### How should this be manually tested?
Current code: https://abacate--pricingqa.myvtex.com/admin/promotions
Updated code: https://vlauxbeta--pricingqa.myvtex.com/admin/promotions

Add a filter by Trade Policy (TP). Refresh the page. 

Current behaviour: 
- TP filter cannot be restored; TP filter unavailable; Clear filters enabled

Expected behaviour:
- TP filter restored to its previous state 

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5256673/85627190-84c8b980-b644-11ea-99f6-7be17c190f62.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
