### PR TITLE
Fixing font size of Input and Dropdown with small size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.134.1] - 2020-12-22
+
 ### Fixed
 
 - Input and dropdown now have font-size of 16px no matter their sizes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Fixed
+
 - Input and dropdown now have font-size of 16px no matter their sizes
 
 ## [9.134.0] - 2020-12-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Input and dropdown now have font-size of 16px no matter their sizes
 
 ## [9.134.0] - 2020-12-04
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.134.0",
+  "version": "9.134.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.134.0",
+  "version": "9.134.1",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -173,11 +173,9 @@ class Dropdown extends Component {
     )
 
     const selectClasses = classNames(
-      'o-0 absolute top-0 left-0 h-100 w-100 bottom-0',
+      'o-0 absolute top-0 left-0 h-100 w-100 bottom-0 t-body',
       {
         pointer: !disabled,
-        't-body': size !== 'small',
-        't-small': size === 'small',
       }
     )
 

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -154,7 +154,6 @@ class Input extends Component {
     switch (size) {
       case 'small':
         prefixSuffixGroupClasses += 'h-small '
-        classes += `${!token ? 't-small' : ''} `
         classes += `${
           prefix && suffix ? '' : prefix ? 'pr5 ' : suffix ? 'pl5 ' : 'ph5 '
         }`

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -154,6 +154,7 @@ class Input extends Component {
     switch (size) {
       case 'small':
         prefixSuffixGroupClasses += 'h-small '
+        classes += `${!token ? 't-body' : ''} `
         classes += `${
           prefix && suffix ? '' : prefix ? 'pr5 ' : suffix ? 'pl5 ' : 'ph5 '
         }`


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR fixes a minor inconsistency between the Input and Dropdown components.  Thanks to @davicosta99 for noticing this one.

#### What problem is this solving?
The Input and Dropdown components both had 14px font-size when their size was set to small. This caused the mobile safari app to zoom in when interacting with them. This PR sets the font-size of these components to 16px no matter their size, fixing the unwanted behavior described previously.

#### How should this be manually tested?
Open this workspace using the mobile safari app and click on the dropdown/input. It shouldn't zoom in.
[Workspace](https://icaroquantity--storecomponents.myvtex.com/fashion-eyeglasses/p)

#### Screenshots or example usage

Before and after the fix:

<img src="https://user-images.githubusercontent.com/8127610/102663108-ecc50c00-415e-11eb-955b-49b3c6772fb5.gif" width="250" /> 
<img src="https://user-images.githubusercontent.com/8127610/102663148-01090900-415f-11eb-9b2b-aac8c41951df.gif" width="250" />

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
