### PR TITLE
Feat/zindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- prop `zIndex` on `Menu` and `ActionMenu` components, to better control the z-index level of these components.
 
 ### Fixed
 

--- a/react/components/ActionMenu/index.js
+++ b/react/components/ActionMenu/index.js
@@ -74,6 +74,7 @@ class ActionMenu extends Component {
       isFirstOfGroup,
       isLastOfGroup,
       isActiveOfGroup,
+      zIndex,
     } = this.props
 
     const { isMenuOpen } = this.state
@@ -88,7 +89,8 @@ class ActionMenu extends Component {
           align={align}
           width={menuWidth}
           options={options}
-          onClose={shouldCloseOnClick ? this.closeMenu : null}>
+          onClose={shouldCloseOnClick ? this.closeMenu : null}
+          zIndex={zIndex}>
           <ButtonWithIcon
             {...{
               icon:
@@ -163,6 +165,8 @@ ActionMenu.propTypes = {
   isLastOfGroup: PropTypes.bool,
   /** */
   isActiveOfGroup: PropTypes.bool,
+  /** Default z-index to Menu view, default is 999 */
+  zIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 
 export default ActionMenu

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -5,6 +5,8 @@ import { Overlay } from 'react-overlays'
 import Toggle from '../Toggle'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
 
+const MAX_Z_INDEX = 2147483647
+const DEFAULT_Z_INDEX = 999
 const CONTAINER_MARGIN = 6
 const WINDOW_MARGIN = 10
 const DEFAULT_DOCUMENT_ELEMENT = {
@@ -112,7 +114,7 @@ class Menu extends Component {
   }
 
   render() {
-    const { options, align, open, onClose, children, width } = this.props
+    const { options, align, open, onClose, children, width, zIndex } = this.props
     const { hasCalculatedSize, isUpwards, isVisible, menuHeight } = this.state
 
     const isRight = align === 'right'
@@ -152,8 +154,9 @@ class Menu extends Component {
                     ? clientWidth - right
                     : left + scrollLeft,
                   width,
+                  zIndex: zIndex === 'max' ? MAX_Z_INDEX : zIndex,
                 }}
-                className={`absolute z-999 ba b--muted-4 br2 shadow-5 ${
+                className={`absolute ba b--muted-4 br2 shadow-5 ${
                   isRight ? 'right-0' : 'left-0'
                 }
               ${isVisible ? 'o-100' : 'o-0'}`}>
@@ -203,6 +206,7 @@ Menu.defaultProps = {
   options: [],
   align: 'right',
   open: false,
+  zIndex: DEFAULT_Z_INDEX,
 }
 
 Menu.propTypes = {
@@ -231,6 +235,8 @@ Menu.propTypes = {
   onClose: PropTypes.func,
   /** Menu Box align (default is right) */
   align: PropTypes.oneOf(['right', 'left']),
+  /** Default z-index to Menu view, default is 999 */
+  zIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 
 export default withForwardedRef(Menu)

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -114,7 +114,15 @@ class Menu extends Component {
   }
 
   render() {
-    const { options, align, open, onClose, children, width, zIndex } = this.props
+    const {
+      options,
+      align,
+      open,
+      onClose,
+      children,
+      width,
+      zIndex,
+    } = this.props
     const { hasCalculatedSize, isUpwards, isVisible, menuHeight } = this.state
 
     const isRight = align === 'right'


### PR DESCRIPTION
#### What is the purpose of this pull request?

The ActionMenu inside a Modal component was not appearing because the zIndex of the Modal is 1000. So I created a prop to be able to set the to a specified value (like: 2,3, 100) or pass the string "max" to put the maximum amount (it is the same amount we use for z-max in our tachyons stylesheet.

#### What problem is this solving?
https://binding--storecomponents.myvtex.com/admin/cms/store
![image](https://user-images.githubusercontent.com/4925068/85803734-3687e900-b71e-11ea-9cb2-041b9c4e77c1.png)


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
