### PR TITLE
Add input.prefix and input.suffix to AutocompleteInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **AutocompleteInput** `input.prefix` and `input.suffix` props.
+
+### Fixed
+
+- **AutocompleteInput** without search button logic.
+
 ## [9.129.1] - 2020-09-24
 
 ### Fixed
 
-- `AutocompleteInput` popup not closing when clicking on search button.
+- **AutocompleteInput** popup not closing when clicking on search button.
 - **EXPERIMENTAL_Table** cell suffix classes.
 
 ## [9.129.0] - 2020-09-15

--- a/react/components/AutocompleteInput/README.md
+++ b/react/components/AutocompleteInput/README.md
@@ -467,7 +467,7 @@ const UsersAutocomplete = () => {
 ;<UsersAutocomplete />
 ```
 
-#### With prefix
+#### With prefix or suffix
 
 ```jsx
 import { uniq } from 'lodash'
@@ -482,7 +482,7 @@ const allUsers = [
   'Daniela',
 ]
 
-const UsersAutocomplete = () => {
+const UsersAutocomplete = ({ suffix, prefix }) => {
   const [term, setTerm] = useState('')
   const [loading, setLoading] = useState(false)
   const timeoutRef = useRef(null)
@@ -515,7 +515,8 @@ const UsersAutocomplete = () => {
         setTerm(term)
       }
     },
-    prefix: <IconUser size={16} />,
+    prefix,
+    suffix,
     onClear: () => setTerm(''),
     placeholder: 'Search user... (e.g.: Ana)',
     value: term,
@@ -523,7 +524,12 @@ const UsersAutocomplete = () => {
   return <AutocompleteInput input={input} options={options} />
 }
 
-;<UsersAutocomplete />
+;<>
+  <div className="mb5">
+    <UsersAutocomplete prefix={<IconUser size={16} />} />
+  </div>
+    <UsersAutocomplete suffix={<IconUser size={16} />} />
+</>
 ```
 
 #### Disabled AutocompleteInput

--- a/react/components/AutocompleteInput/README.md
+++ b/react/components/AutocompleteInput/README.md
@@ -467,6 +467,65 @@ const UsersAutocomplete = () => {
 ;<UsersAutocomplete />
 ```
 
+#### With prefix
+
+```jsx
+import { uniq } from 'lodash'
+import { useState, useRef } from 'react'
+import IconUser from '../icon/User'
+
+const allUsers = [
+  'Ana Clara',
+  'Ana Luiza',
+  { value: 1, label: 'Bruno' },
+  'Carlos',
+  'Daniela',
+]
+
+const UsersAutocomplete = () => {
+  const [term, setTerm] = useState('')
+  const [loading, setLoading] = useState(false)
+  const timeoutRef = useRef(null)
+
+  const options = {
+    onSelect: (...args) => console.log('onSelect: ', ...args),
+    loading,
+    value: !term.length
+      ? []
+      : allUsers.filter(user =>
+          typeof user === 'string'
+            ? user.toLowerCase().includes(term.toLowerCase())
+            : user.label.toLowerCase().includes(term.toLowerCase())
+        ),
+  }
+
+  const input = {
+    onChange: term => {
+      if (term) {
+        setLoading(true)
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+        }
+        timeoutRef.current = setTimeout(() => {
+          setLoading(false)
+          setTerm(term)
+          timeoutRef.current = null
+        }, 1000)
+      } else {
+        setTerm(term)
+      }
+    },
+    prefix: <IconUser size={16} />,
+    onClear: () => setTerm(''),
+    placeholder: 'Search user... (e.g.: Ana)',
+    value: term,
+  }
+  return <AutocompleteInput input={input} options={options} />
+}
+
+;<UsersAutocomplete />
+```
+
 #### Disabled AutocompleteInput
 
 ```jsx
@@ -522,7 +581,9 @@ const UsersAutocomplete = () => {
         <div className="ph3 c-muted-1 flex">
           <Info />
         </div>
-        <div className="c-on-base">Some of these users might not be from your organization</div>
+        <div className="c-on-base">
+          Some of these users might not be from your organization
+        </div>
       </div>
     ),
   }

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -31,6 +31,8 @@ const propTypes = {
   error: PropTypes.bool,
   /** Prefix element */
   prefix: PropTypes.node,
+  /** Suffix element */
+  suffix: PropTypes.node,
 }
 
 const defaultProps = {
@@ -54,6 +56,7 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     size = 'regular',
     error,
     prefix,
+    suffix,
     ...inputProps
   } = props
 
@@ -100,6 +103,10 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     pr3: size !== 'large',
     pr4: size === 'large',
   })
+  const suffixClasses = classNames('br2 br-0 br--right pr5', {
+    pl3: size !== 'large',
+    pl4: size === 'large',
+  })
 
   const prefixAndSuffixClasses = classNames('c-muted-2 fw5 flex items-center', {
     't-body': size !== 'small',
@@ -111,9 +118,6 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     activeClass,
     {
       'br--left': onSearch,
-      pr5: !showClearIcon || prefix,
-      pr8: showClearIcon,
-      pl5: !prefix,
       [`h-${size}`]: !regularSize,
       'h-regular': regularSize,
     }
@@ -121,7 +125,19 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
   const inputClasses = classNames(
     'ma0 border-box w-100 bn outline-0',
     styles.noAppearance,
-    activeClass
+    activeClass,
+    {
+      pr5: !showClearIcon && !suffix,
+      pl5: !prefix,
+    }
+  )
+
+  const clearIconClasses = classNames(
+    'c-muted-3 fw5 flex items-center pl3 t-body h-100 pointer',
+    {
+      pr5: !suffix,
+      pr3: suffix,
+    }
   )
 
   return (
@@ -143,10 +159,13 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
             {...inputProps}
           />
           {showClearIcon && (
-            <span
-              className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
-              onClick={handleClear}>
+            <span className={clearIconClasses} onClick={handleClear}>
               <ClearInputIcon />
+            </span>
+          )}
+          {suffix && (
+            <span className={`${prefixAndSuffixClasses} ${suffixClasses}`}>
+              {suffix}
             </span>
           )}
         </div>

--- a/react/components/AutocompleteInput/SearchInput/index.tsx
+++ b/react/components/AutocompleteInput/SearchInput/index.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 
 import IconSearch from '../../icon/Search'
 import ClearInputIcon from '../../icon/Clear'
+import styles from '../../Input/Input.css'
 
 const propTypes = {
   /** Determine if the input's bottom corners should be rounded or not */
@@ -28,6 +29,8 @@ const propTypes = {
   size: PropTypes.oneOf(['small', 'regular', 'large']),
   /** Determine if the input and button should be styled with error borders */
   error: PropTypes.bool,
+  /** Prefix element */
+  prefix: PropTypes.node,
 }
 
 const defaultProps = {
@@ -37,7 +40,7 @@ const defaultProps = {
 const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
   Omit<
     React.HTMLProps<HTMLInputElement>,
-    'onChange' | 'value' | 'size'
+    'onChange' | 'value' | 'size' | 'prefix'
   >> = props => {
   const {
     onClear,
@@ -48,8 +51,9 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     onFocus,
     onBlur,
     disabled,
-    size,
+    size = 'regular',
     error,
+    prefix,
     ...inputProps
   } = props
 
@@ -80,8 +84,6 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
     'br--top': !roundedBottom,
     'bg-disabled c-disabled': disabled,
     'bg-base c-on-base': !disabled,
-    [`h-${size}`]: !regularSize,
-    'h-regular': regularSize,
   })
 
   const buttonClasses = classNames(
@@ -94,36 +96,61 @@ const SearchInput: React.FC<PropTypes.InferProps<typeof propTypes> &
   )
 
   const showClearIcon = onClear && value
-  const inputClasses = classNames(
+  const prefixClasses = classNames('br2 br-0 br--left pl5', {
+    pr3: size !== 'large',
+    pr4: size === 'large',
+  })
+
+  const prefixAndSuffixClasses = classNames('c-muted-2 fw5 flex items-center', {
+    't-body': size !== 'small',
+    't-small': size === 'small',
+  })
+
+  const inputGroupClasses = classNames(
+    'flex flex-row items-stretch overflow-hidden bw1 br2 b--solid',
     activeClass,
-    'w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5',
     {
       'br--left': onSearch,
-      pr5: !showClearIcon,
+      pr5: !showClearIcon || prefix,
       pr8: showClearIcon,
+      pl5: !prefix,
+      [`h-${size}`]: !regularSize,
+      'h-regular': regularSize,
     }
+  )
+  const inputClasses = classNames(
+    'ma0 border-box w-100 bn outline-0',
+    styles.noAppearance,
+    activeClass
   )
 
   return (
     <div className="flex flex-row">
-      <div className="relative w-100">
-        <input
-          className={inputClasses}
-          value={value}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          onChange={handleChange}
-          disabled={disabled}
-          {...inputProps}
-        />
-        {showClearIcon && (
-          <span
-            className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
-            onClick={handleClear}>
-            <ClearInputIcon />
-          </span>
-        )}
-      </div>
+      <label className="relative w-100">
+        <div className={inputGroupClasses}>
+          {prefix && (
+            <span className={`${prefixAndSuffixClasses} ${prefixClasses}`}>
+              {prefix}
+            </span>
+          )}
+          <input
+            className={inputClasses}
+            value={value}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onChange={handleChange}
+            disabled={disabled}
+            {...inputProps}
+          />
+          {showClearIcon && (
+            <span
+              className="absolute c-muted-3 fw5 flex items-center pl3 pr5 t-body top-0 right-0 h-100 pointer"
+              onClick={handleClear}>
+              <ClearInputIcon />
+            </span>
+          )}
+        </div>
+      </label>
       {onSearch && (
         <button
           className={buttonClasses}

--- a/react/components/AutocompleteInput/__snapshots__/index.test.tsx.snap
+++ b/react/components/AutocompleteInput/__snapshots__/index.test.tsx.snap
@@ -8,17 +8,21 @@ exports[`AutocompleteInput should render a regular version of search bar if size
     <div
       class="flex flex-row"
     >
-      <div
+      <label
         class="relative w-100"
       >
-        <input
-          class="b--muted-4 bg-base c-on-base h-regular w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 br--left pr5"
-          placeholder=""
-          value=""
-        />
-      </div>
+        <div
+          class="flex flex-row items-stretch overflow-hidden bw1 br2 b--solid b--muted-4 bg-base c-on-base br--left h-regular"
+        >
+          <input
+            class="ma0 border-box w-100 bn outline-0 b--muted-4 bg-base c-on-base pr5 pl5"
+            placeholder=""
+            value=""
+          />
+        </div>
+      </label>
       <button
-        class="b--muted-4 bg-base c-on-base h-regular bg-base br2 br--right w3 bw1 ba pa0 bl-0 c-link pointer"
+        class="b--muted-4 bg-base c-on-base bg-base br2 br--right w3 bw1 ba pa0 bl-0 c-link pointer"
       >
         <svg
           class="vtex__icon-search  "
@@ -51,17 +55,21 @@ exports[`AutocompleteInput should render with a large size bar 1`] = `
     <div
       class="flex flex-row"
     >
-      <div
+      <label
         class="relative w-100"
       >
-        <input
-          class="b--muted-4 bg-base c-on-base h-large w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 br--left pr5"
-          placeholder=""
-          value=""
-        />
-      </div>
+        <div
+          class="flex flex-row items-stretch overflow-hidden bw1 br2 b--solid b--muted-4 bg-base c-on-base br--left h-large"
+        >
+          <input
+            class="ma0 border-box w-100 bn outline-0 b--muted-4 bg-base c-on-base pr5 pl5"
+            placeholder=""
+            value=""
+          />
+        </div>
+      </label>
       <button
-        class="b--muted-4 bg-base c-on-base h-large bg-base br2 br--right w3 bw1 ba pa0 bl-0 c-link pointer"
+        class="b--muted-4 bg-base c-on-base bg-base br2 br--right w3 bw1 ba pa0 bl-0 c-link pointer"
       >
         <svg
           class="vtex__icon-search  "
@@ -94,17 +102,21 @@ exports[`AutocompleteInput should render with a regular size bar 1`] = `
     <div
       class="flex flex-row"
     >
-      <div
+      <label
         class="relative w-100"
       >
-        <input
-          class="b--muted-4 bg-base c-on-base h-regular w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 br--left pr5"
-          placeholder=""
-          value=""
-        />
-      </div>
+        <div
+          class="flex flex-row items-stretch overflow-hidden bw1 br2 b--solid b--muted-4 bg-base c-on-base br--left h-regular"
+        >
+          <input
+            class="ma0 border-box w-100 bn outline-0 b--muted-4 bg-base c-on-base pr5 pl5"
+            placeholder=""
+            value=""
+          />
+        </div>
+      </label>
       <button
-        class="b--muted-4 bg-base c-on-base h-regular bg-base br2 br--right w3 bw1 ba pa0 bl-0 c-link pointer"
+        class="b--muted-4 bg-base c-on-base bg-base br2 br--right w3 bw1 ba pa0 bl-0 c-link pointer"
       >
         <svg
           class="vtex__icon-search  "
@@ -137,17 +149,21 @@ exports[`AutocompleteInput should render with a regular size bar when prop is ab
     <div
       class="flex flex-row"
     >
-      <div
+      <label
         class="relative w-100"
       >
-        <input
-          class="b--muted-4 bg-base c-on-base h-regular w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 br--left pr5"
-          placeholder=""
-          value=""
-        />
-      </div>
+        <div
+          class="flex flex-row items-stretch overflow-hidden bw1 br2 b--solid b--muted-4 bg-base c-on-base br--left h-regular"
+        >
+          <input
+            class="ma0 border-box w-100 bn outline-0 b--muted-4 bg-base c-on-base pr5 pl5"
+            placeholder=""
+            value=""
+          />
+        </div>
+      </label>
       <button
-        class="b--muted-4 bg-base c-on-base h-regular bg-base br2 br--right w3 bw1 ba pa0 bl-0 c-link pointer"
+        class="b--muted-4 bg-base c-on-base bg-base br2 br--right w3 bw1 ba pa0 bl-0 c-link pointer"
       >
         <svg
           class="vtex__icon-search  "
@@ -180,17 +196,21 @@ exports[`AutocompleteInput should render with a small size bar 1`] = `
     <div
       class="flex flex-row"
     >
-      <div
+      <label
         class="relative w-100"
       >
-        <input
-          class="b--muted-4 bg-base c-on-base h-small w-100 ma0 border-box bw1 br2 ba outline-0 t-body ph5 br--left pr5"
-          placeholder=""
-          value=""
-        />
-      </div>
+        <div
+          class="flex flex-row items-stretch overflow-hidden bw1 br2 b--solid b--muted-4 bg-base c-on-base br--left h-small"
+        >
+          <input
+            class="ma0 border-box w-100 bn outline-0 b--muted-4 bg-base c-on-base pr5 pl5"
+            placeholder=""
+            value=""
+          />
+        </div>
+      </label>
       <button
-        class="b--muted-4 bg-base c-on-base h-small bg-base br2 br--right w3 bw1 ba pa0 bl-0 c-link pointer"
+        class="b--muted-4 bg-base c-on-base bg-base br2 br--right w3 bw1 ba pa0 bl-0 c-link pointer"
       >
         <svg
           class="vtex__icon-search  "

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -198,10 +198,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
   }
 
   const handleSearch = () => {
-    if (!onSearch) {
-      return
-    }
-    onSearch(term)
+    onSearch?.(term)
     setShowPopover(false)
   }
 
@@ -261,7 +258,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
         roundedBottom={!popoverOpened}
         onKeyDown={handleKeyDown}
         onFocus={() => setShowPopover(true)}
-        onSearch={handleSearch}
+        onSearch={onSearch && handleSearch}
         onClear={handleClear}
         onChange={handleTermChange}
         error={errorStyle}


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says...
Also, fixes the "Without search button" logic.

#### What problem is this solving?

There was no way of defining prefix or suffix on `AutocompleteInput`. And about the search button, `handleSearch` was always being passed to `SearchInput`.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/94449879-f56efd00-0182-11eb-905b-8314ec8410ae.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
