### PR TITLE
Release v9.130.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.130.0] - 2020-09-29
+
 ### Added
 
 - **AutocompleteInput** `input.prefix` and `input.suffix` props.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.129.1",
+  "version": "9.130.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.129.1",
+  "version": "9.130.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",


### PR DESCRIPTION
## [9.130.0] - 2020-09-29

### Added

- **AutocompleteInput** `input.prefix` and `input.suffix` props.

### Fixed

- **AutocompleteInput** without search button logic.