### PR TITLE
Fix autocomplete disabled and active classes

### DIFF
--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -53,39 +53,49 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
   const [focused, setFocused] = useState(false)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange && onChange(e.target.value)
+    onChange?.(e.target.value)
   }
 
   const handleClear = () => {
-    onClear && onClear()
+    if (!disabled) {
+      onClear?.()
+    }
   }
 
   const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
     setFocused(true)
-    onFocus && onFocus(e)
+    onFocus?.(e)
   }
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     setFocused(false)
-    onBlur && onBlur(e)
+    onBlur?.(e)
   }
   const regularSize = size !== 'small' && size !== 'large'
-  const activeClass = classNames({
+
+  const activeClasses = classNames({
     'b--muted-3': focused,
     'b--muted-4': !focused,
     'br--top': !roundedBottom,
     'bg-disabled c-disabled': disabled,
-    'bg-base c-on-base': !disabled,
+    'bg-base': !disabled,
     [`h-${size}`]: !regularSize,
     'h-regular': regularSize,
   })
 
+  const inputClasses = classNames(
+    activeClasses,
+    'w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 pr8 br--left',
+    {
+      'c-on-base': !disabled,
+    }
+  )
+
   const buttonClasses = classNames(
-    activeClass,
+    activeClasses,
     'bg-base br2 br--right w3 bw1 ba pa0 bl-0',
     {
       'c-link pointer': !disabled,
-      'c-disabled': disabled,
     }
   )
 
@@ -93,7 +103,7 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     <div className="flex flex-row">
       <div className="relative w-100">
         <input
-          className={`${activeClass} w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 pr8 br--left`}
+          className={inputClasses}
           value={value}
           onFocus={handleFocus}
           onBlur={handleBlur}
@@ -103,7 +113,10 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
         />
         {onClear && value && (
           <span
-            className="absolute c-muted-3 fw5 flex items-center ph3 t-body top-0 right-0 h-100 pointer"
+            className={classNames(
+              'absolute c-muted-3 fw5 flex items-center ph3 t-body top-0 right-0 h-100',
+              { pointer: !disabled }
+            )}
             onClick={handleClear}>
             <ClearInputIcon />
           </span>


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### What problem is this solving?

The button color must be `c-link`, not `c-on-base`.
The user should not be able to clear disabled inputs.

#### How should this be manually tested?

Check the documentation preview or use the Codesandbox playground

#### Screenshots or example usage
### Before:
![Screen Recording 2020-06-26 at 16 52 47 2020-06-26 17_00_21](https://user-images.githubusercontent.com/6964311/85896508-f9c7fa80-b7ce-11ea-9ea4-427226075e6f.gif)
<img width="857" alt="Screen Shot 2020-06-26 at 16 52 21" src="https://user-images.githubusercontent.com/6964311/85895745-9db0a680-b7cd-11ea-81f7-f0527eae46b8.png">

### After:
<img width="857" alt="Screen Shot 2020-06-26 at 16 52 04" src="https://user-images.githubusercontent.com/6964311/85895737-9b4e4c80-b7cd-11ea-9ce6-c6bd2a1fc30d.png">


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
