### PR TITLE
bugfix/change-rel-prop-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Behavior of the rel attribute for `Button` component
 
 ## [9.117.0] - 2020-05-13
 

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -205,7 +205,6 @@ class Button extends Component {
 
     const linkModeProps = {
       target,
-      rel,
       referrerPolicy,
       download,
     }
@@ -234,6 +233,7 @@ class Button extends Component {
         onBlur={this.props.onBlur}
         ref={this.props.forwardedRef}
         style={style}
+        rel={rel}
         // Button-mode exclusive props
         type={href ? undefined : this.props.type}
         // Link-mode exclusive props


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR was created to allow the use of the `rel` attribute without a `href`.

#### What problem is this solving?

There is an issue on search-result app that we need to add the `rel` attribute for the fetch more and previous buttons.

With that change we can have a better SEO performance.

[issue](https://github.com/vtex-apps/store-discussion/issues/315)

[Running workspace](https://task315--carrefourbr.myvtex.com/celulares-e-smartphones?crfint=hm|header-menu-departamentos|celular-e-smartphones|1&page=2)

#### How should this be manually tested?
To test you have to add the prop `rel` in the `Button` component, for example

`<Button size='small' rel='prev'>Example</Button>`

#### Screenshots or example usage

Add the prop in the Button component
![image](https://user-images.githubusercontent.com/19579091/89238299-eda03b80-d5cb-11ea-8db4-f3228aa47d27.png)

Result
![image](https://user-images.githubusercontent.com/19579091/89238327-09a3dd00-d5cc-11ea-9dbe-6f2dcc37f161.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
