### PR TITLE
Fix padding right to AutoComplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Plus** icon size and color.
 
+### Fixed
+
+- `AutoCompleteInput` padding-right when `ClearInputIcon` is shown.
+
 ## [9.127.0] - 2020-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Fixed
 
 - **Plus** icon size and color.
-
-### Fixed
-
 - `AutoCompleteInput` padding-right when `ClearInputIcon` is shown.
 
 ## [9.127.0] - 2020-08-13

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -119,8 +119,7 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
         {showClearIcon && (
           <span
             className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
-            onClick={handleClear}
-          >
+            onClick={handleClear}>
             <ClearInputIcon />
           </span>
         )}
@@ -129,8 +128,7 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
         <button
           className={buttonClasses}
           disabled={disabled}
-          onClick={() => onSearch(value)}
-        >
+          onClick={() => onSearch(value)}>
           <IconSearch size={16} />
         </button>
       )}

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -34,10 +34,11 @@ const defaultProps = {
   roundedBottom: true,
 }
 
-const SearchInput: React.FC<
-  PropTypes.InferProps<typeof propTypes> &
-    Omit<React.HTMLProps<HTMLInputElement>, 'onChange' | 'value' | 'size'>
-> = (props) => {
+const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
+  Omit<
+    React.HTMLProps<HTMLInputElement>,
+    'onChange' | 'value' | 'size'
+  >> = props => {
   const {
     onClear,
     onSearch,
@@ -98,8 +99,9 @@ const SearchInput: React.FC<
     'w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5',
     {
       'br--left': onSearch,
-    },
-    `pr${showClearIcon ? 8 : 5}`
+      pr5: !showClearIcon,
+      pr8: showClearIcon,
+    }
   )
 
   return (
@@ -117,7 +119,8 @@ const SearchInput: React.FC<
         {showClearIcon && (
           <span
             className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
-            onClick={handleClear}>
+            onClick={handleClear}
+          >
             <ClearInputIcon />
           </span>
         )}
@@ -126,7 +129,8 @@ const SearchInput: React.FC<
         <button
           className={buttonClasses}
           disabled={disabled}
-          onClick={() => onSearch(value)}>
+          onClick={() => onSearch(value)}
+        >
           <IconSearch size={16} />
         </button>
       )}

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -34,11 +34,10 @@ const defaultProps = {
   roundedBottom: true,
 }
 
-const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
-  Omit<
-    React.HTMLProps<HTMLInputElement>,
-    'onChange' | 'value' | 'size'
-  >> = props => {
+const SearchInput: React.FC<
+  PropTypes.InferProps<typeof propTypes> &
+    Omit<React.HTMLProps<HTMLInputElement>, 'onChange' | 'value' | 'size'>
+> = (props) => {
   const {
     onClear,
     onSearch,
@@ -93,12 +92,14 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     }
   )
 
+  const showClearIcon = onClear && value
   const inputClasses = classNames(
     activeClass,
-    'w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 pr8',
+    'w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5',
     {
       'br--left': onSearch,
-    }
+    },
+    `pr${showClearIcon ? 8 : 5}`
   )
 
   return (
@@ -113,7 +114,7 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
           disabled={disabled}
           {...inputProps}
         />
-        {onClear && value && (
+        {showClearIcon && (
           <span
             className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
             onClick={handleClear}>

--- a/react/components/AutocompleteInput/__snapshots__/index.test.tsx.snap
+++ b/react/components/AutocompleteInput/__snapshots__/index.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`AutocompleteInput should render a regular version of search bar if size
         class="relative w-100"
       >
         <input
-          class="b--muted-4 bg-base c-on-base h-regular w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 pr8 br--left"
+          class="b--muted-4 bg-base c-on-base h-regular w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 br--left pr5"
           placeholder=""
           value=""
         />
@@ -55,7 +55,7 @@ exports[`AutocompleteInput should render with a large size bar 1`] = `
         class="relative w-100"
       >
         <input
-          class="b--muted-4 bg-base c-on-base h-large w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 pr8 br--left"
+          class="b--muted-4 bg-base c-on-base h-large w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 br--left pr5"
           placeholder=""
           value=""
         />
@@ -98,7 +98,7 @@ exports[`AutocompleteInput should render with a regular size bar 1`] = `
         class="relative w-100"
       >
         <input
-          class="b--muted-4 bg-base c-on-base h-regular w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 pr8 br--left"
+          class="b--muted-4 bg-base c-on-base h-regular w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 br--left pr5"
           placeholder=""
           value=""
         />
@@ -141,7 +141,7 @@ exports[`AutocompleteInput should render with a regular size bar when prop is ab
         class="relative w-100"
       >
         <input
-          class="b--muted-4 bg-base c-on-base h-regular w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 pr8 br--left"
+          class="b--muted-4 bg-base c-on-base h-regular w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 br--left pr5"
           placeholder=""
           value=""
         />
@@ -184,7 +184,7 @@ exports[`AutocompleteInput should render with a small size bar 1`] = `
         class="relative w-100"
       >
         <input
-          class="b--muted-4 bg-base c-on-base h-small w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 pr8 br--left"
+          class="b--muted-4 bg-base c-on-base h-small w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 br--left pr5"
           placeholder=""
           value=""
         />


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix #1306 

<!--- Describe your changes in detail. -->
Creates a new condition to adjust the padding-right when CloseIconInput does not show. 

#### What problem is this solving?
[Running workspace](https://fixautocomplete--cosmetics1.myvtex.com/admin/app/collections/9259?tab=add)

<!--- What is the motivation and context for this change? -->
#1306 

#### How should this be manually tested?
1- Try to put a long placehold in AutoCompleteInput 
2- Check if the padding is changing when the CloseIconInput isn't being shown.

#### Screenshots or example usage
Before
![Captura de tela de 2020-08-24 11-24-53](https://user-images.githubusercontent.com/11728655/91056525-7a9f4900-e5fc-11ea-8c62-e79a6fe781bb.png)

After
![Captura de tela de 2020-08-24 11-17-59](https://user-images.githubusercontent.com/11728655/91056346-40ce4280-e5fc-11ea-9191-09bdc83aad2c.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
