### PR TITLE
Fix PageHeader link button hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Table's empty state style
+- Page header button hover
 
 ## [9.124.2] - 2020-07-09
 

--- a/react/components/PageHeader/index.js
+++ b/react/components/PageHeader/index.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
 import ArrowBack from '../icon/ArrowBack'
-import Button from '../Button'
+import ButtonPlain from '../ButtonPlain'
 
 class PageHeader extends PureComponent {
   handleClick = e => {
@@ -15,21 +15,11 @@ class PageHeader extends PureComponent {
     return (
       <div className="vtex-pageHeader__container pa5 pa7-ns">
         {linkLabel && (
-          <div className="vtex-pageHeader-link__container">
-            <Button
-              size="small"
-              variation="tertiary"
-              neutral
-              onClick={this.handleClick}>
-              <span
-                className="flex align-baseline relative"
-                style={{ marginLeft: '-16px' }}>
-                <span className="mr3">
-                  <ArrowBack color="currentColor" />
-                </span>
-                {linkLabel}
-              </span>
-            </Button>
+          <div className="vtex-pageHeader-link__container mb3">
+            <ButtonPlain onClick={this.handleClick}>
+              <ArrowBack color="currentColor" />
+              <span className="ml3 ttu t-action--small">{linkLabel}</span>
+            </ButtonPlain>
           </div>
         )}
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
As title says.

#### What problem is this solving?
Button link on PageHeader has an exceeding padding on the right.
![image](https://user-images.githubusercontent.com/5256673/86803088-0d375900-c04c-11ea-8f1a-856458ec2261.png)

#### How should this be manually tested?
https://styleguide-git-fix-page-header-btn.styleguide-core.vercel.app/#/Components/Admin%20structure/PageHeader

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5256673/86826746-87c1a200-c067-11ea-85a9-1e9cda825f27.png)

(using ButtonPlain as recommended by @davicosta99)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
