### PR TITLE
Removes team-specific collaborators #1268

### DIFF
--- a/react/components/FilterBar/FilterTag.js
+++ b/react/components/FilterBar/FilterTag.js
@@ -172,7 +172,7 @@ class FilterTag extends PureComponent {
         console.warn(
           '[Deprecation alert]',
           'FilterBar prop "options" will change contract due to Conditions and Statement refactor.',
-          'please if you are using it inform our vtex team...'
+          'If you are using it, please inform our VTEX Styleguide team.'
         )
         return {
           ...verb,

--- a/react/components/FilterBar/FilterTag.js
+++ b/react/components/FilterBar/FilterTag.js
@@ -172,7 +172,7 @@ class FilterTag extends PureComponent {
         console.warn(
           '[Deprecation alert]',
           'FilterBar prop "options" will change contract due to Conditions and Statement refactor.',
-          'please if you are using it let @guigs and @eric know...'
+          'please if you are using it inform our vtex team...'
         )
         return {
           ...verb,


### PR DESCRIPTION
#### What is the purpose of this pull request?

As @kevinch specified in PR #1268, people come and go while teams remain. I removed the targeting for users and includes a nomination for the vtex team.

#### What problem is this solving?

Removes indication of specific people and includes something more generic.

#### How should this be manually tested?

It can be tested by viewing the FilterBar documentation.

#### Screenshots or example usage

It is not necessary.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
