### PR TITLE
Fix/stepper unit multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # Fixed
 
-- Typing on NumericStepper now works properly with `unitMultiplier` different than 1
+- **NumericStepper** `unitMultiplier` behavior when different from 1.
 
 ## [9.135.3] - 2021-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+# Fixed
+
+- Typing on NumericStepper now works properly with `unitMultiplier` different than 1
+
 ## [9.135.3] - 2021-02-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.135.4] - 2021-02-26
+
 # Fixed
 
 - **NumericStepper** `unitMultiplier` behavior when different from 1.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.135.3",
+  "version": "9.135.4",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.135.3",
+  "version": "9.135.4",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 
 import styles from '../Input/Input.css'
 
-const normalizeMin = (min) => (min == null ? -Infinity : min)
-const normalizeMax = (max) => (max == null ? Infinity : max)
+const normalizeMin = min => (min == null ? -Infinity : min)
+const normalizeMax = max => (max == null ? Infinity : max)
 
 const validateValue = (
   value,
@@ -26,7 +26,9 @@ const validateValue = (
   }
 
   const parsedValue = parseFloat(value, 10)
-  const normalizedValue = isTyping ? Math.round(parsedValue / unitMultiplier) : parsedValue
+  const normalizedValue = isTyping
+    ? Math.round(parsedValue / unitMultiplier)
+    : parsedValue
 
   return Math.max(min, Math.min(max, normalizedValue))
 }
@@ -177,19 +179,19 @@ class NumericStepper extends Component {
     }
   }
 
