### PR TITLE
Add onClick prop to ActionMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `onClick` prop to `ActionMenu` component.
+
 ### Fixed
 
 - **Plus** icon size and color.

--- a/react/components/ActionMenu/index.js
+++ b/react/components/ActionMenu/index.js
@@ -29,7 +29,8 @@ class ActionMenu extends Component {
     this.setState({ isMenuOpen: false })
   }
 
-  handleClick = () => {
+  handleClick = event => {
+    this.props.onClick && this.props.onClick(event)
     if (!this.state.isMenuOpen) {
       this.openMenu()
     } else {
@@ -170,6 +171,8 @@ ActionMenu.propTypes = {
   isActiveOfGroup: PropTypes.bool,
   /** Default z-index to Menu view, default is 999 */
   zIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** _onClick_ event. */
+  onClick: PropTypes.func,
 }
 
 export default ActionMenu


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add onClick prop to ActionMenu to provide event handling.

#### What problem is this solving?
Example:
Go into [this workspace](https://actionmenu--recorrenciaqa.myvtex.com/admin/app/orders/1052461639489-01) mobile version and try to click on the action menu like the gif below. The collapsible will also move when the button is clicked, which is not wanted. With the onClick prop, I'm able to stop event propagation.

Note: The collapsible being used in this example is a copy of the Styleguide's but with some small design changes like margins and the caret to fit the Admin V4 aesthetic.

#### How should this be manually tested?
https://fixed--recorrenciaqa.myvtex.com/admin/app/orders/1052461639489-01

#### Screenshots or example usage

Before:
![actionMenu](https://user-images.githubusercontent.com/27328184/91230706-5ded3900-e702-11ea-985b-b75980a3a02b.gif)

After:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/27328184/91231006-ee2b7e00-e702-11ea-8135-c052dc80ad92.gif)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
