### PR TITLE
Remove semicolons from the beginning of the examples

### DIFF
--- a/react/components/Alert/README.md
+++ b/react/components/Alert/README.md
@@ -75,7 +75,7 @@ You can associate an action to an Alert.
 const Button = require('../Button').default
 const alertRef = React.createRef()
 
-;<div>
+<div>
   <Alert ref={alertRef} type="warning" onClose={() => console.log('Closed!')}>
     Click on the button below to focus on (scroll to) the alert
   </Alert>

--- a/react/components/ButtonGroup/README.md
+++ b/react/components/ButtonGroup/README.md
@@ -9,7 +9,7 @@ Default
 ```js
 const Button = require('../Button').default
 initialState = { active: 1 }
-;<div>
+<div>
   <ButtonGroup
     buttons={[
       <Button
@@ -37,7 +37,7 @@ Sizes
 ```js
 const Button = require('../Button').default
 initialState = { active: 1 }
-;<div>
+<div>
   <ButtonGroup
     buttons={[
       <Button
@@ -87,7 +87,7 @@ Misc
 ```js
 const Button = require('../Button').default
 initialState = { active: 1 }
-;<div>
+<div>
   <ButtonGroup
     buttons={[
       <Button
@@ -140,7 +140,7 @@ const edit = <Edit />
 const plus = <PlusLines />
 
 initialState = { active: 1 }
-;<div>
+<div>
   <ButtonGroup
     buttons={[
       <ButtonWithIcon
@@ -189,7 +189,7 @@ const options = [
 }))
 
 initialState = { active: 1 }
-;<div>
+<div>
   <ButtonGroup
     buttons={[
       <Button isActiveOfGroup>new</Button>,

--- a/react/components/Checkbox/README.md
+++ b/react/components/Checkbox/README.md
@@ -19,7 +19,7 @@ Default
 
 ```js
 initialState = { check1: true, check2: false, check3: false }
-;<div>
+<div>
   <div className="mb3">
     <Checkbox
       checked={state.check1}
@@ -95,7 +95,7 @@ Without label
 
 ```js
 initialState = { check1: true, check2: false, check3: false }
-;<div>
+<div>
   <div className="mb3">
     <Checkbox
       checked={state.check1}

--- a/react/components/CheckboxGroup/README.md
+++ b/react/components/CheckboxGroup/README.md
@@ -24,7 +24,7 @@ initialState = { checkedMap: {
     check3: {label: "Filter 3", checked: false}
    }
 }
-;<div>
+<div>
   <CheckboxGroup
     name="simpleCheckboxGroup"
     label="All Filters"
@@ -47,7 +47,7 @@ initialState = { checkedMap: {
     check3: {label: "Filter 3", checked: false}
    }
 }
-;<div>
+<div>
   <CheckboxGroup
     name="disabledCheckboxGroup"
     disabled
@@ -72,7 +72,7 @@ initialState = { checkedMap: {
     check3: {label: "Filter 3", checked: false}
    }
 }
-;<div>
+<div>
   <CheckboxGroup
     padded={false}
     name="withoutPaddingCheckboxGroup"

--- a/react/components/Collapsible/README.md
+++ b/react/components/Collapsible/README.md
@@ -50,7 +50,7 @@ Custom Caret Color Example
 
 ```js
 initialState = { isOpen1: false, isOpen2: false, isOpen3: false }
-;<div>
+<div>
   <div className="mb5">
     <Collapsible
       header={<span>Here goes your base header</span>}
@@ -85,7 +85,7 @@ Navigation bar example
 ```js
 const PageBlock = require('../PageBlock').default
 initialState = { isOpen1: false, isOpen2: false, isOpen3: false }
-;<div>
+<div>
   <div className="w5">
     <div className="mt5">
       <Collapsible
@@ -258,7 +258,7 @@ function toggleAccordion(questionNbr) {
     })
 }
 
-;<div>
+<div>
   <div className="bg-muted-5 pa8">
     <div className="w-100">
       <Box>

--- a/react/components/DatePicker/README.md
+++ b/react/components/DatePicker/README.md
@@ -22,7 +22,7 @@ initialState = {
   startDate2: new Date(),
   startDate3: new Date(),
 }
-;<div>
+<div>
   <div className="mb5">
     <DatePicker
       label="Small"

--- a/react/components/EXPERIMENTAL_Select/README.md
+++ b/react/components/EXPERIMENTAL_Select/README.md
@@ -38,7 +38,7 @@ const options = [
   },
 ]
 
-;<div>
+<div>
   <div className="mb5">
     <Select
       defaultValue={options[0]}
@@ -94,7 +94,7 @@ const options = [
   },
 ]
 
-;<div>
+<div>
   <Select
     label="Label"
     options={options}
@@ -138,7 +138,7 @@ const options = [
   },
 ]
 
-;<div>
+<div>
   <Select
     label="Label"
     options={options}
@@ -164,7 +164,7 @@ const options = [
   },
 ]
 
-;<div>
+<div>
   <Select
     options={options}
     multi={true}
@@ -189,7 +189,7 @@ const options = [
   },
 ]
 
-;<div>
+<div>
   <Select
     label="Label"
     options={options}
@@ -215,7 +215,7 @@ const options = [
     label: 'Second Option',
   },
 ]
-;<div>
+<div>
   <Select
     label="Label"
     options={options}
@@ -242,7 +242,7 @@ const options = [
   },
 ]
 
-;<div>
+<div>
   <Select
     disabled={true}
     label="Label"
@@ -286,7 +286,7 @@ const options = [
   },
 ]
 
-;<div>
+<div>
   <Select
     loading={true}
     label="Label"
@@ -317,7 +317,7 @@ const options = [
 
 const ref = React.createRef()
 
-;<div>
+<div>
   <Select
     ref={ref}
     label="Click in the button below to focus on this Select"

--- a/react/components/EmptyState/README.md
+++ b/react/components/EmptyState/README.md
@@ -14,7 +14,7 @@
 ```js
 const Button = require('../Button').default
 
-;<div>
+<div>
   <EmptyState title="A big headline">
     <p>
       A longer explanation of what should be here, and why should I care about

--- a/react/components/Input/README.md
+++ b/react/components/Input/README.md
@@ -18,7 +18,7 @@
 Sizes
 
 ```js
-;<div>
+<div>
   <div className="mb5">
     <Input placeholder="Placeholder" size="small" label="Small" />
   </div>
@@ -136,7 +136,7 @@ const handleFocusClick = () => {
   this.input.current.focus()
 }
 
-;<div>
+<div>
   <Input
     ref={this.input}
     placeholder="Placeholder"

--- a/react/components/InputButton/README.md
+++ b/react/components/InputButton/README.md
@@ -22,7 +22,7 @@ In addition to the props above, InputButton accepts all the props the Input comp
 With submit button
 
 ```js
-;<div>
+<div>
   <div className="mb5">
     <InputButton placeholder="Placeholder" size="regular" label="Regular" button="Submit" />
   </div>
@@ -58,7 +58,7 @@ initialState = { isLoading: false };
 Disabled
 
 ```js
-;<div>
+<div>
   <div className="mb5">
     <InputButton placeholder="Placeholder" size="regular" label="Regular disabled" button="Submit" disabled />
   </div>

--- a/react/components/InputCurrency/README.md
+++ b/react/components/InputCurrency/README.md
@@ -4,7 +4,7 @@ Sizes
 
 ```js
 initialState = { value1: '', value2: '', value3: '' }
-;<div>
+<div>
   <div className="mb5">
     <InputCurrency
       label="Small"

--- a/react/components/InputPassword/README.md
+++ b/react/components/InputPassword/README.md
@@ -1,6 +1,6 @@
 ```js
 initialState = { value1: 'Passw0rd', value2: 'Passw0rd', value3: 'Passw0rd' }
-;<div>
+<div>
   <form
     className="mb5"
     onSubmit={e => {

--- a/react/components/InputSearch/README.md
+++ b/react/components/InputSearch/README.md
@@ -2,7 +2,7 @@ Sizes
 
 ```js
 initialState = { value1: '', value2: '', value3: '' }
-;<div>
+<div>
   <InputSearch
     placeholder="Search..."
     value={state.value1}

--- a/react/components/MultiSelect/README.md
+++ b/react/components/MultiSelect/README.md
@@ -42,7 +42,7 @@ options = [
   { label: 'Dark-red', value: 'dark-red' },
   { label: 'Light-blue', value: 'light-blue' },
 ]
-;<div>
+<div>
   <MultiSelect
     label="Colors"
     options={options}

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -34,7 +34,7 @@ const defaultSchema = {
   },
 }
 
-;<div>
+<div>
   <div className="mb5">
     <Table
       fullWidth
@@ -411,7 +411,7 @@ const defaultSchema = {
   },
 }
 
