### PR TITLE
Fix AutocompleteInput term to follow input.value changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **AutocompleteInput** term should follow `input.value` changes to allow input control outside the component.
+
 ## [9.130.2] - 2020-10-02
+
 ### Changed
 - **Spinner** Make animation simpler for better performance.
 

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 
 import Spinner from '../Spinner'
 import { useClickOutside, useArrowNavigation } from './hooks'
@@ -127,6 +127,13 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
   },
 }) => {
   const [term, setTerm] = useState(value || '')
+  useEffect(
+    function updateTermWhenInputValueChanges() {
+      setTerm(value)
+    },
+    [value]
+  )
+
   const [showPopover, setShowPopover] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const searching = term.length


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, the `term` value (private state) should follow `input.value` changes to allow control outside the component.

#### What problem is this solving?

Basically, without it, the parent component changes on `input.value` will not reflect on `AutocompleteInput`. The `term` variable should only be used to control the input value when browsing options with the arrow keys.

#### How should this be manually tested?

1. Access this [workspace](https://logistics--logisticsqa.myvtex.com/admin/inventory)
2. Change any item's quantity **but don't save it**
3. Change the autocomplete input value. E.g.: Type 'chaveiro'.
4. Select an option.
5. When the modal shows up, click "Keep editing".
6. The input value should be cleared.

#### Screenshots or example usage

![inventory](https://user-images.githubusercontent.com/15948386/94705146-15cfc080-0317-11eb-965f-39a71c7688c4.gif)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
