### PR TITLE
Fix Table v2 cell suffix display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `AutocompleteInput` popup not closing when clicking on search button.
+- **EXPERIMENTAL_Table** cell suffix classes.
 
 ## [9.129.0] - 2020-09-15
 

--- a/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Cell.tsx
@@ -125,7 +125,7 @@ function useHover(init = false) {
 
 function Eyesight({ children, visible }) {
   const SUFIX_GAP = 0.5
-  const className = classNames({ dn: !visible, inline: visible }, 'absolute')
+  const className = classNames({ 'o-0': !visible }, 'inline')
   return (
     <span className={className} style={{ marginLeft: `${SUFIX_GAP}rem` }}>
       {children}


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, the cell's suffix display was broken.

#### What problem is this solving?

With `absolute` class, the cell's suffix width was not being considered and it was breaking the table's layout.

#### Screenshots or example usage

##### Before

![image](https://user-images.githubusercontent.com/15948386/93912186-c582ae00-fcd9-11ea-8e3c-a4cf0cf157f9.png)

##### Now

![image](https://user-images.githubusercontent.com/15948386/93912120-b00d8400-fcd9-11ea-879e-62545d4a26ee.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
