### PR TITLE
Exposes more props of the Dropzone component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `accept`, `minSize` and `maxSize` props to `Dropzone` component.
+
 ## [9.126.0] - 2020-08-03
 
 ### Added

--- a/react/components/Dropzone/README.md
+++ b/react/components/Dropzone/README.md
@@ -50,6 +50,60 @@ class MyDropZone extends React.Component {
 ;<MyDropZone />
 ```
 
+Size and file type restriction
+
+```js
+class MyDropZone extends React.Component {
+  constructor() {
+    super()
+    this.state = { files: null, result: null }
+    this.handleFile = this.handleFile.bind(this)
+  }
+
+  handleFile(files) {
+    this.setState({ result: files })
+  }
+
+  handleReset(files) {
+    if (files) {
+      console.log(files)
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <Dropzone
+          accept=".xml"
+          minSize={2000}
+          maxSize={10000}
+          onDropAccepted={this.handleFile}
+          onFileReset={this.handleReset}>
+          <div className="pt7">
+            <div>
+              <span className="f4">Drop here your XML or </span>
+              <span className="f4 c-link" style={{ cursor: 'pointer' }}>
+                choose a file
+              </span>
+              <p className="f6 c-muted-2 tc">Maximum file size of 10 KB.</p>
+            </div>
+          </div>
+        </Dropzone>
+        {this.state.result && (
+          <div className="mt4">
+            <p className="ttu f6">Result:</p>
+            <pre className="bg-black-025 pa4 f7">
+              {JSON.stringify(this.state.result, null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+    )
+  }
+}
+;<MyDropZone />
+```
+
 Custom icon
 
 ```js

--- a/react/components/Dropzone/index.js
+++ b/react/components/Dropzone/index.js
@@ -53,7 +53,15 @@ class Dropzone extends PureComponent {
   }
 
   render() {
-    const { children, isLoading, icon, multiple } = this.props
+    const {
+      children,
+      isLoading,
+      icon,
+      multiple,
+      accept,
+      maxSize,
+      minSize,
+    } = this.props
     const { isHovering, fileDropped, files } = this.state
     const initialState = !isHovering && !fileDropped
 
@@ -87,6 +95,9 @@ class Dropzone extends PureComponent {
       <ReactDropZone
         ref={dropzoneRef}
         multiple={multiple}
+        accept={accept}
+        maxSize={maxSize}
+        minSize={minSize}
         onDropAccepted={this.handleDropAccepted}
         onDropRejected={this.handleDropRejected}
         onDragEnter={this.handleDragEnter}
@@ -139,6 +150,9 @@ Dropzone.defaultProps = {
   isLoading: false,
   onFileReset: () => {},
   multiple: false,
+  maxSize: Infinity,
+  minSize: 0,
+  accept: null,
 }
 
 Dropzone.propTypes = {
@@ -156,6 +170,12 @@ Dropzone.propTypes = {
   icon: PropTypes.node,
   /** Allow multiple files drop */
   multiple: PropTypes.bool,
+  /** Set accepted file types. See [this MDN article](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) for more information. */
+  accept: PropTypes.string,
+  /** Maximum file size (in bytes) */
+  maxSize: PropTypes.number,
+  /** Minimum file size (in bytes) */
+  minSize: PropTypes.number,
 }
 
 export default Dropzone


### PR DESCRIPTION
#### What is the purpose of this pull request?

Expose more properties of the `react-dropzone` lib through Styleguide's `<Dropzone />` component. This should give the community (and me =P) more flexibility when using the component.

#### What problem is this solving?
None. It's a feature.
We're developing an admin app that only takes .xml files as the input of some of its fields. Being able to specify maximum file size and extension is extremely helpful for out app.

#### How should this be manually tested?
Clone the project and run `yarn install && yarn start`. This will launch the Styleguide page and then you can see the doc for the component as well as a working example on http://127.0.0.1:6061/#/Components/Forms/Dropzone.

#### Screenshots or example usage

![styleguide-dropzone](https://user-images.githubusercontent.com/8474847/89569524-368a0700-d7fb-11ea-85db-e652be8dc83c.gif)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
