### PR TITLE
Fixing stepper's displayValue boundary detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.136.2] - 2021-03-23
+
 ### Fixed
 
 - **NumericStepper** `displayValue` boundary detection when `unitMultiplier` was different from 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **NumericStepper** `displayValue` boundary detection when `unitMultiplier` was different from 1
+
 ## [9.136.1] - 2021-03-15
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.136.1",
+  "version": "9.136.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.136.1",
+  "version": "9.136.2",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -56,8 +56,9 @@ const validateDisplayValue = (
   // It allows for temporarily invalid values (namely, empty string and minus sign without a number following it)
   // However, it prevents values out of boundaries, and invalid characters, e.g. letters
 
-  min = normalizeMin(min) * unitMultiplier
-  max = normalizeMax(max) * unitMultiplier
+  const boundaryMultiplier = isTyping ? unitMultiplier : 1
+  min = normalizeMin(min) * boundaryMultiplier
+  max = normalizeMax(max) * boundaryMultiplier
 
   const parsedValue = parseFloat(value)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR fixes an issue where the `displayValue` of the `NumericStepper` was considering wrong boundaries (min and max values) when using a `unitMultiplier` different from 1.

#### What problem is this solving?

[Breaking workspace](https://poccarrefourarg.myvtex.com/papa-x-kg-/p)
[Fixed workspace](https://icarovtex--poccarrefourarg.myvtex.com/papa-x-kg-/p)
[Fixed workspace 2](https://icarostepper--storecomponents.myvtex.com/traveler-backpack/p)

#### How should this be manually tested?

Try setting a small value for min and max values and a unitMultiplier different from 1. It increases the real integer `value`, but the `displayValue` remains unchanged when the real integer `value >= maxValue * unitMultiplier`.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
