### PR TITLE
Fix utilities not being included in the package entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `utilities` folder not being included in the package entrypoint.
+
 ## [9.133.2] - 2020-11-12
 
 ### Fixed

--- a/scripts/entrypoints.js
+++ b/scripts/entrypoints.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 
 const componentsFolder = path.join(__dirname, '../react/components')
 const iconsFolder = path.join(__dirname, '../react/components/icon')
+const utilitiesFolder = path.join(__dirname, '../react/utilities')
 const entrypointsFolder = path.join(__dirname, '../react')
 
 const isComponentFolder = s =>
@@ -34,6 +35,18 @@ fs.readdir(iconsFolder, (err, files) => {
 
   files.filter(isComponentFolder).forEach(file => {
     const entrypointPath = path.join(entrypointsFolder, `Icon${file}.js`)
+    console.log(`Writing ${entrypointPath}`)
+    fs.writeFileSync(entrypointPath, entrypointTemplate(file, true))
+  })
+})
+
+fs.readdir(utilitiesFolder, (err, files) => {
+  if (err) {
+    throw err
+  }
+
+  files.forEach(file => {
+    const entrypointPath = path.join(entrypointsFolder, `utilities/${file}.js`)
     console.log(`Writing ${entrypointPath}`)
     fs.writeFileSync(entrypointPath, entrypointTemplate(file, true))
   })


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

[Running workspace](http://link)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

<!-- Add the code that is necessary to test your change in the Playground-->
<details>
<summary>Add this code in <code>react/playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react'
import PageHeader from '../PageHeader'
import Layout from '../Layout'
const Playground = () => (
  <Layout fullWidth pageHeader={<PageHeader title="Playground" />}>
    {/* Add your code here, don't forget to delete after */}
  </Layout>
)
export default Playground
```

</details>

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