-;<div>
+<div>
   <div>
     <Table
       fullWidth
@@ -598,7 +598,7 @@ const lineActions = [
   },
 ]
 
-;<div>
+<div>
   <div className="mb5">
     <Table
       fullWidth

--- a/react/components/Tabs/README.md
+++ b/react/components/Tabs/README.md
@@ -30,7 +30,7 @@ Default
 ```js
 const Tab = require('./Tab').default
 initialState = { currentTab: 1 }
-;<div>
+<div>
   <Tabs>
     <Tab
       label="Today"
@@ -71,7 +71,7 @@ Full width tabs
 ```js
 const Tab = require('./Tab').default
 initialState = { currentTab: 1 }
-;<div>
+<div>
   <Tabs fullWidth>
     <Tab
       label="Accounts"
@@ -99,7 +99,7 @@ Disabled tabs
 
 ```js
 const Tab = require('./Tab').default
-;<div>
+<div>
   <Tabs>
     <Tab label="Active and disabled tab" active disabled onClick={() => {}} />
     <Tab label="Disabled tab" disabled onClick={() => {}} />

--- a/react/components/Textarea/README.md
+++ b/react/components/Textarea/README.md
@@ -2,7 +2,7 @@
 initialState = {
   value: '',
 }
-;<div>
+<div>
   <div className="mb6">
     <Textarea label="Default state">Please enter your feedbacks here…</Textarea>
   </div>

--- a/react/components/TimePicker/README.md
+++ b/react/components/TimePicker/README.md
@@ -12,7 +12,7 @@ Simple _TimePicker_
 
 ```js
 initialState = { date1: undefined, date2: undefined, date3: undefined }
-;<div>
+<div>
   <div className="mb5">
     <TimePicker
       label="Small"
@@ -50,7 +50,7 @@ Locale
 ```js
 const RadioGroup = require('../RadioGroup').default
 initialState = { locale: 'pt-BR', date: undefined }
-;<div>
+<div>
   <div className="mb5">
     <RadioGroup
       name="locale"
@@ -82,7 +82,7 @@ Using ref
 const Button = require('../Button').default
 initialState = { date: undefined }
 const ref = React.createRef()
-;<div>
+<div>
   <div className="mb5">
     <TimePicker
       ref={ref}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Hello everyone, everything good? Is there any intention to include semicolons at the beginning of the code?

If there is no apparent utility, the pull request removes all of them from the beginning.

#### What problem is this solving?

Removes the seemingly inefficient semicolons at the beginning of the code. To make the code cleaner.

#### How should this be manually tested?

Just viewing the page, in the examples section.

#### Screenshots or example usage

For this pull request, there is no need.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
