### PR TITLE
Fix select label size on regular variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Table's empty state style
 - Page header button hover
 - `Tab` active color being set as `outset`.
+- Select's label size on regular variation.
 
 ### Added
 

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -210,8 +210,8 @@ class Select extends Component {
         {label && (
           <label
             className={classNames('dib mb3 w-100 c-on-base', {
-              't-small': size === 'small',
-              't-body': size !== 'small',
+              't-small': size !== 'large',
+              't-body': size === 'large',
             })}>
             {label}
           </label>

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -207,7 +207,10 @@ class Select extends Component {
     return (
       <div className="flex flex-column">
         {label && (
-          <label className={`dib mb3 w-100 ${getFontClassNameFromSize(size)}`}>
+          <label
+            className={`dib mb3 w-100 c-on-base ${getFontClassNameFromSize(
+              size
+            )}`}>
             {label}
           </label>
         )}

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import uuid from 'uuid/v4'
@@ -208,9 +209,10 @@ class Select extends Component {
       <div className="flex flex-column">
         {label && (
           <label
-            className={`dib mb3 w-100 c-on-base ${getFontClassNameFromSize(
-              size
-            )}`}>
+            className={classNames('dib mb3 w-100 c-on-base', {
+              't-small': size === 'small',
+              't-body': size !== 'small',
+            })}>
             {label}
           </label>
         )}

--- a/react/components/EXPERIMENTAL_Select/styles.js
+++ b/react/components/EXPERIMENTAL_Select/styles.js
@@ -1,9 +1,9 @@
 export const getFontClassNameFromSize = size => {
   switch (size) {
-    case 'large':
-      return 't-body'
-    default:
+    case 'small':
       return 't-small'
+    default:
+      return 't-body'
   }
 }
 

--- a/react/components/EXPERIMENTAL_Select/styles.js
+++ b/react/components/EXPERIMENTAL_Select/styles.js
@@ -1,10 +1,9 @@
 export const getFontClassNameFromSize = size => {
   switch (size) {
-    case 'small':
-      return 't-small'
     case 'large':
-    default:
       return 't-body'
+    default:
+      return 't-small'
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says...

#### What problem is this solving?

Regular sized select's label size should be `t-small`

#### Screenshots or example usage

##### Without the change

Input label sizes:

![image](https://user-images.githubusercontent.com/15948386/87459751-3030b280-c5e2-11ea-91a4-77fddb0dc299.png)

Select label sizes:

![image](https://user-images.githubusercontent.com/15948386/87459811-42aaec00-c5e2-11ea-97f7-e563d90f8b36.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
