### PR TITLE
Fix Checkbox alignment with large texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Plus** icon size and color.
 - `AutoCompleteInput` padding-right when `ClearInputIcon` is shown.
+- Checkbox alignment with large texts
 
 ## [9.127.0] - 2020-08-13
 

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import CheckIcon from '../icon/Check'
 import CheckPartial from '../icon/CheckPartial'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
+import Styles from './styles.css'
 
 class Checkbox extends PureComponent {
   constructor(props) {
@@ -52,9 +53,12 @@ class Checkbox extends PureComponent {
           }
         )}>
         <div
-          className={classNames('vtex-checkbox__container relative w1 h1', {
-            mr3: label,
-          })}>
+          className={classNames(
+            `vtex-checkbox__container relative w1 h1 ${Styles.mw1}`,
+            {
+              mr3: label,
+            }
+          )}>
           <div
             className={classNames(
               'vtex-checkbox__inner-container h1 w1 absolute ba bw1 br1 ',

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -52,7 +52,7 @@ class Checkbox extends PureComponent {
           }
         )}>
         <div
-          className={classNames(`vtex-checkbox__container relative w1 h1`, {
+          className={classNames('vtex-checkbox__container relative w1 h1', {
             mr3: label,
           })}>
           <div

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -54,7 +54,7 @@ class Checkbox extends PureComponent {
         )}>
         <div
           className={classNames(
-            `vtex-checkbox__container relative w1 h1 ${Styles.mw1}`,
+            `vtex-checkbox__container relative w1 h1 ${Styles.checkboxContainer}`,
             {
               mr3: label,
             }

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -5,7 +5,6 @@ import classNames from 'classnames'
 import CheckIcon from '../icon/Check'
 import CheckPartial from '../icon/CheckPartial'
 import { withForwardedRef, refShape } from '../../modules/withForwardedRef'
-import Styles from './styles.css'
 
 class Checkbox extends PureComponent {
   constructor(props) {
@@ -47,14 +46,14 @@ class Checkbox extends PureComponent {
     return (
       <div
         className={classNames(
-          'vtex-checkbox__line-container flex items-center relative',
+          'vtex-checkbox__line-container flex items-start relative',
           {
             pointer: !disabled,
           }
         )}>
         <div
           className={classNames(
-            `vtex-checkbox__container relative w1 h1 ${Styles.checkboxContainer}`,
+            `vtex-checkbox__container relative w1 h1`,
             {
               mr3: label,
             }
@@ -125,7 +124,7 @@ class Checkbox extends PureComponent {
         {label && (
           <label
             className={classNames(
-              'vtex-checkbox__label',
+              'vtex-checkbox__label w-100',
               { 'c-disabled': disabled },
               { 'c-on-base pointer': !disabled }
             )}

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -52,12 +52,9 @@ class Checkbox extends PureComponent {
           }
         )}>
         <div
-          className={classNames(
-            `vtex-checkbox__container relative w1 h1`,
-            {
-              mr3: label,
-            }
-          )}>
+          className={classNames(`vtex-checkbox__container relative w1 h1`, {
+            mr3: label,
+          })}>
           <div
             className={classNames(
               'vtex-checkbox__inner-container h1 w1 absolute ba bw1 br1 ',

--- a/react/components/Checkbox/styles.css
+++ b/react/components/Checkbox/styles.css
@@ -1,0 +1,3 @@
+.mw1 {
+  min-width: 1rem;
+}

--- a/react/components/Checkbox/styles.css
+++ b/react/components/Checkbox/styles.css
@@ -1,3 +1,4 @@
-.mw1 {
+.checkboxContainer {
   min-width: 1rem;
+  margin-bottom: auto;
 }

--- a/react/components/Checkbox/styles.css
+++ b/react/components/Checkbox/styles.css
@@ -1,4 +1,0 @@
-.checkboxContainer {
-  min-width: 1rem;
-  margin-bottom: auto;
-}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes #1299 

#### What problem is this solving?
When the Checkbox has a text that breaks the line it overflows over the box, the problem is caused due to not having `min-width` property.

#### How should this be manually tested?
Have a checkbox with a text that cannot be displayed in a single line.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/16125001/91057778-0d8cb300-e5fe-11ea-90b4-11b9f375754b.png)

Before:
![image](https://user-images.githubusercontent.com/16125001/91057851-239a7380-e5fe-11ea-8335-73581513c934.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
