### PR TITLE
Add input.error and input.errorMessage props to AutocompleteInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Tooltip `Portal` proptypes.
 
+### Added
+
+- `error` and `errorMessage` props to `AutocompleteInput` component.
+
 ## [9.125.0] - 2020-07-23
 
 ### Fixed

--- a/react/components/AutocompleteInput/README.md
+++ b/react/components/AutocompleteInput/README.md
@@ -351,6 +351,65 @@ const UsersAutocomplete = () => {
 ;<UsersAutocomplete />
 ```
 
+#### With error state
+
+```jsx
+import { uniq } from 'lodash'
+import { useState, useRef } from 'react'
+
+const allUsers = [
+  'Ana Clara',
+  'Ana Luiza',
+  { value: 1, label: 'Bruno' },
+  'Carlos',
+  'Daniela',
+]
+
+const UsersAutocomplete = () => {
+  const [term, setTerm] = useState('')
+  const [loading, setLoading] = useState(false)
+  const timeoutRef = useRef(null)
+
+  const options = {
+    onSelect: (...args) => console.log('onSelect: ', ...args),
+    loading,
+    value: !term.length
+      ? []
+      : allUsers.filter(user =>
+          typeof user === 'string'
+            ? user.toLowerCase().includes(term.toLowerCase())
+            : user.label.toLowerCase().includes(term.toLowerCase())
+        ),
+  }
+
+  const input = {
+    onChange: term => {
+      if (term) {
+        setLoading(true)
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+        }
+        timeoutRef.current = setTimeout(() => {
+          setLoading(false)
+          setTerm(term)
+          timeoutRef.current = null
+        }, 1000)
+      } else {
+        setTerm(term)
+      }
+    },
+    onSearch: (...args) => console.log('onSearch:', ...args),
+    onClear: () => setTerm(''),
+    placeholder: 'Search user... (e.g.: Ana)',
+    value: term,
+    errorMessage: 'Required Field',
+  }
+  return <AutocompleteInput input={input} options={options} />
+}
+
+;<UsersAutocomplete />
+```
+
 #### Without search button 🔍
 
 ```jsx
