### PR TITLE
fix slider race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Slider race condition.
+
 ## [9.133.0] - 2020-10-14
 
 ### Added

--- a/react/components/Slider/index.js
+++ b/react/components/Slider/index.js
@@ -238,16 +238,16 @@ export default class Slider extends Component {
     const translatePx = this.getTranslateValueForInputValue(value, position)
 
     requestAnimationFrame(() => {
-      this.setState({
+      this.setState(state => ({
         values: {
-          ...this.state.values,
+          ...state.values,
           [position]: value,
         },
         translate: {
-          ...this.state.translate,
+          ...state.translate,
           [position]: translatePx,
         },
-      })
+      }))
     })
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix a race condition in the Slider component

#### What problem is this solving?

When the Slider is rendered, the component will calculate left and right selector positions. This creates. a race condition, and sometimes, only one selector will have the correct position

To reproduce, go to this  [URL](https://storecomponents.myvtex.com/apparel---accessories/accessories/?fuzzy=auto&operator=or&priceRange=994%20TO%202200).

This URL has the query string `priceRange=994%20TO%202200)`, it means that the slider should render the range from 994 to 2200. Like this:

![Captura de Tela 2020-10-28 às 13 30 42](https://user-images.githubusercontent.com/40380674/97466727-2ed18e80-1922-11eb-8d45-3cc2c4750946.png)

But it is rendering this:

![image](https://user-images.githubusercontent.com/40380674/97466792-414bc800-1922-11eb-9a7d-4991cb1a955c.png)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[workspace with the fix](https://sliderracecondition--storecomponents.myvtex.com/apparel---accessories/accessories/?fuzzy=auto&operator=or&priceRange=994%20TO%202200)

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
