### PR TITLE
Scroll polyfill

### DIFF
--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -8,6 +8,7 @@ import TopBar from './TopBar'
 import BottomBar from './BottomBar'
 import styles from './modal.css'
 
+import '../../modules/scrollPollyfill'
 import './modal.global.css'
 
 class Modal extends PureComponent {

--- a/react/modules/scrollPollyfill.js
+++ b/react/modules/scrollPollyfill.js
@@ -1,0 +1,7 @@
+function isFunction(functionToCheck) {
+  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
+}
+
+if (!isFunction(window.scroll)) {
+  window.scroll = window.scrollTo
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Currently, there is a bug when you click outside of a modal, it will break the whole `my-account` component because of a library (no-scroll) that calls the `window.scroll` function. The error is that `window.scroll is not a function` and instead it's an object

[Workspace with the bug fix](https://wishlistvtex--bestride.myvtex.com/account?__bindingAddress=www.bestride.ro/#/profile)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Environments:

https://www.supermercato.ro/
https://bestride.myvtex.com/

Steps to reproduce:

Login as a customer
Go in "My Account" section
Click on "Logout"
A confirmation modal is opened. Close this modal (Cancel or X)

Actual result:
The elements from the main container disappears and the customer has to refresh the page in order to see again the my account sections
Expected result:
User should remain in the same page
Extra info:
In Dev Tools - Console appears an error related to window.scroll event from react-dom
When the retargeting app is present, the react-dom library seems to be different
https://supermercato.vtexassets.com/_v/public/assets/v1/npm/react-dom@0.0.0-experimental-94c0244ba/umd/react-dom.production.min.js?async=2&workspace=master
I saw that we have 2 retargeting apps. (one of them is on ion ambrinoc github account)

#### Screenshots or example usage

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
