### PR TITLE
Change AutocompleteInput search button to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `disabled` prop for ActionMenu items
 - Hide clear button on `InputSearch` when disabled
 
+### Changed
+
+- `AutocompleteInput` search icon is now optional.
+
 ## [9.124.2] - 2020-07-09
 
 ### Fixed

--- a/react/components/AutocompleteInput/README.md
+++ b/react/components/AutocompleteInput/README.md
@@ -1,4 +1,4 @@
-#### AutocompleteInput is a search input which, enhanced with a suggestions pop-up, gives the user a more complete search experience when needed.
+#### AutocompleteInput is an input which, enhanced with a suggestions pop-up, gives the user a more complete search experience when needed.
 
 ### 👍 Dos
 
@@ -254,26 +254,6 @@ const UsersAutocomplete = () => {
 ;<UsersAutocomplete />
 ```
 
-#### Disabled AutocompleteInput
-
-```jsx
-import { useState, useRef } from 'react'
-
-const DisabledAutocompleteInput = () => (
-  <AutocompleteInput
-    input={{
-      value: 'Ana Luiza',
-      disabled: true,
-    }}
-    options={{
-      value: [],
-    }}
-  />
-)
-
-;<DisabledAutocompleteInput />
-```
-
 #### Size
 
 ```jsx
@@ -370,3 +350,81 @@ const UsersAutocomplete = () => {
 
 ;<UsersAutocomplete />
 ```
+
+#### Without search button 🔍
+
+```jsx
+import { uniq } from 'lodash'
+import { useState, useRef } from 'react'
+
+const allUsers = [
+  'Ana Clara',
+  'Ana Luiza',
+  { value: 1, label: 'Bruno' },
+  'Carlos',
+  'Daniela',
+]
+
+const UsersAutocomplete = () => {
+  const [term, setTerm] = useState('')
+  const [loading, setLoading] = useState(false)
+  const timeoutRef = useRef(null)
+
+  const options = {
+    onSelect: (...args) => console.log('onSelect: ', ...args),
+    loading,
+    value: !term.length
+      ? []
+      : allUsers.filter(user =>
+          typeof user === 'string'
+            ? user.toLowerCase().includes(term.toLowerCase())
+            : user.label.toLowerCase().includes(term.toLowerCase())
+        ),
+  }
+
+  const input = {
+    onChange: term => {
+      if (term) {
+        setLoading(true)
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+        }
+        timeoutRef.current = setTimeout(() => {
+          setLoading(false)
+          setTerm(term)
+          timeoutRef.current = null
+        }, 1000)
+      } else {
+        setTerm(term)
+      }
+    },
+    onClear: () => setTerm(''),
+    placeholder: 'Search user... (e.g.: Ana)',
+    value: term,
+  }
+  return <AutocompleteInput input={input} options={options} />
+}
+
+;<UsersAutocomplete />
+```
+
+#### Disabled AutocompleteInput
+
+```jsx
+import { useState, useRef } from 'react'
+
+const DisabledAutocompleteInput = () => (
+  <AutocompleteInput
+    input={{
+      value: 'Ana Luiza',
+      disabled: true,
+    }}
+    options={{
+      value: [],
+    }}
+  />
+)
+
+;<DisabledAutocompleteInput />
+```
+

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -89,11 +89,19 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     }
   )
 
+  const inputClasses = classNames(
+    activeClass,
+    'w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 pr8',
+    {
+      'br--left': onSearch,
+    }
+  )
+
   return (
     <div className="flex flex-row">
       <div className="relative w-100">
         <input
-          className={`${activeClass} w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 pr8 br--left`}
+          className={inputClasses}
           value={value}
           onFocus={handleFocus}
           onBlur={handleBlur}
@@ -103,18 +111,20 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
         />
         {onClear && value && (
           <span
-            className="absolute c-muted-3 fw5 flex items-center ph3 t-body top-0 right-0 h-100 pointer"
+            className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
             onClick={handleClear}>
             <ClearInputIcon />
           </span>
         )}
       </div>
-      <button
-        className={buttonClasses}
-        disabled={disabled}
-        onClick={() => onSearch(value)}>
-        <IconSearch size={16} />
-      </button>
+      {onSearch && (
+        <button
+          className={buttonClasses}
+          disabled={disabled}
+          onClick={() => onSearch(value)}>
+          <IconSearch size={16} />
+        </button>
+      )}
     </div>
   )
 }

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -15,8 +15,11 @@ const propTypes = {
   input: PropTypes.shape({
     /** Clear input handler */
     onClear: PropTypes.func.isRequired,
-    /** Search by term handler (fired on enter or when clicking the search button) */
-    onSearch: PropTypes.func.isRequired,
+    /**
+     * Shows the search button and it's a search by term handler
+     * (fired on enter or when clicking the search button)
+     */
+    onSearch: PropTypes.func,
     /** Change term handler */
     onChange: PropTypes.func.isRequired,
     /** Term to be searched */
@@ -79,11 +82,15 @@ const propTypes = {
   }).isRequired,
 }
 
-export type AutocompleteInputProps = PropTypes.InferProps<typeof propTypes>
+export type AutocompleteInputProps = Omit<
+  PropTypes.InferProps<typeof propTypes>,
+  'input'
+> & {
+  input: PropTypes.InferProps<typeof propTypes>['input'] &
+    React.HTMLProps<HTMLInputElement>
+}
 
-const AutocompleteInput: React.FunctionComponent<PropTypes.InferProps<
-  typeof propTypes
->> = ({
+const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
   input: { value, onClear, onSearch, onChange, ...inputProps },
   options: {
     onSelect,
@@ -129,6 +136,7 @@ const AutocompleteInput: React.FunctionComponent<PropTypes.InferProps<
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    inputProps.onKeyDown?.(e)
     if (e.key === 'Enter') {
       const selectedOption =
         selectedOptionIndex !== -1 ? showedOptions[selectedOptionIndex] : term
@@ -137,7 +145,7 @@ const AutocompleteInput: React.FunctionComponent<PropTypes.InferProps<
       if (selectedOptionIndex !== -1) {
         onSelect(selectedOption)
       } else {
-        onSearch(getTermFromOption(selectedOption))
+        onSearch?.(getTermFromOption(selectedOption))
       }
       setSelectedOptionIndex(-1)
       setShowPopover(false)
@@ -213,7 +221,7 @@ const AutocompleteInput: React.FunctionComponent<PropTypes.InferProps<
         roundedBottom={!popoverOpened}
         onKeyDown={handleKeyDown}
         onFocus={() => setShowPopover(true)}
-        onSearch={() => onSearch(term)}
+        onSearch={onSearch && (() => onSearch(term))}
         onClear={handleClear}
         onChange={handleTermChange}
         size={size}


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, the idea is to have an optional search button.

#### What problem is this solving?

Some cases need an autocomplete to be put in different contexts from search (other design systems do that as well).

Only two examples:
- [Angular Material](https://material.angular.io/components/autocomplete/examples)
- [Ant Design](https://ant.design/components/auto-complete/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/87705900-00fe7a80-c775-11ea-9aa8-cdde0929c4f9.png)

![image](https://user-images.githubusercontent.com/15948386/87705909-078cf200-c775-11ea-992d-b6f92d92852d.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
