### PR TITLE
Fix conditions' operator label color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Tab` active color being set as `outset`.
 - Select's label size on regular variation.
 - Accent on `Select` input change.
+- Conditions' operator label color
 
 ### Added
 

--- a/react/components/Conditions/index.tsx
+++ b/react/components/Conditions/index.tsx
@@ -89,7 +89,7 @@ const Conditions: React.FC<Props> = ({
   }
 
   return (
-    <div>
+    <div className="t-body c-on-base">
       {!hideOperator && (
         <div className={`mh6 ${isRtl ? 'flex justify-end' : ''}`}>
           <StrategySelector
@@ -101,7 +101,7 @@ const Conditions: React.FC<Props> = ({
         </div>
       )}
 
-      <div className="t-body c-on-base ph5 pt3 mt4 br3 b--muted-4 ba">
+      <div className="ph5 pt3 mt4 br3 b--muted-4 ba">
         {statements.length === 0 ? (
           <div className="flex-grow-1 mv6">
             <Statement


### PR DESCRIPTION
#### What is the purpose of this pull request?
As title says.

#### What problem is this solving?
Operator (`StrategySelector`) label using wrong font color:

![image](https://user-images.githubusercontent.com/5256673/87798470-7411fa80-c822-11ea-8174-394ee1f754ee.png)

#### How should this be manually tested?
https://styleguide-git-fix-conditions-label-color.styleguide-core.vercel.app/#/Components/Forms/Conditions

#### Screenshots or example usage
Now using `c-on-base`

![image](https://user-images.githubusercontent.com/5256673/87798608-9c015e00-c822-11ea-83d1-da6f8bdf356c.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
