### PR TITLE
Fixing font size on small sized dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Small sized dropdowns now have appropriate font size (`t-small`). 
 
 ## [9.134.0] - 2020-12-04
 

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -138,6 +138,7 @@ class Dropdown extends Component {
         'c-muted-2': !disabled && valueLabel && isPlaceholder,
         ph2: isInline && size !== 'x-large',
         'pl5 pr3': !isInline && size !== 'x-large',
+        't-small': size === 'small',
         't-body pv5 ph5': size === 'x-large',
       }
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR fixes a minor inconsistency between the input and dropdown components.  Thanks to @davicosta99 for noticing this one.

#### What problem is this solving?
The selected dropdown option should have 14px when its size is set to small, as do the input field. It was especially noticeable on the product-quantity app.

#### How should this be manually tested?
[Workspace](https://icaroquantity--storecomponents.myvtex.com/fashion-eyeglasses/p)

#### Screenshots or example usage

Before the fix:
![Screen Recording 2020-12-18 at 3 23 14 PM](https://user-images.githubusercontent.com/8127610/102647810-29840980-4145-11eb-9481-68fc9190a895.gif)

After the fix:
![Screen Recording 2020-12-18 at 3 17 25 PM](https://user-images.githubusercontent.com/8127610/102647775-1c671a80-4145-11eb-8f0a-a1df9c6d6d70.gif)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
