### PR TITLE
Fix overflown modal content overlapping on mobile Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **EXPERIMENTAL_Modal** height on small screens.
+- **EXPERIMENTAL_Modal** overflown content overlapping on iOS Safari.
 
 ## [9.133.2] - 2020-11-12
 

--- a/react/components/EXPERIMENTAL_Modal/__snapshots__/index.test.tsx.snap
+++ b/react/components/EXPERIMENTAL_Modal/__snapshots__/index.test.tsx.snap
@@ -50,9 +50,13 @@ exports[`Modal CSS API centered 1`] = `
         </div>
       </div>
       <div
-        class="ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined undefined pb7-ns mb5"
+        class="t-body flex flex-column flex-shrink-1 flex-grow-1 undefined"
       >
-        Foo
+        <div
+          class="ph7 ph8-ns flex-auto overflow-auto pb7-ns mb5"
+        >
+          Foo
+        </div>
       </div>
     </div>
   </div>
@@ -109,9 +113,13 @@ exports[`Modal CSS API default 1`] = `
         </div>
       </div>
       <div
-        class="ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined undefined pb7-ns mb5"
+        class="t-body flex flex-column flex-shrink-1 flex-grow-1 undefined"
       >
-        Foo
+        <div
+          class="ph7 ph8-ns flex-auto overflow-auto pb7-ns mb5"
+        >
+          Foo
+        </div>
       </div>
     </div>
   </div>
@@ -168,9 +176,13 @@ exports[`Modal CSS API responsiveFullScreen true 1`] = `
         </div>
       </div>
       <div
-        class="ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined  pb7-ns mb5"
+        class="t-body flex flex-column flex-shrink-1 flex-grow-1"
       >
-        Foo
+        <div
+          class="ph7 ph8-ns flex-auto overflow-auto pb7-ns mb5"
+        >
+          Foo
+        </div>
       </div>
     </div>
   </div>
@@ -227,9 +239,13 @@ exports[`Modal CSS API showBottomBarBorder false 1`] = `
         </div>
       </div>
       <div
-        class="ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined undefined pb7-ns mb5"
+        class="t-body flex flex-column flex-shrink-1 flex-grow-1 undefined"
       >
-        Foo
+        <div
+          class="ph7 ph8-ns flex-auto overflow-auto pb7-ns mb5"
+        >
+          Foo
+        </div>
       </div>
     </div>
   </div>
@@ -286,9 +302,13 @@ exports[`Modal CSS API showTopBar false 1`] = `
         </div>
       </div>
       <div
-        class="ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined undefined pb7-ns mb5"
+        class="t-body flex flex-column flex-shrink-1 flex-grow-1 undefined"
       >
-        Foo
+        <div
+          class="ph7 ph8-ns flex-auto overflow-auto pb7-ns mb5"
+        >
+          Foo
+        </div>
       </div>
     </div>
   </div>
@@ -345,9 +365,13 @@ exports[`Modal bottomBar should render bottomBar 1`] = `
         </div>
       </div>
       <div
-        class="ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined undefined mb3"
+        class="t-body flex flex-column flex-shrink-1 flex-grow-1 undefined"
       >
-        Foo
+        <div
+          class="ph7 ph8-ns flex-auto overflow-auto mb3"
+        >
+          Foo
+        </div>
       </div>
       <div
         class="flex justify-content flex-row-reverse min-h-regular-ns min-h-small pv6-ns ph8-ns pv7 ph7 mt3 bt b--muted-4"
@@ -413,9 +437,13 @@ exports[`Modal container should render modal inside it 1`] = `
         </div>
       </div>
       <div
-        class="ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined undefined pb7-ns mb5"
+        class="t-body flex flex-column flex-shrink-1 flex-grow-1 undefined"
       >
-        Foo
+        <div
+          class="ph7 ph8-ns flex-auto overflow-auto pb7-ns mb5"
+        >
+          Foo
+        </div>
       </div>
     </div>
   </div>
@@ -472,9 +500,13 @@ exports[`Modal isOpen Should show modal when isOpen is true and hide when is fal
         </div>
       </div>
       <div
