### PR TITLE
Fix Table V2 empty state height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **EXPERIMENTAL_Modal** `ref` not properly passed to modal element.
+- **EXPERIMENTAL_Table** `emptyState` height
 
 ## [9.133.1] - 2020-10-29
 

--- a/react/components/EXPERIMENTAL_Table/Sections/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/index.tsx
@@ -28,7 +28,7 @@ function Sections(
 ) {
   const { emptyState, empty, loading } = useLoadingContext()
   const { testId } = useTestingContext()
-  const { tableHeight } = useMeasuresContext()
+  const { tableHeight, bodyHeight } = useMeasuresContext()
 
   return (
     <div
@@ -54,7 +54,10 @@ function Sections(
         </Loading>
       )}
       {empty && emptyState && (
-        <EmptyState testId={`${testId}__empty-state`} title={emptyState.label}>
+        <EmptyState
+          height={bodyHeight}
+          testId={`${testId}__empty-state`}
+          title={emptyState.label}>
           {emptyState.children}
         </EmptyState>
       )}

--- a/react/components/EmptyState/index.js
+++ b/react/components/EmptyState/index.js
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types'
 
 class EmptyState extends PureComponent {
   render() {
-    const { title, children, testId } = this.props
+    const { children, height, testId, title } = this.props
 
     return (
-      <div className="flex items-center h-100 c-muted-2" data-testid={testId}>
+      <div
+        className="flex items-center h-100 c-muted-2"
+        data-testid={testId}
+        style={{ height }}>
         <div className="w-80 w-60-l center tc">
           {title && <span className="t-heading-4 mt0">{title}</span>}
           {children && <div className="t-body lh-copy">{children}</div>}
@@ -35,6 +38,8 @@ EmptyState.propTypes = {
   },
   /** Data attribute */
   testId: PropTypes.string,
+  /** Component's height */
+  height: PropTypes.number,
 }
 
 export default EmptyState


### PR DESCRIPTION
#### What is the purpose of this pull request?
As title says.

#### What problem is this solving?
Empty state on TableV2 was not taking into account header's height, although Loading state was.
This change does the same as done on the Loading one.

#### How should this be manually tested?
https://styleguide-git-fix-empty-state-height.styleguide-core.vercel.app/#/Components/%F0%9F%91%BB%20Experimental/Table%20V2

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/5256673/98754023-805b2e00-23a4-11eb-8418-4a5be1da4218.png)

After:
![image](https://user-images.githubusercontent.com/5256673/98754290-1a22db00-23a5-11eb-987a-78c1a3a440be.png)

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
