### PR TITLE
Fix EXPERIMENTAL_Table emptyState type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **EXPERIMENTAL_Table** `emptyState` type definitions.
+
 ## [9.132.0] - 2020-10-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **AutocompleteInput** restart navigating from top when reaching the end of the suggested options with the down arrow key.
+
 ### Fixed
 
 - **AutocompleteInput** double focus issue when navigating through the suggested options with tab and arrow keys.
 - **EXPERIMENTAL_useCheckboxTree** root checkbox behavior when all children checkboxes are disabled.
-
-### Added
-
-- **AutocompleteInput** restart navigating from top when reaching the end of the suggested options with the down arrow key.
 
 ## [9.131.0] - 2020-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.132.1] - 2020-10-08
+
 ### Fixed
 
 - **EXPERIMENTAL_Table** `emptyState` type definitions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.132.0] - 2020-10-08
+
 ### Added
 
 - **AutocompleteInput** restart navigating from top when reaching the end of the suggested options with the down arrow key.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.132.0",
+  "version": "9.132.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.131.0",
+  "version": "9.132.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.132.0",
+  "version": "9.132.1",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.131.0",
+  "version": "9.132.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Table/context/loading.tsx
+++ b/react/components/EXPERIMENTAL_Table/context/loading.tsx
@@ -7,10 +7,9 @@ interface Loading {
     | {
         renderAs?: () => React.ReactNode
       }
-  emptyState?: {
+  emptyState?: PropsWithChildren<{
     label?: string
-    children?: Element
-  }
+  }>
 }
 
 const LoadingContext = createContext<Loading>(null)

--- a/react/components/EXPERIMENTAL_Table/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/index.tsx
@@ -1,4 +1,11 @@
-import React, { FC, Fragment, forwardRef, PropsWithChildren, Ref } from 'react'
+import React, {
+  FC,
+  Fragment,
+  forwardRef,
+  PropsWithChildren,
+  Ref,
+  ComponentProps,
+} from 'react'
 
 import Toolbar from './Toolbar/index'
 import Pagination, { PaginationProps } from './Pagination'
@@ -105,9 +112,7 @@ interface SpecificProps {
   /** Function that defines if a row is active or not */
   isRowActive?: (data: unknown) => boolean
   /** Table EmptyState component */
-  emptyState?: PropsWithChildren<{
-    label: string
-  }>
+  emptyState?: ComponentProps<typeof LoadingProvider>['emptyState']
   /** Sorting properties */
   sorting?: ReturnType<typeof useTableSort>
   /** Base testId */


### PR DESCRIPTION
### ℹ️  When approved, I'll release v9.132.1 in this same PR

#### What is the purpose of this pull request?

As the title says...

#### What problem is this solving?

Publishing Styleguide v9.132.0 on VTEX IO failed because of these types definitions.

![image](https://user-images.githubusercontent.com/15948386/95469858-78980c00-0956-11eb-91ad-acd4a804ab78.png)

#### How should this be manually tested?

Just try to `vtex link` this branch on any workspace

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/95470012-a8471400-0956-11eb-8895-9350fdd79857.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
