### PR TITLE
Add testId property to option in ActionMenu component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `disabled` prop for ActionMenu items
 - Hide clear button on `InputSearch` when disabled
+- `testId` property to option in `ActionMenu`.
 
 ### Changed
 

--- a/react/components/ActionMenu/README.md
+++ b/react/components/ActionMenu/README.md
@@ -264,6 +264,7 @@ const options = [
   },
   {
     label: 'Quit now and cake will be served',
+    testId: 'dangerous-option',
     isDangerous: 'true',
     onClick: () => alert('The cake is a lie'),
   },

--- a/react/components/ActionMenu/index.js
+++ b/react/components/ActionMenu/index.js
@@ -151,6 +151,8 @@ ActionMenu.propTypes = {
       label: PropTypes.node,
       onClick: PropTypes.func,
       disabled: PropTypes.bool,
+      /** Optional testid property */
+      testId: PropTypes.string,
       /** whether option has inline toggle */
       toggle: PropTypes.shape({
         checked: PropTypes.bool,

--- a/react/components/Menu/index.js
+++ b/react/components/Menu/index.js
@@ -183,6 +183,7 @@ class Menu extends Component {
                             'hover-bg-muted-5 pointer': !option.disabled,
                           }
                         )}
+                        data-testid={option.testId || `menu-option-${index}`}
                         onClick={() => {
                           option.onClick(option)
                           if (onClose) {
@@ -243,6 +244,8 @@ Menu.propTypes = {
       label: PropTypes.node,
       onClick: PropTypes.func,
       disabled: PropTypes.bool,
+      /** Optional testid property */
+      testId: PropTypes.string,
       /** whether option has inline toggle */
       toggle: PropTypes.shape({
         checked: PropTypes.bool,


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, this is meant to better test action menu items.

#### What problem is this solving?

The `ActionMenu` selectors are so much likely to fail (as the z-index change made the `vtex.admin-logistics` tests fail).

#### Screenshots or example usage

At the last example:

![image](https://user-images.githubusercontent.com/15948386/88190032-26293800-cc10-11ea-8954-e89379efbe86.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
