### PR TITLE
Table's empty state style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Table's empty state style
+
 ## [9.124.2] - 2020-07-09
 
 ### Fixed
@@ -23,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [9.124.0] - 2020-07-02
 
 ### Added
+
 - prop `zIndex` on `Menu` and `ActionMenu` components, to better control the z-index level of these components.
 
 ### Fixed

--- a/react/components/EmptyState/index.js
+++ b/react/components/EmptyState/index.js
@@ -6,11 +6,9 @@ class EmptyState extends PureComponent {
     const { title, children, testId } = this.props
 
     return (
-      <div
-        className="MAIN br3 flex c-muted-2 justify-center pv9 ph6 ph9-l tc"
-        data-testid={testId}>
-        <div className="w-80 w-50-l">
-          {title && <span className="t-heading-3 mt0 mt0">{title}</span>}
+      <div className="flex items-center h-100 c-muted-2" data-testid={testId}>
+        <div className="w-80 w-60-l center tc">
+          {title && <span className="t-heading-3 mt0">{title}</span>}
           {children && <div className="t-body lh-copy">{children}</div>}
         </div>
       </div>

--- a/react/components/EmptyState/index.js
+++ b/react/components/EmptyState/index.js
@@ -8,7 +8,7 @@ class EmptyState extends PureComponent {
     return (
       <div className="flex items-center h-100 c-muted-2" data-testid={testId}>
         <div className="w-80 w-60-l center tc">
-          {title && <span className="t-heading-3 mt0">{title}</span>}
+          {title && <span className="t-heading-4 mt0">{title}</span>}
           {children && <div className="t-body lh-copy">{children}</div>}
         </div>
       </div>

--- a/react/components/Table/SimpleTable.js
+++ b/react/components/Table/SimpleTable.js
@@ -215,7 +215,7 @@ class SimpleTable extends Component {
             <Spinner />
           </div>
         ) : (
-          <div>
+          <div className="h-100">
             <AutoSizer key={tableKey}>
               {({ width }) => {
                 const colsWidth = Object.keys(schema.properties).reduce(
@@ -427,7 +427,7 @@ class SimpleTable extends Component {
               }}
             </AutoSizer>
             {items.length === 0 && (
-              <div style={{ marginTop: HEADER_HEIGHT }}>
+              <div className="h-100" style={{ paddingTop: HEADER_HEIGHT }}>
                 <EmptyState title={emptyStateLabel}>
                   {emptyStateChildren}
                 </EmptyState>


### PR DESCRIPTION
#### What is the purpose of this pull request?
As title says. See discussion [here](https://vtex.slack.com/archives/C1MCRG7CK/p1593715263074400).

#### What problem is this solving?
Changes made:
- empty state content vertically aligned
- width changed from 50 to 60% on large screens (>64rem)
- emptyStateLabel using h4 instead of h3

#### How should this be manually tested?
https://styleguide-git-fix-table-empty-state.styleguide-core.vercel.app/#/Components/Display/Table

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/5256673/86962119-bce9f500-c138-11ea-9f08-bec697d0068d.png)

After:
![image](https://user-images.githubusercontent.com/5256673/86962134-c1aea900-c138-11ea-8efc-0e078c9bd1a5.png)

Before:
![image](https://user-images.githubusercontent.com/5256673/86962152-c8d5b700-c138-11ea-9a3f-1c9d50df42a4.png)

After:
![image](https://user-images.githubusercontent.com/5256673/86962173-d0955b80-c138-11ea-97e4-116415cfda5e.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
