### PR TITLE
Add custom option component to react-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Experimental_Select` dropdown style
+
 ## [9.123.0] - 2020-06-26
 
 ### Added

--- a/react/components/EXPERIMENTAL_Select/Option.tsx
+++ b/react/components/EXPERIMENTAL_Select/Option.tsx
@@ -4,13 +4,22 @@ import OptionProps from 'react-select'
 import IconCheck from '../icon/Check'
 
 const Option = (props: OptionProps) => {
-  const { children, getStyles, isSelected, innerRef, innerProps } = props
+  const {
+    children,
+    getStyles,
+    isMulti,
+    innerProps,
+    innerRef,
+    isSelected,
+  } = props
   return (
     <div style={getStyles('option', props)} ref={innerRef} {...innerProps}>
       <div className="flex">
-        <span className="flex self-center pr3" style={{ width: '1rem' }}>
-          {isSelected ? <IconCheck /> : null}
-        </span>
+        {isMulti ? null : (
+          <span className="flex self-center pr3" style={{ width: '1rem' }}>
+            {isSelected ? <IconCheck /> : null}
+          </span>
+        )}
         {children}
       </div>
     </div>

--- a/react/components/EXPERIMENTAL_Select/Option.tsx
+++ b/react/components/EXPERIMENTAL_Select/Option.tsx
@@ -16,7 +16,7 @@ const Option = (props: OptionProps) => {
     <div style={getStyles('option', props)} ref={innerRef} {...innerProps}>
       <div className="flex">
         {isMulti ? null : (
-          <span className="flex self-center pr3" style={{ width: '1rem' }}>
+          <span className="flex self-center pr3 w1">
             {isSelected ? <IconCheck /> : null}
           </span>
         )}

--- a/react/components/EXPERIMENTAL_Select/Option.tsx
+++ b/react/components/EXPERIMENTAL_Select/Option.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import OptionProps from 'react-select'
+
+import IconCheck from '../icon/Check'
+
+const Option = (props: OptionProps) => {
+  const { children, getStyles, isSelected, innerRef, innerProps } = props
+  return (
+    <div style={getStyles('option', props)} ref={innerRef} {...innerProps}>
+      <div className="flex">
+        <span className="flex self-center pr3" style={{ width: '1rem' }}>
+          {isSelected ? <IconCheck /> : null}
+        </span>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default Option

--- a/react/components/EXPERIMENTAL_Select/colors.js
+++ b/react/components/EXPERIMENTAL_Select/colors.js
@@ -3,6 +3,7 @@ export default {
   blue: '#134cd8',
   gray: '#979899',
   lightGray: '#f2f4f5',
+  'hover-action-secondary': '#DBE9FD',
   'c-on-base': '#3f3f40',
   'muted-1': '#727273',
   'muted-2': '#979899',

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -148,6 +148,9 @@ class Select extends Component {
           backgroundColor: state.isDisabled
             ? COLORS['muted-4']
             : COLORS.aliceBlue,
+          ':hover': {
+            backgroundColor: COLORS['hover-action-secondary'],
+          },
           borderRadius: 100,
           padding: getTagPaddingFromSize(size),
           position: 'relative',

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -4,12 +4,13 @@ import uuid from 'uuid/v4'
 import ReactSelect from 'react-select'
 import CreatableSelect from 'react-select/lib/Creatable'
 
-import COLORS from './colors'
 import ClearIndicator from './ClearIndicator'
+import COLORS from './colors'
+import ControlComponent from './Control'
 import DropdownIndicatorComponent from './DropdownIndicator'
 import MultiValueRemove from './MultiValueRemove'
 import Placeholder from './Placeholder'
-import ControlComponent from './Control'
+import Option from './Option'
 import {
   getFontClassNameFromSize,
   getTagPaddingFromSize,
@@ -93,6 +94,7 @@ class Select extends Component {
         IndicatorSeparator: () => null,
         MultiValueRemove,
         Placeholder,
+        Option,
         ...components,
       },
       defaultValue,
@@ -166,7 +168,14 @@ class Select extends Component {
             color: COLORS.blue,
           },
         }),
-        option: style => ({ ...style, cursor: 'pointer' }),
+        option: (style, state) => ({
+          ...style,
+          cursor: 'pointer',
+          backgroundColor: state.isFocused
+            ? COLORS['hover-action-secondary']
+            : 'transparent',
+          color: COLORS['c-muted-1'],
+        }),
         valueContainer: (style, state) => ({
           ...style,
           cursor: 'pointer',

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -149,6 +149,7 @@ class Select extends Component {
             ? COLORS['muted-4']
             : COLORS.aliceBlue,
           ':hover': {
+            transition: '.15s ease-in-out',
             backgroundColor: COLORS['hover-action-secondary'],
           },
           borderRadius: 100,


### PR DESCRIPTION
#### What is the purpose of this pull request?
As discussed on the last Styleguide's working session, following the work done on https://github.com/vtex/styleguide/pull/1249, we would like to do some more changes on our select to make it more consistent with our Design System. 
#### What problem is this solving?
One defined actionable was to change de dropdown behaviour to show the selected option with a checkbox in front instead of highlighting it with a primary color (`react-select`'s default).

Also fixes multi-select's tag hover ;-) 

#### How should this be manually tested?
https://styleguide-git-feature-custom-option-comp.styleguide-core.vercel.app/

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/5256673/85882933-8914e400-b7b6-11ea-936b-f00926fea948.png)
After:
![image](https://user-images.githubusercontent.com/5256673/85882943-8ca86b00-b7b6-11ea-99f4-1c5cb964ace0.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
