### PR TITLE
Fixed utilities not being compiled on package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ styleguide-visual/*.diff.png
 /lib
 /modules
 /styleguide
+/utilities
 
 # misc
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **EXPERIMENTAL_Modal** height on small screens.
 - **EXPERIMENTAL_Modal** overflown content overlapping on iOS Safari.
+- `utilities` folder not being compiled on the package build.
 
 ## [9.133.2] - 2020-11-12
 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "babel:lib": "NODE_ENV=production babel ./react/components --out-dir ./lib --extensions \".js,.jsx,.ts,.tsx\" --ignore '__tests__,*.spec.js' --ignore '*.md' --copy-files",
     "build:types": "tsc --emitDeclarationOnly",
     "babel:modules": "NODE_ENV=production babel ./react/modules --out-dir ./modules --ignore '__tests__,*.spec.js' --ignore '*.md' --copy-files",
+    "babel:utilities": "NODE_ENV=production babel ./react/utilities --out-dir ./utilities --extensions \".js,.jsx,.ts,.tsx\" --ignore '__tests__,*.spec.js' --ignore '*.md' --copy-files",
     "clean:lib": "rm -rf lib",
     "clean:modules": "rm -rf modules",
-    "compile": "run-s clean:lib clean:modules build:types babel:lib babel:modules",
+    "compile": "run-s clean:lib clean:modules build:types babel:lib babel:modules babel:utilities",
     "prepublishOnly": "run-s compile deploy",
     "prepare": "yarn --cwd react --ignore-scripts",
     "postreleasy": "vtex publish --public --verbose",
@@ -30,7 +31,8 @@
   "files": [
     "lib/",
     "modules/",
-    "codemod/"
+    "codemod/",
+    "utilities/"
   ],
   "keywords": [
     "vtex",


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
The npm package is giving error when using the utilities `useMergeRefs` and `useDisclousure` because they are not included in the compiled package.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
1. `yarn build`
2. `yarn link`
3. Run `yarn link "@vtex/styleguide" ` in a project which uses styleguide through `npm`


#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