@@ -427,4 +486,3 @@ const DisabledAutocompleteInput = () => (
 
 ;<DisabledAutocompleteInput />
 ```
-

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -26,6 +26,10 @@ const propTypes = {
   disabled: PropTypes.bool,
   /** Determine the search bar size */
   size: PropTypes.oneOf(['small', 'regular', 'large']),
+  /** Determine if the input and button should be styled with error borders */
+  error: PropTypes.bool,
+  /** The error message to be desiplayed below the input field */
+  errorMessage: PropTypes.node,
 }
 
 const defaultProps = {
@@ -47,6 +51,8 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     onBlur,
     disabled,
     size,
+    error,
+    errorMessage,
     ...inputProps
   } = props
 
@@ -69,10 +75,12 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     setFocused(false)
     onBlur && onBlur(e)
   }
+  const errorStyle = error || Boolean(errorMessage)
   const regularSize = size !== 'small' && size !== 'large'
   const activeClass = classNames({
-    'b--muted-3': focused,
-    'b--muted-4': !focused,
+    'b--muted-3': focused && !errorStyle,
+    'b--muted-4': !focused && !errorStyle,
+    'b--danger hover-b--danger': errorStyle,
     'br--top': !roundedBottom,
     'bg-disabled c-disabled': disabled,
     'bg-base c-on-base': !disabled,
@@ -98,34 +106,39 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
   )
 
   return (
-    <div className="flex flex-row">
-      <div className="relative w-100">
-        <input
-          className={inputClasses}
-          value={value}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          onChange={handleChange}
-          disabled={disabled}
-          {...inputProps}
-        />
-        {onClear && value && (
-          <span
-            className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
-            onClick={handleClear}>
-            <ClearInputIcon />
-          </span>
+    <>
+      <div className="flex flex-row">
+        <div className="relative w-100">
+          <input
+            className={inputClasses}
+            value={value}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onChange={handleChange}
+            disabled={disabled}
+            {...inputProps}
+          />
+          {onClear && value && (
+            <span
+              className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
+              onClick={handleClear}>
+              <ClearInputIcon />
+            </span>
+          )}
+        </div>
+        {onSearch && (
+          <button
+            className={buttonClasses}
+            disabled={disabled}
+            onClick={() => onSearch(value)}>
+            <IconSearch size={16} />
+          </button>
         )}
       </div>
-      {onSearch && (
-        <button
-          className={buttonClasses}
-          disabled={disabled}
-          onClick={() => onSearch(value)}>
-          <IconSearch size={16} />
-        </button>
+      {errorMessage && (
+        <div className="c-danger t-small mt3 lh-title">{errorMessage}</div>
       )}
-    </div>
+    </>
   )
 }
 

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -28,7 +28,7 @@ const propTypes = {
   size: PropTypes.oneOf(['small', 'regular', 'large']),
   /** Determine if the input and button should be styled with error borders */
   error: PropTypes.bool,
-  /** The error message to be desiplayed below the input field */
+  /** The error message to be displayed below the input field */
   errorMessage: PropTypes.node,
 }
 

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -28,8 +28,6 @@ const propTypes = {
   size: PropTypes.oneOf(['small', 'regular', 'large']),
   /** Determine if the input and button should be styled with error borders */
   error: PropTypes.bool,
-  /** The error message to be displayed below the input field */
-  errorMessage: PropTypes.node,
 }
 
 const defaultProps = {
@@ -52,7 +50,6 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     disabled,
     size,
     error,
-    errorMessage,
     ...inputProps
   } = props
 
@@ -75,12 +72,11 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     setFocused(false)
     onBlur && onBlur(e)
   }
-  const errorStyle = error || Boolean(errorMessage)
   const regularSize = size !== 'small' && size !== 'large'
   const activeClass = classNames({
-    'b--muted-3': focused && !errorStyle,
-    'b--muted-4': !focused && !errorStyle,
-    'b--danger hover-b--danger': errorStyle,
+    'b--muted-3': focused && !error,
+    'b--muted-4': !focused && !error,
+    'b--danger hover-b--danger': error,
     'br--top': !roundedBottom,
     'bg-disabled c-disabled': disabled,
     'bg-base c-on-base': !disabled,
@@ -106,39 +102,34 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
   )
 
   return (
-    <>
-      <div className="flex flex-row">
-        <div className="relative w-100">
-          <input
-            className={inputClasses}
-            value={value}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            onChange={handleChange}
-            disabled={disabled}
-            {...inputProps}
-          />
-          {onClear && value && (
-            <span
-              className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
-              onClick={handleClear}>
-              <ClearInputIcon />
-            </span>
-          )}
-        </div>
-        {onSearch && (
-          <button
-            className={buttonClasses}
-            disabled={disabled}
-            onClick={() => onSearch(value)}>
-            <IconSearch size={16} />
-          </button>
+    <div className="flex flex-row">
+      <div className="relative w-100">
+        <input
+          className={inputClasses}
+          value={value}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          disabled={disabled}
+          {...inputProps}
+        />
+        {onClear && value && (
+          <span
+            className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
+            onClick={handleClear}>
+            <ClearInputIcon />
+          </span>
         )}
       </div>
-      {errorMessage && (
-        <div className="c-danger t-small mt3 lh-title">{errorMessage}</div>
+      {onSearch && (
+        <button
+          className={buttonClasses}
+          disabled={disabled}
+          onClick={() => onSearch(value)}>
+          <IconSearch size={16} />
+        </button>
       )}
-    </>
+    </div>
   )
 }
 

--- a/react/components/AutocompleteInput/__snapshots__/index.test.tsx.snap
+++ b/react/components/AutocompleteInput/__snapshots__/index.test.tsx.snap
@@ -36,6 +36,9 @@ exports[`AutocompleteInput should render a regular version of search bar if size
         </svg>
       </button>
     </div>
+    <div
+      class="relative"
+    />
   </div>
 </DocumentFragment>
 `;
@@ -76,6 +79,9 @@ exports[`AutocompleteInput should render with a large size bar 1`] = `
         </svg>
       </button>
     </div>
+    <div
+      class="relative"
+    />
   </div>
 </DocumentFragment>
 `;
@@ -116,6 +122,9 @@ exports[`AutocompleteInput should render with a regular size bar 1`] = `
         </svg>
       </button>
     </div>
+    <div
+      class="relative"
+    />
   </div>
 </DocumentFragment>
 `;
@@ -156,6 +165,9 @@ exports[`AutocompleteInput should render with a regular size bar when prop is ab
         </svg>
       </button>
     </div>
+    <div
+      class="relative"
+    />
   </div>
 </DocumentFragment>
 `;
@@ -196,6 +208,9 @@ exports[`AutocompleteInput should render with a small size bar 1`] = `
         </svg>
       </button>
     </div>
+    <div
+      class="relative"
+    />
   </div>
 </DocumentFragment>
 `;

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -28,7 +28,7 @@ const propTypes = {
     disabled: PropTypes.bool,
     /** Determine if the input and button should be styled with error borders */
     error: PropTypes.bool,
-    /** The error message to be desiplayed below the input field */
+    /** The error message to be displayed below the input field */
     errorMessage: PropTypes.node,
   }).isRequired,
   /** Options props. More details in the examples */

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -26,6 +26,10 @@ const propTypes = {
     value: PropTypes.string,
     /** Determine if the input and button should be disabled */
     disabled: PropTypes.bool,
+    /** Determine if the input and button should be styled with error borders */
+    error: PropTypes.bool,
+    /** The error message to be desiplayed below the input field */
+    errorMessage: PropTypes.node,
   }).isRequired,
   /** Options props. More details in the examples */
   options: PropTypes.shape({

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -95,7 +95,15 @@ export type AutocompleteInputProps = Omit<
 }
 
 const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
-  input: { value, onClear, onSearch, onChange, ...inputProps },
+  input: {
+    value,
+    error,
+    errorMessage,
+    onClear,
+    onSearch,
+    onChange,
+    ...inputProps
+  },
   options: {
     onSelect,
     value: options,
@@ -212,6 +220,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
   )
 
   const popoverOpened = showPopover && (!!showedOptions.length || loading)
+  const errorStyle = error || Boolean(errorMessage)
 
   return (
     <div ref={containerRef} className="flex flex-column w-100">
@@ -228,10 +237,11 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
         onSearch={onSearch && (() => onSearch(term))}
         onClear={handleClear}
         onChange={handleTermChange}
+        error={errorStyle}
         size={size}
       />
-      {popoverOpened ? (
-        <div className="relative">
+      <div className="relative">
+        {popoverOpened ? (
           <div className="absolute br--bottom br2 bb bl br bw1 b--muted-3 bg-base w-100 z-1 shadow-5">
             {renderOptions()}
             {loading && (
@@ -240,8 +250,11 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
               </div>
             )}
           </div>
-        </div>
-      ) : null}
+        ) : null}
+        {errorMessage && (
+          <div className="c-danger t-small mt3 lh-title">{errorMessage}</div>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says...

#### What problem is this solving?

There was no error state on `AutocompleteInput` component. [Discussion on Slack](https://vtex.slack.com/archives/C1MCRG7CK/p1595862494183500)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/88960736-55781e80-d27a-11ea-9cde-07392a0b6843.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
