### PR TITLE
Added polyfill to fix NaN on stepper on IE11

### DIFF
--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -25,6 +25,10 @@ const validateValue = (value, min, max, defaultValue) => {
 }
 
 const formattedDisplayValue = (value, unitMultiplier, suffix) => {
+  if (Number.EPSILON === undefined) {
+    Number.EPSILON = Math.pow(2, -52)
+  }
+
   const parsedSuffix = suffix ? ` ${suffix}` : suffix
   return `${Math.round((value * unitMultiplier + Number.EPSILON) * 100) /
     100}${parsedSuffix}`


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR fixes the behavior of the stepper component on IE11. You can see the bug [here](https://storetheme.vtex.com) (remember to use IE11).

#### What problem is this solving?
When accessed via IE11, the stepper component previously showed `NaN` on the input field no matter which value was inserted.

This was happening because IE11 lacks support for `Number.EPSILON`. I've added a simple polyfill taken from [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/EPSILON) that fixes the problem.

#### How should this be manually tested?

You can go [here](https://icaro--storecomponents.myvtex.com) to see it working just fine (remember to use IE11).

#### Screenshots or example usage
Antes do fix: 
![image](https://user-images.githubusercontent.com/8127610/97628043-f8237300-1a0a-11eb-8684-1c1e7236a598.png)

Após o fix:
![image](https://user-images.githubusercontent.com/8127610/97628090-040f3500-1a0b-11eb-9965-8b7a60f14793.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
