### PR TITLE
Add disabled prop to ActionMenu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Table's empty state style
 - Page header button hover
 
+### Added
+
+- `disabled` prop for ActionMenu items
+
 ## [9.124.2] - 2020-07-09
 
 ### Fixed

--- a/react/components/ActionMenu/README.md
+++ b/react/components/ActionMenu/README.md
@@ -21,8 +21,8 @@ const options = [
     onClick: () => alert('sure, everybody knows that the bird is the word...'),
   },
   {
-    label: 'Hey look',
-    onClick: () => alert('Listen!'),
+    label: 'I\'m a poor disabled option',
+    disabled: true,
   },
   {
     label: 'Quit now and cake will be served',

--- a/react/components/ActionMenu/index.js
+++ b/react/components/ActionMenu/index.js
@@ -150,6 +150,7 @@ ActionMenu.propTypes = {
     PropTypes.shape({
       label: PropTypes.node,
       onClick: PropTypes.func,
+      disabled: PropTypes.bool,
       /** whether option has inline toggle */
       toggle: PropTypes.shape({
         checked: PropTypes.bool,

--- a/react/components/ActionMenu/index.js
+++ b/react/components/ActionMenu/index.js
@@ -149,7 +149,7 @@ ActionMenu.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.node,
-      handleCallback: PropTypes.func,
+      onClick: PropTypes.func,
       /** whether option has inline toggle */
       toggle: PropTypes.shape({
         checked: PropTypes.bool,

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -176,7 +176,9 @@ class Menu extends Component {
                       <button
                         disabled={option.disabled}
                         key={index}
-                        className="flex justify-between items-center t-body ph6 h-regular pointer hover-bg-muted-5 ma0 bg-transparent bn w-100 tl"
+                        className={`flex justify-between items-center t-body ph6 h-regular ma0 bg-transparent bn w-100 tl ${
+                          option.disabled ? '' : 'hover-bg-muted-5 pointer'
+                        }`}
                         onClick={() => {
                           option.onClick(option)
                           if (onClose) {

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -174,6 +174,7 @@ class Menu extends Component {
                     className={menuHeight ? 'overflow-auto' : ''}>
                     {options.map((option, index) => (
                       <button
+                        disabled={option.disabled}
                         key={index}
                         className="flex justify-between items-center t-body ph6 h-regular pointer hover-bg-muted-5 ma0 bg-transparent bn w-100 tl"
                         onClick={() => {
@@ -185,7 +186,13 @@ class Menu extends Component {
                         <span
                           className={`${
                             option.toggle ? 'w-70 truncate' : 'w-100 truncate'
-                          } ${option.isDangerous ? 'c-danger' : ''}`}>
+                          } ${
+                            option.disabled
+                              ? 'c-disabled'
+                              : option.isDangerous
+                              ? 'c-danger'
+                              : ''
+                          }`}>
                           {option.label}
                         </span>
                         {option.toggle && (
@@ -232,6 +239,7 @@ Menu.propTypes = {
     PropTypes.shape({
       label: PropTypes.node,
       onClick: PropTypes.func,
+      disabled: PropTypes.bool,
       /** whether option has inline toggle */
       toggle: PropTypes.shape({
         checked: PropTypes.bool,

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Overlay } from 'react-overlays'
+import classNames from 'classnames'
 
 import Toggle from '../Toggle'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
@@ -176,9 +177,12 @@ class Menu extends Component {
                       <button
                         disabled={option.disabled}
                         key={index}
-                        className={`flex justify-between items-center t-body ph6 h-regular ma0 bg-transparent bn w-100 tl ${
-                          option.disabled ? '' : 'hover-bg-muted-5 pointer'
-                        }`}
+                        className={classNames(
+                          'flex justify-between items-center t-body ph6 h-regular ma0 bg-transparent bn w-100 tl',
+                          {
+                            'hover-bg-muted-5 pointer': !option.disabled,
+                          }
+                        )}
                         onClick={() => {
                           option.onClick(option)
                           if (onClose) {
@@ -186,15 +190,12 @@ class Menu extends Component {
                           }
                         }}>
                         <span
-                          className={`${
-                            option.toggle ? 'w-70 truncate' : 'w-100 truncate'
-                          } ${
-                            option.disabled
-                              ? 'c-disabled'
-                              : option.isDangerous
-                              ? 'c-danger'
-                              : ''
-                          }`}>
+                          className={classNames({
+                            'w-70 truncate': option.toggle,
+                            'w-100 truncate': !option.toggle,
+                            'c-disabled': option.disabled,
+                            'c-danger': option.isDangerous,
+                          })}>
                           {option.label}
                         </span>
                         {option.toggle && (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Simple as described on title. Details on linked issue #1150 

#### How should this be manually tested?
https://styleguide-git-fix-1150disabled-menu-options.styleguide-core.vercel.app/#/Components/Forms/ActionMenu

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5256673/87188151-b2f4fd00-c2c4-11ea-9d8f-e3ce627d6465.png)
![image](https://user-images.githubusercontent.com/5256673/87188186-c2744600-c2c4-11ea-964f-ca47de2bf00d.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
