### PR TITLE
fix select menu overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Select menu overflow
+
 ## [9.124.0] - 2020-07-02
 ### Added
 - prop `zIndex` on `Menu` and `ActionMenu` components, to better control the z-index level of these components.

--- a/react/components/EXPERIMENTAL_Select/README.md
+++ b/react/components/EXPERIMENTAL_Select/README.md
@@ -352,7 +352,6 @@ class SelectWithModalExample extends React.Component {
   constructor() {
     super()
     this.state = { isModalOpen: false }
-    this.ref = React.createRef()
     this.handleModalToggle = this.handleModalToggle.bind(this)
   }
 

--- a/react/components/EXPERIMENTAL_Select/README.md
+++ b/react/components/EXPERIMENTAL_Select/README.md
@@ -330,3 +330,67 @@ const ref = React.createRef()
   </div>
 </div>
 ```
+
+With Modal
+
+```js
+const Button = require('../Button').default
+const Modal = require('../Modal').default
+
+const options = [
+  {
+    value: 'first-option',
+    label: 'First option',
+  },
+  {
+    value: 'second-option',
+    label: 'Second option',
+  },
+]
+
+class SelectWithModalExample extends React.Component {
+  constructor() {
+    super()
+    this.state = { isModalOpen: false }
+    this.ref = React.createRef()
+    this.handleModalToggle = this.handleModalToggle.bind(this)
+  }
+
+  handleModalToggle() {
+    this.setState({ isModalOpen: !this.state.isModalOpen })
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <Button onClick={this.handleModalToggle}>Open</Button>
+        <Modal
+          centered
+          title="Select in Modal"
+          isOpen={this.state.isModalOpen}
+          onClose={this.handleModalToggle}
+          bottomBar={
+            <div className="nowrap">
+              <span className="mr4">
+                <Button variation="tertiary" onClick={this.handleModalToggle}>
+                  Cancel
+                </Button>
+              </span>
+              <span>
+                <Button variation="primary" onClick={this.handleModalToggle}>
+                  Send
+                </Button>
+              </span>
+            </div>
+          }>
+          <div className="mb3">
+            <Select options={options} />
+          </div>
+        </Modal>
+      </React.Fragment>
+    )
+  }
+}
+
+;<SelectWithModalExample />
+```

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -73,6 +73,7 @@ class Select extends Component {
     } = this.props
 
     const reactSelectComponentProps = {
+      menuPosition: 'fixed',
       defaultMenuIsOpen,
       ref: forwardedRef,
       autoFocus,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allows the no select menu to overflow the modal

<!--- Describe your changes in detail. -->

#### What problem is this solving?
Currently, when using select within a modal, it ends up having the overflow with error.
![Screen Shot 2020-07-08 at 17 24 38](https://user-images.githubusercontent.com/10627086/86966673-ece8c680-c13f-11ea-8ec3-66e3bad0f6f1.png) 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

entering the documentation and going to the select session, last example

#### Screenshots or example usage

![Screen Shot 2020-07-08 at 17 25 31](https://user-images.githubusercontent.com/10627086/86966733-0853d180-c140-11ea-9dbe-46e35cdc3b5d.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
