### PR TITLE
Release v9.133.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.133.2] - 2020-11-12
+
 ### Fixed
 
 - **EXPERIMENTAL_Modal** `ref` not properly passed to modal element.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.133.1",
+  "version": "9.133.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.133.1",
+  "version": "9.133.2",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",


### PR DESCRIPTION
## [9.133.2] - 2020-11-12

### Fixed

- **EXPERIMENTAL_Modal** `ref` not properly passed to modal element.
- **EXPERIMENTAL_Table** `emptyState` height
