### PR TITLE
Fix/tab active color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Table's empty state style
 - Page header button hover
+- `Tab` active color being set as `outset`.
 
 ### Added
 

--- a/react/components/Tabs/Tab.js
+++ b/react/components/Tabs/Tab.js
@@ -15,7 +15,7 @@ class Tab extends Component {
     if (active && disabled) {
       tabStyle = 'fw5 b--muted-1 c-muted-2'
     } else if (active) {
-      tabStyle = 'c-on-muted b--emphasis fw5 vtex-tab__button--active'
+      tabStyle = 'c-on-muted b--emphasis fw5 vtex-tab__button--active b--solid'
     } else if (disabled) {
       tabStyle = 'b--muted-4 c-muted-3'
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Closes https://github.com/vtex/styleguide/issues/1236
<!--- Describe your changes in detail. -->

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Chrome automatically added `border-style: outset` and safari too. Check the issue for more info.

#### How should this be manually tested?
[Check fixed here](https://fixtabcolor--storecomponents.myvtex.com/admin/collections/1182/?tab=add) and then [compare to master](https://storecomponents.myvtex.com/admin/collections/1182/?tab=add)

#### Screenshots or example usage

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
