### PR TITLE
Fixed hexadecimal regex validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- `FilterOptions` behaviour and example.
-- Bug on color hex validation
+- **FilterOptions** behaviour and example.
+- **ColorPicker** hex validation
 
 ## [9.128.1] - 2020-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `FilterOptions` behaviour and example.
+- Bug on color hex validation
 
 ## [9.128.1] - 2020-08-28
 

--- a/react/components/ColorPicker/HexInput.js
+++ b/react/components/ColorPicker/HexInput.js
@@ -46,7 +46,10 @@ class HexInput extends React.Component {
   updateInputValue() {
     const { rgb } = this.props
     const color = colorutil.rgb.to.hex(rgb)
-    this.setState({ inputValue: color })
+
+    if (!colorutil.areEqualHexColors(color, this.state.inputValue)) {
+      this.setState({ inputValue: color })
+    }
   }
 
   render() {

--- a/react/components/ColorPicker/colorUtil.js
+++ b/react/components/ColorPicker/colorUtil.js
@@ -145,7 +145,7 @@ const hexTohsv = hex => {
 }
 
 const validHex = hex => {
-  return /(^#[0-9A-F]{6}$)/i.test(hex)
+  return /#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/i.test(hex)
 }
 
 /** Get color format */

--- a/react/components/ColorPicker/colorUtil.js
+++ b/react/components/ColorPicker/colorUtil.js
@@ -1,3 +1,5 @@
+const THREE_CHAR_HEX_LENGTH = 4 //because of the '#'
+
 const COLOR_CONSTS = {
   RGB_MAX_VALUE: 255,
 }
@@ -125,8 +127,20 @@ const hsvTohex = hsv => {
   return rgbTohex(rgb)
 }
 
+const hex3to6 = hex => {
+  let sixCharHex = '#' 
+  for (let char of hex.slice(1)) {
+      sixCharHex += char.repeat(2)
+  }
+  return sixCharHex
+} 
+
 /** Convert Hex to RGB */
 const hexTorgb = hex => {
+  if (hex.length === THREE_CHAR_HEX_LENGTH) { 
+    hex = hex3to6(hex)
+  }
+
   const r = parseInt(hex.substring(1, 3), 16)
   const g = parseInt(hex.substring(3, 5), 16)
   const b = parseInt(hex.substring(5, 7), 16)

--- a/react/components/ColorPicker/colorUtil.js
+++ b/react/components/ColorPicker/colorUtil.js
@@ -50,6 +50,10 @@ const rgbTohsv = rgb => {
   }
 }
 
+const areEqualHexColors = (col1, col2) =>
+  col1.toLowerCase() === col2.toLowerCase() ||
+  tryHex6to3(col1).toLowerCase() === tryHex6to3(col2).toLowerCase()
+
 /** Convert RGB to Hex*/
 const rgbTohex = rgb => {
   const { r, g, b } = rgb
@@ -128,16 +132,33 @@ const hsvTohex = hsv => {
 }
 
 const hex3to6 = hex => {
-  let sixCharHex = '#' 
-  for (let char of hex.slice(1)) {
-      sixCharHex += char.repeat(2)
+  let sixCharHex = '#'
+  for (const char of hex.slice(1)) {
+    sixCharHex += char.repeat(2)
   }
   return sixCharHex
-} 
+}
+
+/**
+ * Attempts to convert if a hex with 6 chars to 3, if not possible returns the same hex
+ * @param {*} hex
+ */
+const tryHex6to3 = hex => {
+  if (hex.length === THREE_CHAR_HEX_LENGTH) {
+    return hex
+  }
+
+  let threeCharHex = '#'
+  for (let i = 1; i < hex.length - 1; i += 2) {
+    if (hex[i] !== hex[i + 1]) return hex
+    threeCharHex += hex[i]
+  }
+  return threeCharHex
+}
 
 /** Convert Hex to RGB */
 const hexTorgb = hex => {
-  if (hex.length === THREE_CHAR_HEX_LENGTH) { 
+  if (hex.length === THREE_CHAR_HEX_LENGTH) {
     hex = hex3to6(hex)
   }
 
@@ -240,5 +261,7 @@ export default {
       hex: anyTohex,
     },
   },
+  tryHex6to3: tryHex6to3,
   validateHex: validHex,
+  areEqualHexColors: areEqualHexColors,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix an issue on regex validation for hexadecimal colors

#### What problem is this solving?

Colors with only three chars are being returned false (e.g. #FFF), which then causes an error on the next line: 

```
else if ('h' in color && 's' in color && 'v' in color) return COLOR_FORMAT.HSV
```

```
Uncaught TypeError: Cannot use 'in' operator to search for 'h' in #FFF
```

#### How should this be manually tested?

You can use the ColorPicker and on the `color` prop use a three chars hexa color: 
https://github.com/vtex-apps/admin-pages/blob/22593b3f44aab7add43e96b7771e1c6788b79987/react/components/admin/store/PWAForm/index.tsx#L188


#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