-  handleTypeQuantity = (event) => {
+  handleTypeQuantity = event => {
     this.changeValue(event.target.value, event, true)
   }
 
-  handleIncreaseValue = (event) => {
+  handleIncreaseValue = event => {
     this.changeValue(this.state.value + 1, event, false)
   }
 
-  handleDecreaseValue = (event) => {
+  handleDecreaseValue = event => {
     this.changeValue(this.state.value - 1, event, false)
   }
 
-  handleFocusInput = (e) => {
+  handleFocusInput = e => {
     e.target.select()
     this.setState({ inputFocused: true })
   }

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -26,14 +26,7 @@ const validateValue = (
   }
 
   const parsedValue = parseFloat(value, 10)
-
-  let normalizedValue
-
-  if (isTyping) {
-    normalizedValue = Math.round(parsedValue / unitMultiplier)
-  } else {
-    normalizedValue = parsedValue
-  }
+  const normalizedValue = isTyping ? Math.round(parsedValue / unitMultiplier) : parsedValue
 
   if (normalizedValue < min) {
     return min

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -3,10 +3,17 @@ import PropTypes from 'prop-types'
 
 import styles from '../Input/Input.css'
 
-const normalizeMin = min => (min == null ? -Infinity : min)
-const normalizeMax = max => (max == null ? Infinity : max)
+const normalizeMin = (min) => (min == null ? -Infinity : min)
+const normalizeMax = (max) => (max == null ? Infinity : max)
 
-const validateValue = (value, min, max, defaultValue) => {
+const validateValue = (
+  value,
+  min,
+  max,
+  defaultValue,
+  unitMultiplier,
+  isTyping
+) => {
   // This function always return a valid numeric value from the current input.
   // Compare with the function validateDisplayValue
   min = normalizeMin(min)
@@ -16,36 +23,61 @@ const validateValue = (value, min, max, defaultValue) => {
     if (defaultValue < min) return min
     if (defaultValue > max) return max
     return defaultValue
-  } else if (value < min) {
+  }
+
+  const parsedValue = parseFloat(value, 10)
+
+  let normalizedValue
+
+  if (isTyping) {
+    normalizedValue = Math.round(parsedValue / unitMultiplier)
+  } else {
+    normalizedValue = parsedValue
+  }
+
+  if (normalizedValue < min) {
     return min
-  } else if (value > max) {
+  } else if (normalizedValue > max) {
     return max
   }
-  return parseInt(value, 10)
+
+  return normalizedValue
 }
 
-const formattedDisplayValue = (value, unitMultiplier, suffix) => {
+const formattedDisplayValue = (value, unitMultiplier, suffix, isTyping) => {
   const parsedSuffix = suffix ? ` ${suffix}` : suffix
-  return `${Math.round((value * unitMultiplier + Number.EPSILON) * 100) /
-    100}${parsedSuffix}`
+
+  if (!isTyping) {
+    const multipliedValue = Math.round(value * unitMultiplier * 100) / 100
+    return `${multipliedValue}${parsedSuffix}`
+  }
+
+  return `${value}${parsedSuffix}`
 }
 
-const validateDisplayValue = (value, min, max, suffix, unitMultiplier) => {
+const validateDisplayValue = (
+  value,
+  min,
+  max,
+  suffix,
+  unitMultiplier,
+  isTyping
+) => {
   // This function validates the input as the user types
   // It allows for temporarily invalid values (namely, empty string and minus sign without a number following it)
   // However, it prevents values out of boundaries, and invalid characters, e.g. letters
 
-  min = normalizeMin(min)
-  max = normalizeMax(max)
+  min = normalizeMin(min) * unitMultiplier
+  max = normalizeMax(max) * unitMultiplier
 
   const parsedValue = parseFloat(value)
 
   if (value === '') {
-    return formattedDisplayValue(value, unitMultiplier, suffix)
+    return formattedDisplayValue(value, unitMultiplier, suffix, isTyping)
   }
   // Only allows typing the negative sign if negative values are allowed
-  if (value === '-' && min < 0) {
-    return formattedDisplayValue(value, unitMultiplier, suffix)
+  if (typeof value === 'string' && value.startsWith('-') && min < 0) {
+    return formattedDisplayValue(value, unitMultiplier, suffix, isTyping)
   }
   if (isNaN(parsedValue)) {
     return ''
@@ -53,12 +85,12 @@ const validateDisplayValue = (value, min, max, suffix, unitMultiplier) => {
   // Only limit by lower bounds if the min value is 1
   // Otherwise, it could prevent typing, for example, 10 if the min value is 2
   if (parsedValue < min && min === 1) {
-    return formattedDisplayValue(min, unitMultiplier, suffix)
+    return formattedDisplayValue(min, unitMultiplier, suffix, isTyping)
   }
   if (parsedValue > max) {
-    return formattedDisplayValue(max, unitMultiplier, suffix)
+    return formattedDisplayValue(max, unitMultiplier, suffix, isTyping)
   }
-  return formattedDisplayValue(parsedValue, unitMultiplier, suffix)
+  return formattedDisplayValue(parsedValue, unitMultiplier, suffix, isTyping)
 }
 
 class NumericStepper extends Component {
@@ -92,25 +124,28 @@ class NumericStepper extends Component {
       value,
       minValue,
       maxValue,
-      defaultValue
+      defaultValue,
+      unitMultiplier,
+      false
     )
 
     return {
       value: validatedValue,
       ...(!state.inputFocused && {
         displayValue: validateDisplayValue(
-          value,
+          validatedValue,
           minValue,
           maxValue,
           suffix,
-          unitMultiplier
+          unitMultiplier,
+          false
         ),
       }),
     }
   }
 
-  changeValue = (value, event) => {
-    const parsedValue = parseInt(value, 10)
+  changeValue = (value, event, isTyping) => {
+    const parsedValue = parseFloat(value, 10)
 
     const {
       minValue,
@@ -125,15 +160,18 @@ class NumericStepper extends Component {
       parsedValue,
       minValue,
       maxValue,
-      defaultValue
+      defaultValue,
+      unitMultiplier,
+      isTyping
     )
 
     const displayValue = validateDisplayValue(
-      value,
+      isTyping ? value : validatedValue,
       minValue,
       maxValue,
       suffix,
-      unitMultiplier
+      unitMultiplier,
+      isTyping
     )
 
     this.setState({
@@ -152,26 +190,37 @@ class NumericStepper extends Component {
     }
   }
 
-  handleTypeQuantity = event => {
-    this.changeValue(event.target.value, event)
+  handleTypeQuantity = (event) => {
+    this.changeValue(event.target.value, event, true)
   }
 
-  handleIncreaseValue = event => {
-    this.changeValue(this.state.value + 1, event)
+  handleIncreaseValue = (event) => {
+    this.changeValue(this.state.value + 1, event, false)
   }
 
-  handleDecreaseValue = event => {
-    this.changeValue(this.state.value - 1, event)
+  handleDecreaseValue = (event) => {
+    this.changeValue(this.state.value - 1, event, false)
   }
 
-  handleFocusInput = e => {
+  handleFocusInput = (e) => {
     e.target.select()
     this.setState({ inputFocused: true })
   }
 
   handleBlurInput = () => {
+    const { minValue, maxValue, unitMultiplier, suffix } = this.props
+
+    const displayValue = validateDisplayValue(
+      this.state.value,
+      minValue,
+      maxValue,
+      suffix,
+      unitMultiplier,
+      false
+    )
+
     this.setState({
-      displayValue: this.state.value,
+      displayValue,
       inputFocused: false,
     })
   }

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -28,13 +28,7 @@ const validateValue = (
   const parsedValue = parseFloat(value, 10)
   const normalizedValue = isTyping ? Math.round(parsedValue / unitMultiplier) : parsedValue
 
-  if (normalizedValue < min) {
-    return min
-  } else if (normalizedValue > max) {
-    return max
-  }
-
-  return normalizedValue
+  return Math.max(min, Math.min(max, normalizedValue))
 }
 
 const formattedDisplayValue = (value, unitMultiplier, suffix, isTyping) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR fixes the behavior when typing on a NumericStepper with a `unitMultiplier` different than one. Thanks @iago1501 ❤️ for helping me with this.

#### What problem is this solving?
Before it, users had their value multiplied as they were typing, which caused a bad and confusing experience.

[Before the fix](https://biscoind.myvtex.com/alphawire-5857-bk005/p)
[After the fix](https://iespinoza--biscoind.myvtex.com/alphawire-5857-bk005/p)

[Ensuring it's backwards compatible](https://icarovtex--storecomponents.myvtex.com/working-shirt/p)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Use the product quantity stepper present on the page of the links above.

#### Screenshots or example usage

https://user-images.githubusercontent.com/8127610/108276224-3b3e5900-7156-11eb-8120-35956cc4aca0.mov

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
