### PR TITLE
Fix Modal v2 height on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **EXPERIMENTAL_Modal** height on small screens.
+
 ## [9.133.2] - 2020-11-12
 
 ### Fixed

--- a/react/components/EXPERIMENTAL_Modal/FocusTrap.tsx
+++ b/react/components/EXPERIMENTAL_Modal/FocusTrap.tsx
@@ -92,6 +92,7 @@ const FocusTrap: FC<Props> = ({ children }) => {
       ? // The ref property doesn't exist on ReactElement types, but
         // it exist in practice and is the only way to get the child
         // element's ref
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ((child as any).ref as React.Ref<HTMLElement>)
       : () => {},
     focusContainer

--- a/react/components/EXPERIMENTAL_Modal/index.tsx
+++ b/react/components/EXPERIMENTAL_Modal/index.tsx
@@ -158,6 +158,7 @@ const ModalContent = forwardRef<HTMLDivElement, ContentProps>(
       <div
         className={classNames(
           'vtex-modal__modal flex flex-column relative bg-white shadow-5 center mv9 br2',
+          styles.maxHeight100,
           `${size === 'small' ? styles.smallContent : ''}`,
           `${size === 'medium' ? styles.mediumContent : ''}`,
           `${size === 'large' ? styles.largeContent : ''}`,

--- a/react/components/EXPERIMENTAL_Modal/modal.css
+++ b/react/components/EXPERIMENTAL_Modal/modal.css
@@ -28,6 +28,10 @@
   padding-right: 15px;
 }
 
+.maxHeight100 {
+  max-height: 100%;
+}
+
 @media screen and (min-width: 40em) {
   .maxHeight80Desktop {
     max-height: 80vh;

--- a/react/utilities/useMergeRefs/index.ts
+++ b/react/utilities/useMergeRefs/index.ts
@@ -16,6 +16,7 @@ const mergeRefs = <T>(...refs: Ref<T>[]) => {
       // object types the `current` property
       // as read-only, but we can safely write
       // to it.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ;(ref as any).current = node
     })
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
In small screens the modal was exceeding the screen height. 

#### How should this be manually tested?
1. Access Modal v2 on docs
2. Decrease screen height and check if the modal exceeds the screen

#### Screenshots or example usage
**Before**
![Screenshot from 2020-11-16 11-51-01](https://user-images.githubusercontent.com/6867958/99266936-18707180-2802-11eb-88c4-2bce5d812453.png)

**After**
![Screenshot from 2020-11-16 11-51-20](https://user-images.githubusercontent.com/6867958/99266949-1b6b6200-2802-11eb-88e6-ed6309ab9b35.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
