### PR TITLE
Fixed tooltip icon sample code

### DIFF
--- a/react/components/Tooltip/README.md
+++ b/react/components/Tooltip/README.md
@@ -39,18 +39,29 @@ const Button = require('../Button').default
 const Edit = require('../icon/Edit').default
 const Info = require('../icon/Info').default
 
+/*
+  The following code is just for the table above to be rendered.
+  To use the Icon components one need only to import and instanciate it.
+
+  Usage:
+    * VTEX IO: import <IconName> from 'vtex.styleguide'
+    * npm: import <IconName> from '@vtex/styleguide/lib/icon/<IconName>'
+
+  !!!!!! DO NOT IMPORT LIKE BELOW !!!!!!
+*/
+
 ;<div className="flex w-100 justify-center items-center">
   <div className="ph9">
     <Tooltip label="Edit this order">
       <span className="c-on-base pointer">
-        <Edit />
+        <IconEdit />
       </span>
     </Tooltip>
   </div>
   <div className="ph9">
     <Tooltip label="This order was invoiced">
       <span className="c-on-base pointer">
-        <Info />
+        <IconInfo />
       </span>
     </Tooltip>
   </div>

--- a/react/components/Tooltip/README.md
+++ b/react/components/Tooltip/README.md
@@ -39,17 +39,6 @@ const Button = require('../Button').default
 const Edit = require('../icon/Edit').default
 const Info = require('../icon/Info').default
 
-/*
-  The following code is just for the table above to be rendered.
-  To use the Icon components one need only to import and instanciate it.
-
-  Usage:
-    * VTEX IO: import <IconName> from 'vtex.styleguide'
-    * npm: import <IconName> from '@vtex/styleguide/lib/icon/<IconName>'
-
-  !!!!!! DO NOT IMPORT LIKE BELOW !!!!!!
-*/
-
 ;<div className="flex w-100 justify-center items-center">
   <div className="ph9">
     <Tooltip label="Edit this order">

--- a/react/components/Tooltip/README.md
+++ b/react/components/Tooltip/README.md
@@ -36,8 +36,8 @@ const Button = require('../Button').default
 #### Label and Informative text
 
 ```jsx
-const Edit = require('../icon/Edit').default
-const Info = require('../icon/Info').default
+const IconEdit = require('../icon/Edit').default
+const IconInfo = require('../icon/Info').default
 
 ;<div className="flex w-100 justify-center items-center">
   <div className="ph9">


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix sample code for using icons with tooltips

Wrong: `<Edit />` and `<Info />`
Correct: `<IconEdit />` and `<IconInfo />`

#### What problem is this solving?

I was [trying to use the sample code in an app](https://vtex.slack.com/archives/C1MCRG7CK/p1593651613061000) and got an error. This was because the component names for the icons were wrong. Not sure if imports should also be fixed in this sample code or renamed in [this page](https://styleguide.vtex.com/#/Icons), though.

#### How should this be manually tested?

Copy and paste the sample code and try building it in VTEX IO.

#### Screenshots or example usage

![Screen Shot 2020-07-01 at 21 53 45](https://user-images.githubusercontent.com/2094877/86305546-486aff80-bbe8-11ea-9a8b-781ea8000bff.png)

<img width="527" alt="Screen Shot 2020-07-01 at 21 54 46" src="https://user-images.githubusercontent.com/2094877/86305556-515bd100-bbe8-11ea-98fe-44c549f8ba73.png">
<img width="351" alt="Screen Shot 2020-07-01 at 21 55 04" src="https://user-images.githubusercontent.com/2094877/86305558-51f46780-bbe8-11ea-8c56-6a7bc27d159f.png">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
