### PR TITLE
Render the complete table when scrolling is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - **PageBlock** responsiveness issue on aside variation.
-- **EXPERIMENTAL_TableV2** rows' height when using `disableScroll`.
+- **EXPERIMENTAL_TableV2** rows height when using `disableScroll`.
 
 ## [9.135.1] - 2021-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - PageBlock responsiveness issue on aside variation.
+- Render the complete table when scrolling is disabled
 
 ## [9.135.1] - 2021-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- PageBlock responsiveness issue on aside variation.
-- Render the complete table when scrolling is disabled
+- **PageBlock** responsiveness issue on aside variation.
+- **EXPERIMENTAL_TableV2** rows' height when using `disableScroll`.
 
 ## [9.135.1] - 2021-01-28
 

--- a/react/components/EXPERIMENTAL_Table/Sections/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/index.tsx
@@ -33,9 +33,8 @@ function Sections(
   return (
     <div
       style={{ height: disableScroll ? 'auto' : tableHeight, ...motion }}
-      className={classNames('mw-100', ORDER_CLASSNAMES.TABLE, {
-        'overflow-x-auto overflow-y-auto': !disableScroll,
-        'overflow-x-auto': disableScroll,
+      className={classNames('mw-100 overflow-x-auto', ORDER_CLASSNAMES.TABLE, {
+        'overflow-y-auto': !disableScroll,
       })}>
       <table
         ref={ref}

--- a/react/components/EXPERIMENTAL_Table/Sections/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/index.tsx
@@ -32,7 +32,7 @@ function Sections(
 
   return (
     <div
-      style={{ height: tableHeight, ...motion }}
+      style={{ height: disableScroll ? 'auto' : tableHeight, ...motion }}
       className={classNames('mw-100', ORDER_CLASSNAMES.TABLE, {
         'overflow-x-auto overflow-y-auto overflow-hidden': !disableScroll,
       })}>

--- a/react/components/EXPERIMENTAL_Table/Sections/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/index.tsx
@@ -34,7 +34,8 @@ function Sections(
     <div
       style={{ height: disableScroll ? 'auto' : tableHeight, ...motion }}
       className={classNames('mw-100', ORDER_CLASSNAMES.TABLE, {
-        'overflow-x-auto overflow-y-auto overflow-hidden': !disableScroll,
+        'overflow-x-auto overflow-y-auto': !disableScroll,
+        'overflow-x-auto': disableScroll,
       })}>
       <table
         ref={ref}


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

(Resolves #1361)

With custom sections, it is possible to build lines with *dynamic height* . So, setting the table height without scrolling can hide the rendering of some items.

#### What problem is this solving?

[Running workspace](https://mateusv2--sandboxintegracao.myvtex.com/admin/inventory/)

#### Screenshots or example usage
[![Inventory](https://i.gyazo.com/4aa658bbbb05ec79419c84fb2c54e66b.png)](https://gyazo.com/4aa658bbbb05ec79419c84fb2c54e66b)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
