### PR TITLE
Fix AutocompleteInput 'double focus' when navigating with tab + arrow keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - **AutocompleteInput** restart navigating from top when reaching the end of the suggested options with the down arrow key.
->>>>>>> Update CHANGELOG.md
 
 ## [9.131.0] - 2020-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **AutocompleteInput** double focus issue when navigating through the suggested options with tab and arrow keys.
+
+### Added
+
+- **AutocompleteInput** restart navigating from top when reaching the end of the suggested options with the down arrow key.
+>>>>>>> Update CHANGELOG.md
+
 ## [9.131.0] - 2020-10-05
 
 ### Added

--- a/react/components/AutocompleteInput/Option.tsx
+++ b/react/components/AutocompleteInput/Option.tsx
@@ -71,7 +71,7 @@ const Option: React.FunctionComponent<PropTypes.InferProps<
   return (
     <button
       className={buttonClasses}
-      onFocus={() => setHighlightOption(false)}
+      onFocus={() => setHighlightOption(true)}
       onMouseEnter={() => setHighlightOption(true)}
       onMouseLeave={() => setHighlightOption(false)}
       onClick={onClick}>

--- a/react/components/AutocompleteInput/Option.tsx
+++ b/react/components/AutocompleteInput/Option.tsx
@@ -71,7 +71,7 @@ const Option: React.FunctionComponent<PropTypes.InferProps<
   return (
     <button
       className={buttonClasses}
-      onFocus={() => setHighlightOption(true)}
+      onFocus={() => setHighlightOption(false)}
       onMouseEnter={() => setHighlightOption(true)}
       onMouseLeave={() => setHighlightOption(false)}
       onClick={onClick}>

--- a/react/components/AutocompleteInput/hooks.ts
+++ b/react/components/AutocompleteInput/hooks.ts
@@ -44,13 +44,14 @@ export const useArrowNavigation = (
       let index
       switch (e.key) {
         case 'ArrowUp':
-          e.preventDefault()
-          index = Math.max(selectedOptionIndex - 1, initialSelectedOptionIndex)
-          return setSelectedOptionIndex(index)
+            e.preventDefault()
+            index = Math.max(selectedOptionIndex - 1, initialSelectedOptionIndex) 
+            return setSelectedOptionIndex(index)
+          
         case 'ArrowDown':
-          e.preventDefault()
-          index = Math.min(selectedOptionIndex + 1, optionsLength - 1)
-          return setSelectedOptionIndex(index)
+            e.preventDefault()
+            index = (selectedOptionIndex + 1) % optionsLength
+            return setSelectedOptionIndex(index)
         default:
           return
       }

--- a/react/components/AutocompleteInput/hooks.ts
+++ b/react/components/AutocompleteInput/hooks.ts
@@ -45,7 +45,7 @@ export const useArrowNavigation = (
       switch (e.key) {
         case 'ArrowUp':
           e.preventDefault()
-          index = Math.max(selectedOptionIndex - 1, initialSelectedOptionIndex) 
+          index = Math.max(selectedOptionIndex - 1, initialSelectedOptionIndex)
           return setSelectedOptionIndex(index)
         case 'ArrowDown':
           e.preventDefault()

--- a/react/components/AutocompleteInput/hooks.ts
+++ b/react/components/AutocompleteInput/hooks.ts
@@ -47,7 +47,6 @@ export const useArrowNavigation = (
           e.preventDefault()
           index = Math.max(selectedOptionIndex - 1, initialSelectedOptionIndex) 
           return setSelectedOptionIndex(index)
-          
         case 'ArrowDown':
           e.preventDefault()
           index = (selectedOptionIndex + 1) % optionsLength

--- a/react/components/AutocompleteInput/hooks.ts
+++ b/react/components/AutocompleteInput/hooks.ts
@@ -44,14 +44,14 @@ export const useArrowNavigation = (
       let index
       switch (e.key) {
         case 'ArrowUp':
-            e.preventDefault()
-            index = Math.max(selectedOptionIndex - 1, initialSelectedOptionIndex) 
-            return setSelectedOptionIndex(index)
+          e.preventDefault()
+          index = Math.max(selectedOptionIndex - 1, initialSelectedOptionIndex) 
+          return setSelectedOptionIndex(index)
           
         case 'ArrowDown':
-            e.preventDefault()
-            index = (selectedOptionIndex + 1) % optionsLength
-            return setSelectedOptionIndex(index)
+          e.preventDefault()
+          index = (selectedOptionIndex + 1) % optionsLength
+          return setSelectedOptionIndex(index)
         default:
           return
       }

--- a/react/components/AutocompleteInput/hooks.ts
+++ b/react/components/AutocompleteInput/hooks.ts
@@ -49,7 +49,7 @@ export const useArrowNavigation = (
           return setSelectedOptionIndex(index)
         case 'ArrowDown':
           e.preventDefault()
-          index = (selectedOptionIndex + 1) % optionsLength
+          index = (optionsLength === 0) ? -1 : (selectedOptionIndex + 1) % optionsLength
           return setSelectedOptionIndex(index)
         default:
           return

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -126,6 +126,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
     customMessage,
   },
 }) => {
+
   const [term, setTerm] = useState(value || '')
   useEffect(
     function updateTermWhenInputValueChanges() {
@@ -141,6 +142,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
     !searching && lastSearched.value && lastSearched.value.length > 0
 
   const getShowedOptions = (): AutocompleteOption[] => {
+    
     if (showLastSearched) {
       return lastSearched.value
     }
@@ -179,6 +181,10 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
         onSearch?.(getTermFromOption(selectedOption))
       }
       setSelectedOptionIndex(-1)
+      setShowPopover(false)
+    }
+
+    if(e.key === 'Escape' || e.key === 'Tab') {
       setShowPopover(false)
     }
   }
@@ -238,7 +244,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
         renderOption ? (
           renderOption(getOptionProps(option, index), index)
         ) : (
-          <Option {...getOptionProps(option, index)} />
+          <Option {...getOptionProps(option, index)}/>
         )
       )}
     </div>

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -126,7 +126,6 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
     customMessage,
   },
 }) => {
-
   const [term, setTerm] = useState(value || '')
   useEffect(
     function updateTermWhenInputValueChanges() {
@@ -140,9 +139,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
   const searching = term.length
   const showLastSearched =
     !searching && lastSearched.value && lastSearched.value.length > 0
-
   const getShowedOptions = (): AutocompleteOption[] => {
-    
     if (showLastSearched) {
       return lastSearched.value
     }
@@ -183,7 +180,6 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
       setSelectedOptionIndex(-1)
       setShowPopover(false)
     }
-
     if(e.key === 'Escape' || e.key === 'Tab') {
       setShowPopover(false)
     }
@@ -244,7 +240,7 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
         renderOption ? (
           renderOption(getOptionProps(option, index), index)
         ) : (
-          <Option {...getOptionProps(option, index)}/>
+          <Option {...getOptionProps(option, index)} />
         )
       )}
     </div>

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -139,7 +139,8 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
   const searching = term.length
   const showLastSearched =
     !searching && lastSearched.value && lastSearched.value.length > 0
-  const getShowedOptions = (): AutocompleteOption[] => {
+  
+    const getShowedOptions = (): AutocompleteOption[] => {
     if (showLastSearched) {
       return lastSearched.value
     }

--- a/react/components/AutocompleteInput/index.tsx
+++ b/react/components/AutocompleteInput/index.tsx
@@ -139,8 +139,8 @@ const AutocompleteInput: React.FunctionComponent<AutocompleteInputProps> = ({
   const searching = term.length
   const showLastSearched =
     !searching && lastSearched.value && lastSearched.value.length > 0
-  
-    const getShowedOptions = (): AutocompleteOption[] => {
+
+  const getShowedOptions = (): AutocompleteOption[] => {
     if (showLastSearched) {
       return lastSearched.value
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the double focus issue when navigating through the suggested options with `tab` and `arrowKeyDown`.  Also now it's possible to start over from the beginning of the suggested options when reaching the end of the list with `arrowKeyDown`

#### What problem is this solving?
When navigating through the suggested options with `tab` and the `arrowKeyDown`, two options would be marked out with grey as shown below:
![image](https://user-images.githubusercontent.com/12815827/95086883-610f1800-06f7-11eb-95c4-42c6049f333b.png)
 
![image](https://user-images.githubusercontent.com/12815827/95093705-712af580-06ff-11eb-9cd6-937563c0704c.png)

#### How should this be manually tested?

1. Go to [this workspace](https://tabnavigation--vtexhelp.myvtex.com/?__bindingAddress=vtexhelp.myvtex.com/)
2. Search for something (eg: Amazon)
3. If `tab` is pressed, the popover should be hidden
4. Arrow keys navigation should behave normally

![Untitled-1](https://user-images.githubusercontent.com/12815827/95095462-72f5b880-0701-11eb-894d-3fa1dca33a8d.gif)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