-        class="ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined undefined pb7-ns mb5"
+        class="t-body flex flex-column flex-shrink-1 flex-grow-1 undefined"
       >
-        Foo
+        <div
+          class="ph7 ph8-ns flex-auto overflow-auto pb7-ns mb5"
+        >
+          Foo
+        </div>
       </div>
     </div>
   </div>
@@ -531,9 +563,13 @@ exports[`Modal isOpen Should show modal when isOpen is true and hide when is fal
         </div>
       </div>
       <div
-        class="ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined undefined pb7-ns mb5"
+        class="t-body flex flex-column flex-shrink-1 flex-grow-1 undefined"
       >
-        Foo
+        <div
+          class="ph7 ph8-ns flex-auto overflow-auto pb7-ns mb5"
+        >
+          Foo
+        </div>
       </div>
     </div>
   </div>
@@ -600,9 +636,13 @@ exports[`Modal title should render title prop 1`] = `
         </div>
       </div>
       <div
-        class="ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 undefined undefined undefined pb7-ns mb5"
+        class="t-body flex flex-column flex-shrink-1 flex-grow-1 undefined"
       >
-        Foo
+        <div
+          class="ph7 ph8-ns flex-auto overflow-auto pb7-ns mb5"
+        >
+          Foo
+        </div>
       </div>
     </div>
   </div>

--- a/react/components/EXPERIMENTAL_Modal/index.tsx
+++ b/react/components/EXPERIMENTAL_Modal/index.tsx
@@ -188,14 +188,18 @@ const ModalContent = forwardRef<HTMLDivElement, ContentProps>(
         </TopBar>
         <div
           className={classNames(
-            `ph7 ph8-ns t-body overflow-auto flex flex-column flex-shrink-1 flex-grow-1 ${
-              styles.maxHeight80Desktop
-            } ${styles.scrollBar} ${
-              !responsiveFullScreen ? styles.maxHeight80 : ''
-            }`,
-            { 'pb7-ns mb5': !bottomBar, mb3: bottomBar }
+            styles.maxHeight80Desktop,
+            't-body flex flex-column flex-shrink-1 flex-grow-1',
+            { [styles.maxHeight80]: !responsiveFullScreen }
           )}>
-          {children}
+          <div
+            className={classNames(
+              'ph7 ph8-ns flex-auto overflow-auto',
+              styles.scrollBar,
+              { 'pb7-ns mb5': !bottomBar, mb3: bottomBar }
+            )}>
+            {children}
+          </div>
         </div>
         <BottomBar
           showBorder={showBottomBarBorder}


### PR DESCRIPTION
#### What is the purpose of this pull request?

For some reason, if you have content inside the `EXPERIMENTAL_Modal` that exceed the max height (which is supposed to be fine because we have an `overflow-auto` class), on mobile Safari that content is not properly laid out and it can overlap with each other (see the screenshot below). I've found [this StackOverflow](https://stackoverflow.com/questions/42292912/flexbox-max-height-in-ie-and-safari) question that describes this exact same problem, and the only answer posted resolved this issue.

#### What problem is this solving?

[Running workspace](https://billing--checkoutio.myvtex.com/cart/add?sku=289).

You can see the modal in the payment step of the Checkout, if you select a credit card and click the "ver opções de parcelamento" button, the modal should appear.

But you must test this using either an iPhone, or using the macOS Simulator.

#### How should this be manually tested?

No manual tests, I'm afraid.

#### Screenshots or example usage

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img width="598" alt="image" src="https://user-images.githubusercontent.com/10223856/99307735-b2054680-2835-11eb-8c2f-22a969d6beb8.png"></td>
<td><img width="598" alt="image" src="https://user-images.githubusercontent.com/10223856/99307955-fabcff80-2835-11eb-8a04-5603456db3d0.png"></td>
</tr>
</tbody>
</table>

<img height="500" alt="gif" src="https://user-images.githubusercontent.com/10223856/99432749-585f5380-28eb-11eb-96e5-879d0735d5cb.gif">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
