### PR TITLE
fix: InputSearch icon unaligned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [9.128.0] - 2020-08-24
-
-## Fixed
+### Fixed
 
 -  InputSearch component icon unaligned
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.128.0] - 2020-08-24
+
+## Fixed
+
+-  InputSearch component icon unaligned
+
 ## [9.127.0] - 2020-08-13
 
 ### Added

--- a/react/components/InputSearch/index.js
+++ b/react/components/InputSearch/index.js
@@ -64,7 +64,6 @@ class InputSearch extends Component {
     const { disabled, size, value } = this.props
     const iconSize =
       InputSearch.iconSizes[size] || InputSearch.iconSizes.regular
-
     return (
       <Input
         {...this.props}
@@ -94,7 +93,10 @@ class InputSearch extends Component {
                   InputSearch.separatorHeight.regular,
               }}
             />
-            <span className="pointer pl4 c-link" onClick={this.handleSubmit}>
+            <span
+              className="pointer pl4 c-link"
+              onClick={this.handleSubmit}
+              style={{ height: iconSize }}>
               <SearchIcon size={iconSize} />
             </span>
           </div>

--- a/react/components/InputSearch/index.js
+++ b/react/components/InputSearch/index.js
@@ -94,9 +94,8 @@ class InputSearch extends Component {
               }}
             />
             <span
-              className="pointer pl4 c-link"
-              onClick={this.handleSubmit}
-              style={{ height: iconSize }}>
+              className="pointer pl4 c-link flex"
+              onClick={this.handleSubmit}>
               <SearchIcon size={iconSize} />
             </span>
           </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixes ##1302.

#### What problem is this solving?

keeps the search Icon vertically aligned, as it should be

#### How should this be tested manually?

open the InputSearch component and see if the icons are centered horizontally and vertically

#### Screenshots or usage example
before:
![image](https://user-images.githubusercontent.com/44899195/91058123-7c6a0c00-e5fe-11ea-8c6f-95fff170fe44.png)


after:
![image](https://user-images.githubusercontent.com/44899195/91056977-01542600-e5fd-11ea-8781-d2d462b67fb9.png)

#### Types of changes

- [x] Bug fix (an uninterrupted change that fixes a problem)
- [] New feature (a nonstop change that adds functionality)
- [] Breaking the change (fix or feature that would cause the existing functionality to be changed)
- [] Requires changes to the documentation, which has been updated accordingly.
