### PR TITLE
Fixes root checkbox being always checked when all children checkboxes…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **AutocompleteInput** double focus issue when navigating through the suggested options with tab and arrow keys.
+- **EXPERIMENTAL_useCheckboxTree** root checkbox behavior when all children checkboxes are disabled.
 
 ### Added
 

--- a/react/components/EXPERIMENTAL_useCheckboxTree/index.tsx
+++ b/react/components/EXPERIMENTAL_useCheckboxTree/index.tsx
@@ -54,11 +54,25 @@ export default function useCheckboxTree<T>({
 
       if (!childNodes || isEmpty(childNodes)) return
 
-      const childrenChecked = childNodes
-        .filter(childNode => !isDisabled(childNode))
-        .every(childNode => checkedItems.some(comparator(childNode)))
-
       const rootChecked = checkedItems.some(comparator(tree))
+
+      const notDisabledChildNodes = childNodes.filter(
+        childNode => !isDisabled(childNode)
+      )
+
+      if (notDisabledChildNodes.length === 0) {
+        if (rootChecked) {
+          dispatch({
+            type: ActionType.Uncheck,
+            itemToToggle: { item: tree, comparator },
+          })
+        }
+        return
+      }
+
+      const childrenChecked = notDisabledChildNodes.every(childNode =>
+        checkedItems.some(comparator(childNode))
+      )
 
       if (childrenChecked && !rootChecked && !isDisabled(tree))
         dispatch({ type: ActionType.Check, item: tree })

--- a/react/components/EXPERIMENTAL_useCheckboxTree/index.tsx
+++ b/react/components/EXPERIMENTAL_useCheckboxTree/index.tsx
@@ -56,11 +56,11 @@ export default function useCheckboxTree<T>({
 
       const rootChecked = checkedItems.some(comparator(tree))
 
-      const notDisabledChildNodes = childNodes.filter(
+      const enabledChildNodes = childNodes.filter(
         childNode => !isDisabled(childNode)
       )
 
-      if (notDisabledChildNodes.length === 0) {
+      if (enabledChildNodes.length === 0) {
         if (rootChecked) {
           dispatch({
             type: ActionType.Uncheck,
@@ -70,7 +70,7 @@ export default function useCheckboxTree<T>({
         return
       }
 
-      const childrenChecked = notDisabledChildNodes.every(childNode =>
+      const childrenChecked = enabledChildNodes.every(childNode =>
         checkedItems.some(comparator(childNode))
       )
 


### PR DESCRIPTION
… are disabled

#### What is the purpose of this pull request?

As the title says...

#### What problem is this solving?

In the scenario of all children being disabled, as soon as the hook useCheckboxTree runs its `shake` effect, the error appears. 
This happens because the Array.prototype.every method always returns true for empty arrays ([link](https://stackoverflow.com/questions/34137250/why-does-array-prototype-every-return-true-on-an-empty-array)) making the effect mistakenly dispatch an action that checks the root checkbox 

There are two ways of handling it: Just don't do anything or if the root checkbox is checked (for some reason), uncheck it. 
I choose the latter, but I will leave it to the reviewers to decide the best approach.

#### How should this be manually tested?

[Running workspace](https://tenorio--bazarhorizonte.myvtex.com/admin/vtexlog/packing/?status=label_issued,carrier_notified)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/70980489/94822304-de294d00-03d8-11eb-9450-f252b0b8dd41.png)
#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.