### PR TITLE
Fix loading button not passing disabled to the button element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.135.1] - 2021-01-28
+
 ### Fixed
 
 - Button not being disabled if it is loading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Button not being disabled if it is loading.
+
 ## [9.135.0] - 2021-01-20
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.135.0",
+  "version": "9.135.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.135.0",
+  "version": "9.135.1",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -218,7 +218,7 @@ class Button extends Component {
         id={this.props.id}
         data-testid={this.props.testId}
         autoFocus={iconOnly ? undefined : this.props.autoFocus}
-        disabled={iconOnly ? undefined : this.props.disabled}
+        disabled={iconOnly ? undefined : disabled}
         name={iconOnly ? undefined : this.props.name}
         value={iconOnly ? undefined : this.props.value}
         tabIndex={tabIndex}

--- a/react/components/Button/index.test.tsx
+++ b/react/components/Button/index.test.tsx
@@ -4,6 +4,13 @@ import { render } from '@testing-library/react'
 import Button from './index'
 
 describe('Button', () => {
+  it('should disable the button if the button is loading', () => {
+    const { container } = render(<Button isLoading />)
+    const buttonEl = container.querySelector('button')
+
+    expect(buttonEl.disabled).toBe(true)
+  })
+
   describe('CSS API', () => {
     it('primary', () => {
       const { asFragment } = render(<Button variation="primary">Hello</Button>)


### PR DESCRIPTION
#### What is the purpose of this pull request?

When you pass `isLoading` to the button it disables the button visually but doesn't pass the disabled to the element

#### What problem is this solving?

[Running workspace](https://styleguidebutton--storecomponents.myvtex.com/admin/app/new-cms/store/notFound/edit/661814e5-42d9-412c-ae54-e5b979b128cb)

1. The button in the right top corner should be loading and the element should have a `disabled` property defined

#### How should this be manually tested?

<!-- Add the code that is necessary to test your change in the Playground-->
<details>
<summary>Add this code in <code>react/playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react'
import Button from '../Button'

const Playground = () => (
  <Button isLoading>
      A loading disabled button
  </Button>
)
export default Playground
```

</details>

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8517023/106052780-c59c1b80-60c8-11eb-82ee-7547737ef413.png)
![image](https://user-images.githubusercontent.com/8517023/106052814-cfbe1a00-60c8-11eb-9e03-b5ea5a978323.png)


#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
