### PR TITLE
Fix Tooltip position calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Select menu overflow
+- `Tooltip` position calculation. Use container instead of window to calculate collisions.
 
 ## [9.124.0] - 2020-07-02
+
 ### Added
 - prop `zIndex` on `Menu` and `ActionMenu` components, to better control the z-index level of these components.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Select menu overflow
-- `Tooltip` position calculation. Use container instead of window to calculate collisions.
+- `Tooltip` position calculation. Use container and window to calculate collisions.
 
 ## [9.124.0] - 2020-07-02
 

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -209,8 +209,6 @@ const getPopupPositionRecursively = (
     left: styles.left < window.pageXOffset,
   }
 
-  console.log(`Collisions ${position}`, collisions)
-
   if (collisions[position]) {
     fallbackPosition = getFallbackPosition(position, fallbackPosition)
     // If there is no place without collisions, it will not be shown

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -173,8 +173,14 @@ const getPopupPositionRecursively = (
   fallbackPosition,
   originalPosition
 ) => {
-  const horizontalMax = container.clientWidth + window.pageXOffset - OFFSET
-  const verticalMax = container.clientWidth + window.pageYOffset - OFFSET
+  const horizontalMax =
+    Math.min(window.innerWidth, container.clientWidth) +
+    window.pageXOffset -
+    OFFSET
+  const verticalMax =
+    Math.min(window.innerHeight, container.clientHeight) +
+    window.pageYOffset -
+    OFFSET
   const styles = {
     left:
       childRect.left +
@@ -202,6 +208,8 @@ const getPopupPositionRecursively = (
     bottom: styles.top + popupRect.height > verticalMax,
     left: styles.left < window.pageXOffset,
   }
+
+  console.log(`Collisions ${position}`, collisions)
 
   if (collisions[position]) {
     fallbackPosition = getFallbackPosition(position, fallbackPosition)

--- a/react/components/Tooltip/TooltipPopup.tsx
+++ b/react/components/Tooltip/TooltipPopup.tsx
@@ -96,6 +96,7 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   )
 
   const positionStyle = getStyles(
+    container ?? document.body,
     childRect,
     popupRect,
     position,
@@ -121,9 +122,21 @@ const TooltipPopup: FC<PropTypes.InferProps<typeof propTypes>> = ({
   )
 }
 
-const getStyles = (childRect, popupRect, position, fallbackPosition) => {
+const getStyles = (
+  container,
+  childRect,
+  popupRect,
+  position,
+  fallbackPosition
+) => {
   return childRect && popupRect && window && hasComputedDimensions(popupRect)
-    ? getPopupPosition(childRect, popupRect, position, fallbackPosition)
+    ? getPopupPosition(
+        container,
+        childRect,
+        popupRect,
+        position,
+        fallbackPosition
+      )
     : { top: 0, left: 0 }
 }
 
@@ -135,10 +148,17 @@ const FALLBACK_POSITION = {
 }
 
 const getFallbackPosition = (position, fallback) =>
-  fallback || FALLBACK_POSITION[position]
+  fallback ?? FALLBACK_POSITION[position]
 
-const getPopupPosition = (childRect, popupRect, position, fallbackPosition) =>
+const getPopupPosition = (
+  container,
+  childRect,
+  popupRect,
+  position,
+  fallbackPosition
+) =>
   getPopupPositionRecursively(
+    container,
     childRect,
     popupRect,
     position,
@@ -146,14 +166,15 @@ const getPopupPosition = (childRect, popupRect, position, fallbackPosition) =>
     position
   )
 const getPopupPositionRecursively = (
+  container,
   childRect,
   popupRect,
   position,
   fallbackPosition,
   originalPosition
 ) => {
-  const horizontalMax = window.innerWidth + window.pageXOffset
-  const verticalMax = window.innerHeight + window.pageYOffset
+  const horizontalMax = container.clientWidth + window.pageXOffset - OFFSET
+  const verticalMax = container.clientWidth + window.pageYOffset - OFFSET
   const styles = {
     left:
       childRect.left +
@@ -188,6 +209,7 @@ const getPopupPositionRecursively = (
     return fallbackPosition === originalPosition
       ? null
       : getPopupPositionRecursively(
+          container,
           childRect,
           popupRect,
           fallbackPosition,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Now the idea is to use the `container.clientWidth` prop to calculate collisions alongside with `window.innerWidth`.

#### What problem is this solving?

Tooltip getting cropped out of the screen

![image](https://user-images.githubusercontent.com/15948386/86480614-b9173680-bd24-11ea-8375-ce3c66a6858d.png)

#### How should this be manually tested?

Access, at the Vercel CI link, the tooltip page. At the first example, replace it for this code:
```jsx
const Button = require('../Button').default

;<div className="flex w-100 justify-between">
  <Tooltip label="Tooltip text">
    <Button variation="tertiary">Top</Button>
  </Tooltip>
  <Tooltip label="Tooltip text" position="left">
    <Button variation="tertiary">Left</Button>
  </Tooltip>
  <Tooltip label="Tooltip text" position="right">
    <Button variation="tertiary">Right</Button>
  </Tooltip>
  <Tooltip label="Tooltip textTooltip textTooltip textTooltip textTooltip textTooltip textTooltip textTooltip textTooltip text" position="right" trigger="focus">
    <Button variation="tertiary">Bottom</Button>
  </Tooltip>
</div>
```

Now change the screen size so the `BOTTOM` button gets closer to the page end and then click on it.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/86481477-78b8b800-bd26-11ea-83d8-2ab105a1e209.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
