### PR TITLE
deal with undefined event on InputCurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Deal with `undefined` event no `InputCurrency`.
+- **InputCurrency** `undefined` event handling.
 
 ## [9.135.2] - 2021-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.135.3] - 2021-02-22
+
 ### Fixed
 
 - **InputCurrency** `undefined` event handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Deal with `undefined` event no `InputCurrency`.
+
 ## [9.135.2] - 2021-02-10
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.135.2",
+  "version": "9.135.3",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.135.2",
+  "version": "9.135.3",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/InputCurrency/index.js
+++ b/react/components/InputCurrency/index.js
@@ -33,7 +33,7 @@ class InputCurrency extends Component {
       onChange({
         ...event,
         target: {
-          ...event.target,
+          ...(event && event.target),
           value: floatValue,
         },
       })


### PR DESCRIPTION
#### What is the purpose of this pull request?

The global `event` is deprecated. Browsers deal with this object differently and sometimes, it can be unavailable. This PR deal with cases where the `event` is undefined

#### How should this be manually tested?

Go to the workspace, click on "Brake Mounts" and then on "No mount". The `InputCurrency` in the "Price Ranges" will throw an error

[Broken workspace](https://hiago--eriksbikeshop.myvtex.com/cycling)
[Fixed workspace](https://hiago2--eriksbikeshop.myvtex.com/cycling)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/40380674/108387301-3b893380-71ec-11eb-998f-9a4325e5e968.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
