### PR TITLE
Fix AutocompleteInput popup not closing when clicking on search button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `AutocompleteInput` popup not closing when clicking on search button.
+
 ## [9.129.0] - 2020-09-15
 
 ### Added

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -197,6 +197,14 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
     setShowPopover(false)
   }
 
+  const handleSearch = () => {
+    if (!onSearch) {
+      return
+    }
+    onSearch(term)
+    setShowPopover(false)
+  }
+
   const getOptionProps = (option, index) => ({
     key: `${getTermFromOption(option)}-${index}`,
     selected: index === selectedOptionIndex,
@@ -253,7 +261,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
         roundedBottom={!popoverOpened}
         onKeyDown={handleKeyDown}
         onFocus={() => setShowPopover(true)}
-        onSearch={onSearch && (() => onSearch(term))}
+        onSearch={handleSearch}
         onClear={handleClear}
         onChange={handleTermChange}
         error={errorStyle}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6965,7 +6965,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
When the search is made by clicking on the search button the popup doesn't close.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
`yarn && yarn styleguide`
https://styleguide-git-fix-autocompleteinput-popup-not-closing.styleguide-core.vercel.app/#/Components/Forms/AutocompleteInput
1. Type something in the `AutocompleteInput`
2. Click on the search button
3. Check if the popup closes.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
