### PR TITLE
Fix getChartDefaultProps ignoring the user's chosen height property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.137.0] - 2021-03-30
+
 ### Added
 
 - **LineChart** docs warning about `container` config usage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Warning about the use of the `container` config in **LineChart** 
+
 ## [9.136.2] - 2021-03-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Warning about the use of the `container` config in **LineChart** 
+- **LineChart** docs warning about `container` config usage.
 
 ## [9.136.2] - 2021-03-23
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.136.2",
+  "version": "9.137.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.136.2",
+  "version": "9.137.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -128,6 +128,9 @@ The container property is responsible to define the size of the box that will re
 
 - `height`: The percentage value of the chart's width or a fixed width.
 - `width`: The percentage value of the chart's width or a fixed height.
+- `aspect`: Width / height. If specified, the height will be calculated by width / aspect.
+
+⚠️ This wrapper component sets a default value for the `aspect`, which takes priority over the `height` property. To respect the `height` set, you also have to set the `aspect` to `null`. 
 
 ```js
 const sampleData = require('./sampleData').default;

--- a/react/components/EXPERIMENTAL_Charts/LineChart/README.md
+++ b/react/components/EXPERIMENTAL_Charts/LineChart/README.md
@@ -130,7 +130,7 @@ The container property is responsible to define the size of the box that will re
 - `width`: The percentage value of the chart's width or a fixed height.
 - `aspect`: Width / height. If specified, the height will be calculated by width / aspect.
 
-⚠️ This wrapper component sets a default value for the `aspect`, which takes priority over the `height` property. To respect the `height` set, you also have to set the `aspect` to `null`. 
+⚠️ This wrapper component sets a default value of `4 / 3` for the `aspect`, which takes priority over the `height` property. To respect the `height` set, you also have to set the `aspect` to `null`. 
 
 ```js
 const sampleData = require('./sampleData').default;


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow the user to set the container's height property.

#### What problem is this solving?

The `aspect` property in the default config will always overwrite the specified height property. Now we first analyze the user config and check if there's a height property set, and If not, then we set the default `aspect` property.


#### How should this be manually tested?

[Running workspace](https://sortbynotification--vtexlogcarriers.myvtex.com/admin/vtexlog/reports/performance/)

#### Screenshots or example usage
Ignoring the height property:
![image](https://user-images.githubusercontent.com/70980489/109044458-3119de80-76b1-11eb-979e-c8c74fb5713f.png)
![image](https://user-images.githubusercontent.com/70980489/109044481-370fbf80-76b1-11eb-9050-28516e9d1115.png)
With the fix:
![image](https://user-images.githubusercontent.com/70980489/109044508-3f67fa80-76b1-11eb-8a2e-8fb08c11090a.png)
![image](https://user-images.githubusercontent.com/70980489/109044523-442cae80-76b1-11eb-99fe-c13f1f786cef.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
