### PR TITLE
Add CSS handles to Input, Dropdown, and Textarea error messages and help texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
+
 - CSS handles to Input, Dropdown, and Textarea error messages and help texts.
 
 ## [9.132.1] - 2020-10-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CSS handles to Input, Dropdown, and Textarea error messages and help texts.
 
 ## [9.132.1] - 2020-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.133.0] - 2020-10-14
+
 ### Added
 
 - CSS handles to Input, Dropdown, and Textarea error messages and help texts.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.132.1",
+  "version": "9.133.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.132.1",
+  "version": "9.133.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -254,10 +254,14 @@ class Dropdown extends Component {
           </div>
         </label>
         {errorMessage && (
-          <div className="c-danger t-small mt3 lh-title">{errorMessage}</div>
+          <div className="vtex-dropdown__error c-danger t-small mt3 lh-title">
+            {errorMessage}
+          </div>
         )}
         {helpText && (
-          <div className="c-muted-1 t-small mt3 lh-title">{helpText}</div>
+          <div className="vtex-dropdown__help-text c-muted-1 t-small mt3 lh-title">
+            {helpText}
+          </div>
         )}
       </div>
     )

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -262,10 +262,14 @@ class Input extends Component {
           )}
         </div>
         {errorMessage && (
-          <div className="c-danger t-small mt3 lh-title">{errorMessage}</div>
+          <div className="vtex-input__error c-danger t-small mt3 lh-title">
+            {errorMessage}
+          </div>
         )}
         {helpText && (
-          <div className="c-muted-1 t-small mt3 lh-title">{helpText}</div>
+          <div className="vtex-input__help-text c-muted-1 t-small mt3 lh-title">
+            {helpText}
+          </div>
         )}
       </label>
     )

--- a/react/components/Textarea/index.js
+++ b/react/components/Textarea/index.js
@@ -135,12 +135,14 @@ class Textarea extends Component {
         <div className="flex justify-between">
           <div>
             {errorMessage && (
-              <div className="c-danger t-small mt2 lh-title">
+              <div className="vtex-textarea__error c-danger t-small mt2 lh-title">
                 {errorMessage}
               </div>
             )}
             {helpText && (
-              <div className="c-muted-1 t-small mt2 lh-title">{helpText}</div>
+              <div className="vtex-textarea__help-text c-muted-1 t-small mt2 lh-title">
+                {helpText}
+              </div>
             )}
           </div>
           {maxLength && (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixes https://github.com/vtex-apps/store-components/issues/871

#### What problem is this solving?

Make it possible to customize the error and help text elements in Store Framework.

https://highlight--storecomponents.myvtex.com/

#### How should this be manually tested?

1. Open the workspace
2. Go to the bottom of the page
3. Click on the Submit of the Newsletter
4. Check the error message element classes

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/95494442-4f867400-0974-11eb-87b9-2803c27b52f4.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
