### PR TITLE
Add options.customMessage prop to AutocompleteInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `options.customMessage` prop to `AutocompleteInput`.
+
 ### Fixed
 
 - `AutocompleteInput` typing definitions.

--- a/react/components/AutocompleteInput/README.md
+++ b/react/components/AutocompleteInput/README.md
@@ -460,7 +460,7 @@ const UsersAutocomplete = () => {
         ),
     customMessage: (
       <div className="w-100 pa4 f6 br2 br--bottom bg-base flex items-center">
-        <div className="pr3 c-muted-1 flex">
+        <div className="ph3 c-muted-1 flex">
           <Info />
         </div>
         <div className="c-on-base">Some of these users might not be from your organization</div>

--- a/react/components/AutocompleteInput/README.md
+++ b/react/components/AutocompleteInput/README.md
@@ -428,3 +428,68 @@ const DisabledAutocompleteInput = () => (
 ;<DisabledAutocompleteInput />
 ```
 
+#### With a custom message
+
+```jsx
+import { uniq } from 'lodash'
+import { useState, useRef } from 'react'
+import Info from '../icon/Info'
+
+const allUsers = [
+  'Ana Clara',
+  'Ana Luiza',
+  { value: 1, label: 'Bruno' },
+  'Carlos',
+  'Daniela',
+]
+
+const UsersAutocomplete = () => {
+  const [term, setTerm] = useState('')
+  const [loading, setLoading] = useState(false)
+  const timeoutRef = useRef(null)
+
+  const options = {
+    onSelect: (...args) => console.log('onSelect: ', ...args),
+    loading,
+    value: !term.length
+      ? []
+      : allUsers.filter(user =>
+          typeof user === 'string'
+            ? user.toLowerCase().includes(term.toLowerCase())
+            : user.label.toLowerCase().includes(term.toLowerCase())
+        ),
+    customMessage: (
+      <div className="w-100 pa4 f6 br2 br--bottom bg-base flex items-center">
+        <div className="pr3 c-muted-1 flex">
+          <Info />
+        </div>
+        <div className="c-on-base">Some of these users might not be from your organization</div>
+      </div>
+    ),
+  }
+
+  const input = {
+    onChange: term => {
+      if (term) {
+        setLoading(true)
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+        }
+        timeoutRef.current = setTimeout(() => {
+          setLoading(false)
+          setTerm(term)
+          timeoutRef.current = null
+        }, 1000)
+      } else {
+        setTerm(term)
+      }
+    },
+    onClear: () => setTerm(''),
+    placeholder: 'Search user... (e.g.: Ana)',
+    value: term,
+  }
+  return <AutocompleteInput input={input} options={options} />
+}
+
+;<UsersAutocomplete />
+```

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -79,6 +79,11 @@ const propTypes = {
      * `regular` is the default value.
      */
     size: PropTypes.oneOf(['small', 'regular', 'large']),
+    /**
+     * A custom message to be displayed inside the options dropdown.
+     * It can be a warning, an error, or a hint about the options.
+     */
+    customMessage: PropTypes.node,
   }).isRequired,
 }
 
@@ -102,6 +107,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
     lastSearched = {},
     icon,
     size,
+    customMessage,
   },
 }) => {
   const [term, setTerm] = useState(value || '')
@@ -184,7 +190,8 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
     selected: index === selectedOptionIndex,
     value: option,
     searchTerm: term,
-    roundedBottom: index === showedOptions.length - 1,
+    // customMessage should be the last element on dropdown, so should have rounded bottom.
+    roundedBottom: !customMessage && index === showedOptions.length - 1,
     icon: typeof option !== 'string' && icon ? icon : null,
     onClick: () => {
       addToLastSearched(option)
@@ -232,6 +239,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
         <div className="relative">
           <div className="absolute br--bottom br2 bb bl br bw1 b--muted-3 bg-base w-100 z-1 shadow-5">
             {renderOptions()}
+            {customMessage}
             {loading && (
               <div className="flex flex-row justify-center items-center pa4">
                 <Spinner size={20} />

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -216,6 +216,15 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
     </div>
   )
 
+  const renderCustomMessage = (): React.ReactNode =>
+    typeof customMessage !== 'string' ? (
+      customMessage
+    ) : (
+      <div className="w-100 pa4 f6 br2 br--bottom bg-base">
+        <span className="ml3 c-on-base">{customMessage}</span>
+      </div>
+    )
+
   const popoverOpened = showPopover && (!!showedOptions.length || loading)
 
   return (
@@ -239,12 +248,12 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
         <div className="relative">
           <div className="absolute br--bottom br2 bb bl br bw1 b--muted-3 bg-base w-100 z-1 shadow-5">
             {renderOptions()}
-            {customMessage}
             {loading && (
               <div className="flex flex-row justify-center items-center pa4">
                 <Spinner size={20} />
               </div>
             )}
+            {renderCustomMessage()}
           </div>
         </div>
       ) : null}


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, this prop should be added.

#### What problem is this solving?

Today it's not possible to give some feedback to the users about something related to the `AutocompleteInput` options. For example, if the suggestions (loaded from the server) cannot be queried, this error can now be shown by using the `options.customMessage` prop.

There are plenty more examples of usages (error/warning messages, hints about the field, etc) and that's why the prop name is generic.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/88579038-cc65ab00-d01f-11ea-9622-438b36196107.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
