### PR TITLE
added new css handle for tag component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Class `vtex-tag` on `Tag` component.
+
 ## [9.133.3] - 2020-11-19
 
 ### Fixed

--- a/react/components/Tag/index.js
+++ b/react/components/Tag/index.js
@@ -49,7 +49,7 @@ class Tag extends PureComponent {
         break
     }
 
-    const baseClasses = `br-pill dib fw5 ${sizeClasses}`
+    const baseClasses = `vtex-tag br-pill dib fw5 ${sizeClasses}`
 
     let theme = ''
     const variationIsLow = variation === 'low'


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a css handle on `Tag` component to be able styling from store-theme.

#### What problem is this solving?

Adding this class we will be able to style Tag component through VTEX store-theme using css selectors.

[Running workspace](https://minicartcoupon--outletespacohering.myvtex.com/)

#### How should this be manually tested?

Add a product your cart, open minicart and add a coupon. After that you will see a Tag component used by [Coupon](https://github.com/vtex-apps/checkout-coupon) styled.

#### Screenshots or example usage

Example: https://prnt.sc/vm5ipo

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
