### PR TITLE
Fix/dangerous bulk actions experimental table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.138.0] - 2021-04-05
+
 ### Changed
 
 - **EXPERIMENTAL_TableV2** accept `isDangerous` attribute for secondary `BulkActions`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **EXPERIMENTAL_TableV2** accept `isDangerous` attribute for secondary `BulkActions`.
+
 ## [9.137.0] - 2021-03-30
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.137.0",
+  "version": "9.138.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.137.0",
+  "version": "9.138.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Table/BulkActions/Actions.tsx
+++ b/react/components/EXPERIMENTAL_Table/BulkActions/Actions.tsx
@@ -46,6 +46,7 @@ function Secondary({ label, actions, onActionClick }: SecondaryProps) {
         options={actions.map(el => ({
           label: el.label,
           onClick: () => onActionClick(el),
+          isDangerous: el.isDangerous
         }))}
       />
     </div>
@@ -57,8 +58,12 @@ type PrimaryProps = {
   onClick: () => void
 }
 
+type SecondaryActionProps = MenuAction & {
+  isDangerous?: boolean
+}
+
 type SecondaryProps = {
   label: string
-  actions: Array<MenuAction>
+  actions: Array<SecondaryActionProps>
   onActionClick: (el: MenuAction) => void
 }

--- a/react/components/EXPERIMENTAL_Table/BulkActions/Actions.tsx
+++ b/react/components/EXPERIMENTAL_Table/BulkActions/Actions.tsx
@@ -46,7 +46,7 @@ function Secondary({ label, actions, onActionClick }: SecondaryProps) {
         options={actions.map(el => ({
           label: el.label,
           onClick: () => onActionClick(el),
-          isDangerous: el.isDangerous
+          isDangerous: el.isDangerous,
         }))}
       />
     </div>

--- a/react/components/EXPERIMENTAL_Table/docs/Components.md
+++ b/react/components/EXPERIMENTAL_Table/docs/Components.md
@@ -458,11 +458,12 @@ function TotalizerExample() {
 
 - Button to handle secondary actions.
 
-| Property      | Type                    | Required | Default | Description             |
-| ------------- | ----------------------- | -------- | ------- | ----------------------- |
-| label         | string                  | ✅       | 🚫      | Button text             |
-| onClick       | () => void              | ✅       | 🚫      | Action on click button  |
-| onActionClick | (e: MenuAction) => void | 🚫       | 🚫      | Action on click actions |
+| Property      | Type                              | Required | Default | Description             |
+| ------------- | --------------------------------- | -------- | ------- | ----------------------- |
+| label         | string                            | ✅       | 🚫      | Button text             |
+| onClick       | () => void                        | ✅       | 🚫      | Action on click button  |
+| isDangerous   | boolean                           | 🚫       | 🚫      | Mark whether the action performs a dangerous option or not  |
+| onActionClick | (e: SecondaryActionProps) => void | 🚫       | 🚫      | Action on click actions |
 
 #### Tail
 
@@ -562,6 +563,7 @@ function BulkFullExample() {
       {
         label: 'Decrease 50',
         onClick: checked => decreaseQty(checked, 50),
+        isDangerous: true
       },
     ],
     onActionClick: action => action.onClick(checkboxes.checkedItems),


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add optional `isDangerous` prop to secondary bulk actions in Experimental Table.

#### What problem is this solving?

[Running workspace](https://gabriela--sandboxintegracao.myvtex.com/admin/received-skus/pending/)

The motivation for this change is that in Received SKUs we use the table bulk actions to approve and reject SKUs and rejecting SKUs is considered a dangerous action so it should be visually expressed in the UI.
Another motivation for this change is that the previous table had this behaviour and seems useful to other cases too.

#### How should this be manually tested?

#### Screenshots or example usage

<img width="1552" alt="Screen Shot 2021-03-31 at 18 39 57" src="https://user-images.githubusercontent.com/27388955/113214909-81580380-9250-11eb-81fa-c352645a2763.png">

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
