### PR TITLE
Allow accent on Select's input change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Page header button hover
 - `Tab` active color being set as `outset`.
 - Select's label size on regular variation.
+- Accent on `Select` input change.
 
 ### Added
 

--- a/react/components/EXPERIMENTAL_Select/Control.js
+++ b/react/components/EXPERIMENTAL_Select/Control.js
@@ -10,7 +10,7 @@ function heightClassFromSize(size) {
   }[size]
 }
 
-const Control = ({ size, ...props }) => {
+const Control = ({ selectProps: { size }, ...props }) => {
   return (
     <div className={`pa0 ${heightClassFromSize(size)}`}>
       <components.Control {...props} />
@@ -19,8 +19,7 @@ const Control = ({ size, ...props }) => {
 }
 
 Control.propTypes = {
-  errorMessage: PropTypes.string,
-  size: PropTypes.oneOf(['large', 'regular', 'small']),
+  selectProps: PropTypes.object.isRequired,
 }
 
 export default Control

--- a/react/components/EXPERIMENTAL_Select/DropdownIndicator.js
+++ b/react/components/EXPERIMENTAL_Select/DropdownIndicator.js
@@ -11,7 +11,7 @@ function paddingRightClassFromSize(size) {
   }[size]
 }
 
-const DropdownIndicator = ({ innerProps, selectProps, size }) => {
+const DropdownIndicator = ({ innerProps, selectProps }) => {
   const arrowColorClassName = selectProps.isDisabled
     ? 'c-disabled'
     : 'c-action-primary'
@@ -19,7 +19,7 @@ const DropdownIndicator = ({ innerProps, selectProps, size }) => {
   return (
     <div
       className={`flex items-center h-100 ${paddingRightClassFromSize(
-        size
+        selectProps.size
       )} pointer ${arrowColorClassName}`}
       {...innerProps}>
       <ArrowDownIcon size={18} />

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -27,25 +27,7 @@ class Select extends Component {
   constructor(props) {
     super(props)
 
-    this.state = {
-      searchTerm: undefined,
-    }
-
     this.inputId = `react-select-input-${uuid()}`
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    const { searchTerm } = this.state
-    const { searchTerm: prevSearchTerm } = prevState
-    const { loading } = this.props
-    const { loading: prevLoading } = prevProps
-
-    if (
-      searchTerm !== prevSearchTerm ||
-      (searchTerm && loading !== prevLoading)
-    ) {
-      document.getElementById(this.inputId).focus()
-    }
   }
 
   render() {
@@ -80,20 +62,12 @@ class Select extends Component {
       ref: forwardedRef,
       autoFocus,
       className: `pointer bw1 ${getFontClassNameFromSize(size)}`,
+      errorMessage,
+      size,
       components: {
         ClearIndicator,
-        Control: function Control(props) {
-          return (
-            <ControlComponent
-              errorMessage={errorMessage}
-              size={size}
-              {...props}
-            />
-          )
-        },
-        DropdownIndicator: function DropdownIndicator(props) {
-          return <DropdownIndicatorComponent size={size} {...props} />
-        },
+        Control: ControlComponent,
+        DropdownIndicator: DropdownIndicatorComponent,
         IndicatorSeparator: () => null,
         MultiValueRemove,
         Placeholder,
@@ -110,9 +84,6 @@ class Select extends Component {
       noOptionsMessage,
       inputId: this.inputId,
       onInputChange: (value, { action }) => {
-        this.setState({
-          searchTerm: value,
-        })
         if (
           action === 'input-change' &&
           typeof onSearchInputChange === 'function'


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, the current `Select` implementation doesn't allow accents on it but it should.

#### What problem is this solving?

Basically, if you type anything with an accent in the `Select` input, the value will be computed like this:

![image](https://user-images.githubusercontent.com/15948386/87466329-75f27880-c5ec-11ea-80ed-82faa15a3092.png)

Some explanation/context 🤓 

This is happening because of the Select's `componentDidUpdate` method's implementation. To fix a focus bug on PR #524, this method was implemented and did a manual focus on the component.

The problem was happening because some custom components (`Control` and `DropdownIndicator`) were redefined every time the component renders. As **brand new** components (and not the same with other props) were added to the component tree, React didn't preserve their state and the input lost its focus.

Now, with the state preserved, the browser can know that this apostrophe was supposed to be an accent when a letter is pressed afterward, and not just a simple apostrophe.

#### Screenshots or example usage

##### Then

![image](https://user-images.githubusercontent.com/15948386/87466958-8c4d0400-c5ed-11ea-8bf3-090e32d95799.png)

##### Now

![image](https://user-images.githubusercontent.com/15948386/87467036-adadf000-c5ed-11ea-8a94-1c47c3579c44.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
