### PR TITLE
Hide clear button on `InputSearch` when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `disabled` prop for ActionMenu items
+- Hide clear button on `InputSearch` when disabled
 
 ## [9.124.2] - 2020-07-09
 

--- a/react/components/InputSearch/index.js
+++ b/react/components/InputSearch/index.js
@@ -61,7 +61,7 @@ class InputSearch extends Component {
 
   render() {
     const { hover, focus } = this.state
-    const { size } = this.props
+    const { disabled, size, value } = this.props
     const iconSize =
       InputSearch.iconSizes[size] || InputSearch.iconSizes.regular
 
@@ -76,12 +76,12 @@ class InputSearch extends Component {
         type="search"
         suffix={
           <div className="flex flex-row items-center">
-            {this.props.value && (
+            {value && (
               <span
                 tabIndex={0}
                 onClick={this.handleClickClear}
                 className="pointer mr4 c-muted-3">
-                <ClearIcon size={iconSize} />
+                {!disabled && <ClearIcon size={iconSize} />}
               </span>
             )}
             <div
@@ -105,6 +105,7 @@ class InputSearch extends Component {
 }
 
 InputSearch.propTypes = {
+  disabled: PropTypes.bool,
   /** @ignore Forwarded Ref */
   forwardedRef: refShape,
   onChange: PropTypes.func,


### PR DESCRIPTION
#### What is the purpose of this pull request?
As title says. Details on linked issue #1254 

#### What problem is this solving?
Disabled button is visible even when input is disabled. This allow input content to be cleared.

#### How should this be manually tested?
https://styleguide-git-fix-1254hide-clear-when-disabled.styleguide-core.vercel.app/#/Components/Forms/InputSearch

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5256673/87192748-809bcd80-c2cd-11ea-92ae-185501975b70.png)


#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
