### PR TITLE
Fix AutocompleteInput typing definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-# Fixed
+### Added
+
+- `options.customMessage` prop to `AutocompleteInput`.
+
+### Fixed
 
 - Tooltip `Portal` proptypes.
 - `AutocompleteInput` typing definitions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `options.customMessage` prop to `AutocompleteInput`.
+- `error` and `errorMessage` props to `AutocompleteInput` component.
 
 ### Fixed
 
 - Tooltip `Portal` proptypes.
 - `AutocompleteInput` typing definitions.
-
-### Added
-
-- `error` and `errorMessage` props to `AutocompleteInput` component.
 
 ## [9.125.0] - 2020-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 # Fixed
 
 - Tooltip `Portal` proptypes.
+- `AutocompleteInput` typing definitions.
 
 ### Added
 

--- a/react/components/AutocompleteInput/README.md
+++ b/react/components/AutocompleteInput/README.md
@@ -486,3 +486,69 @@ const DisabledAutocompleteInput = () => (
 
 ;<DisabledAutocompleteInput />
 ```
+
+#### With a custom message
+
+```jsx
+import { uniq } from 'lodash'
+import { useState, useRef } from 'react'
+import Info from '../icon/Info'
+
+const allUsers = [
+  'Ana Clara',
+  'Ana Luiza',
+  { value: 1, label: 'Bruno' },
+  'Carlos',
+  'Daniela',
+]
+
+const UsersAutocomplete = () => {
+  const [term, setTerm] = useState('')
+  const [loading, setLoading] = useState(false)
+  const timeoutRef = useRef(null)
+
+  const options = {
+    onSelect: (...args) => console.log('onSelect: ', ...args),
+    loading,
+    value: !term.length
+      ? []
+      : allUsers.filter(user =>
+          typeof user === 'string'
+            ? user.toLowerCase().includes(term.toLowerCase())
+            : user.label.toLowerCase().includes(term.toLowerCase())
+        ),
+    customMessage: (
+      <div className="w-100 pa4 f6 br2 br--bottom bg-base flex items-center">
+        <div className="pr3 c-muted-1 flex">
+          <Info />
+        </div>
+        <div className="c-on-base">Some of these users might not be from your organization</div>
+      </div>
+    ),
+  }
+
+  const input = {
+    onChange: term => {
+      if (term) {
+        setLoading(true)
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+        }
+        timeoutRef.current = setTimeout(() => {
+          setLoading(false)
+          setTerm(term)
+          timeoutRef.current = null
+        }, 1000)
+      } else {
+        setTerm(term)
+      }
+    },
+    onClear: () => setTerm(''),
+    placeholder: 'Search user... (e.g.: Ana)',
+    value: term,
+  }
+  return <AutocompleteInput input={input} options={options} />
+}
+
+;<UsersAutocomplete />
+```

--- a/react/components/AutocompleteInput/README.md
+++ b/react/components/AutocompleteInput/README.md
@@ -519,7 +519,7 @@ const UsersAutocomplete = () => {
         ),
     customMessage: (
       <div className="w-100 pa4 f6 br2 br--bottom bg-base flex items-center">
-        <div className="pr3 c-muted-1 flex">
+        <div className="ph3 c-muted-1 flex">
           <Info />
         </div>
         <div className="c-on-base">Some of these users might not be from your organization</div>

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -228,6 +228,15 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
     </div>
   )
 
+  const renderCustomMessage = (): React.ReactNode =>
+    typeof customMessage !== 'string' ? (
+      customMessage
+    ) : (
+      <div className="w-100 pa4 f6 br2 br--bottom bg-base">
+        <span className="ml3 c-on-base">{customMessage}</span>
+      </div>
+    )
+
   const popoverOpened = showPopover && (!!showedOptions.length || loading)
   const errorStyle = error || Boolean(errorMessage)
 
@@ -253,12 +262,12 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
         {popoverOpened ? (
           <div className="absolute br--bottom br2 bb bl br bw1 b--muted-3 bg-base w-100 z-1 shadow-5">
             {renderOptions()}
-            {customMessage}
             {loading && (
               <div className="flex flex-row justify-center items-center pa4">
                 <Spinner size={20} />
               </div>
             )}
+            {renderCustomMessage()}
           </div>
         ) : null}
         {errorMessage && (

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -86,12 +86,14 @@ const propTypes = {
   }).isRequired,
 }
 
+type CustomInputProps = PropTypes.InferProps<typeof propTypes>['input']
+
 export type AutocompleteInputProps = Omit<
   PropTypes.InferProps<typeof propTypes>,
   'input'
 > & {
-  input: PropTypes.InferProps<typeof propTypes>['input'] &
-    Omit<React.HTMLProps<HTMLInputElement>, 'onChange'>
+  input: CustomInputProps &
+    Omit<React.HTMLProps<HTMLInputElement>, keyof CustomInputProps>
 }
 
 const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -91,7 +91,7 @@ export type AutocompleteInputProps = Omit<
   'input'
 > & {
   input: PropTypes.InferProps<typeof propTypes>['input'] &
-    React.HTMLProps<HTMLInputElement>
+    Omit<React.HTMLProps<HTMLInputElement>, 'onChange'>
 }
 
 const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -237,7 +237,8 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
       </div>
     )
 
-  const popoverOpened = showPopover && (!!showedOptions.length || loading)
+  const popoverOpened =
+    showPopover && (!!showedOptions.length || loading || !!customMessage)
   const errorStyle = error || Boolean(errorMessage)
 
   return (

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -83,6 +83,11 @@ const propTypes = {
      * `regular` is the default value.
      */
     size: PropTypes.oneOf(['small', 'regular', 'large']),
+    /**
+     * A custom message to be displayed inside the options dropdown.
+     * It can be a warning, an error, or a hint about the options.
+     */
+    customMessage: PropTypes.node,
   }).isRequired,
 }
 
@@ -114,6 +119,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
     lastSearched = {},
     icon,
     size,
+    customMessage,
   },
 }) => {
   const [term, setTerm] = useState(value || '')
@@ -196,7 +202,8 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
     selected: index === selectedOptionIndex,
     value: option,
     searchTerm: term,
-    roundedBottom: index === showedOptions.length - 1,
+    // customMessage should be the last element on dropdown, so should have rounded bottom.
+    roundedBottom: !customMessage && index === showedOptions.length - 1,
     icon: typeof option !== 'string' && icon ? icon : null,
     onClick: () => {
       addToLastSearched(option)
@@ -246,6 +253,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
         {popoverOpened ? (
           <div className="absolute br--bottom br2 bb bl br bw1 b--muted-3 bg-base w-100 z-1 shadow-5">
             {renderOptions()}
+            {customMessage}
             {loading && (
               <div className="flex flex-row justify-center items-center pa4">
                 <Spinner size={20} />


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

The problem is that the `onChange` function from the `HTMLInput` is being overwritten and the current props definition doesn't express that. So, when passing the right `onChange` function, the component's types break.

#### Screenshots or example usage

##### Then

![image](https://user-images.githubusercontent.com/15948386/88327544-88139b80-ccfd-11ea-8852-94c4baf864f0.png)

##### Now

![image](https://user-images.githubusercontent.com/15948386/88327451-729e7180-ccfd-11ea-9a15-263d0bf14095.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
