### PR TITLE
Stop re-rendering all rows if the children of the table changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.138.2] - 2021-04-14
+
 ### Fixed
 
 - **EXPERIMENTAL_TableV2** Sections issue introduced in the previous version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **EXPERIMENTAL_TableV2** Sections issue introduced in the previous version.
+
+## [9.138.1] - 2021-04-13
+
 ### Changed
 
 - **EXPERIMENTAL_TableV2** performance enhancement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **EXPERIMENTAL_TableV2** performance enhancement.
+
 ## [9.138.0] - 2021-04-05
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.138.0",
+  "version": "9.138.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.138.1",
+  "version": "9.138.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.138.0",
+  "version": "9.138.1",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.138.1",
+  "version": "9.138.2",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Table/Sections/Tbody.tsx
+++ b/react/components/EXPERIMENTAL_Table/Sections/Tbody.tsx
@@ -67,7 +67,7 @@ export type ComposableTbody = ComposableWithRef<
   Composites
 >
 
-const FowardedTbody: ComposableTbody = forwardRef(Tbody)
+const FowardedTbody: ComposableTbody = React.memo(forwardRef(Tbody))
 
 FowardedTbody.Row = Row
 

--- a/react/components/EXPERIMENTAL_Table/context/body.tsx
+++ b/react/components/EXPERIMENTAL_Table/context/body.tsx
@@ -19,7 +19,20 @@ export function useBodyContext() {
 
 export function BodyProvider({
   children,
-  ...value
+  onRowClick,
+  isRowActive,
+  rowKey,
+  highlightOnHover,
 }: PropsWithChildren<BodyProps>) {
+  const value = React.useMemo(
+    () => ({
+      onRowClick,
+      isRowActive,
+      rowKey,
+      highlightOnHover,
+    }),
+    [highlightOnHover, isRowActive, onRowClick, rowKey]
+  )
+
   return <BodyContext.Provider value={value}>{children}</BodyContext.Provider>
 }

--- a/react/components/EXPERIMENTAL_Table/context/data.tsx
+++ b/react/components/EXPERIMENTAL_Table/context/data.tsx
@@ -17,6 +17,18 @@ export function useDataContext() {
   return context
 }
 
-export function DataProvider({ children, ...value }: PropsWithChildren<Data>) {
+export function DataProvider({
+  children,
+  items,
+  columns,
+}: PropsWithChildren<Data>) {
+  const value = React.useMemo(
+    () => ({
+      columns,
+      items,
+    }),
+    [columns, items]
+  )
+
   return <DataContext.Provider value={value}>{children}</DataContext.Provider>
 }

--- a/react/components/EXPERIMENTAL_Table/context/head.tsx
+++ b/react/components/EXPERIMENTAL_Table/context/head.tsx
@@ -19,7 +19,16 @@ export function useHeadContext() {
 
 export function HeadProvider({
   children,
-  ...value
+  sticky,
+  sorting,
 }: PropsWithChildren<HeadProps>) {
+  const value = React.useMemo(
+    () => ({
+      sticky,
+      sorting,
+    }),
+    [sorting, sticky]
+  )
+
   return <HeadContext.Provider value={value}>{children}</HeadContext.Provider>
 }

--- a/react/components/EXPERIMENTAL_Table/context/loading.tsx
+++ b/react/components/EXPERIMENTAL_Table/context/loading.tsx
@@ -16,8 +16,19 @@ const LoadingContext = createContext<Loading>(null)
 
 export function LoadingProvider({
   children,
-  ...value
+  empty,
+  loading,
+  emptyState,
 }: PropsWithChildren<Loading>) {
+  const value = React.useMemo(
+    () => ({
+      empty,
+      loading,
+      emptyState,
+    }),
+    [empty, emptyState, loading]
+  )
+
   return (
     <LoadingContext.Provider value={value}>{children}</LoadingContext.Provider>
   )

--- a/react/components/EXPERIMENTAL_Table/context/testing.tsx
+++ b/react/components/EXPERIMENTAL_Table/context/testing.tsx
@@ -22,9 +22,9 @@ export function TestingProvider({
   testId,
   children,
 }: PropsWithChildren<Props>) {
+  const value = React.useMemo(() => ({ testId }), [testId])
+
   return (
-    <TestingContext.Provider value={{ testId }}>
-      {children}
-    </TestingContext.Provider>
+    <TestingContext.Provider value={value}>{children}</TestingContext.Provider>
   )
 }

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableMeasures.tsx
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableMeasures.tsx
@@ -22,13 +22,16 @@ export default function useTableMeasures({
     [rowHeight, size]
   )
 
-  return {
-    density,
-    rowHeight,
-    tableHeight,
-    bodyHeight,
-    setDensity,
-  }
+  return useMemo(
+    () => ({
+      density,
+      rowHeight,
+      tableHeight,
+      bodyHeight,
+      setDensity,
+    }),
+    [bodyHeight, density, rowHeight, tableHeight]
+  )
 }
 
 export type MeasuresInput = {

--- a/react/components/EXPERIMENTAL_Table/hooks/useTableProportion.ts
+++ b/react/components/EXPERIMENTAL_Table/hooks/useTableProportion.ts
@@ -13,9 +13,12 @@ export default function useTableProportion({ columns, ratio }: ProportionData) {
     [calculatedWidths, columns]
   )
 
-  return {
-    sizedColumns,
-  }
+  return useMemo(
+    () => ({
+      sizedColumns,
+    }),
+    [sizedColumns]
+  )
 }
 
 function calculateWidths(columns: Array<Column>, ratio: Array<number>) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

The table was re-rendering all rows when anything changed inside the Table's children. Because of that, when the table had a lot of items (in the example it has 100 items), it started to make typing slow

#### What problem is this solving?

[Workspace with the changes](https://tableperformance--storecomponents.myvtex.com/admin/app/new-cms/store)
![image](https://user-images.githubusercontent.com/8517023/113779123-9aa2f900-9703-11eb-84d0-c5c3a2133bd0.png)

[Workspace without the changes](https://tableslow--storecomponents.myvtex.com/admin/app/new-cms/store)
![image](https://user-images.githubusercontent.com/8517023/113779474-2c126b00-9704-11eb-89f7-f88b34b9847b.png)


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

1. Open the React Profiler
2. Start recording
3. Type something in the search
4. Stop recording
5. Compare both worksapces

<!-- Add the code that is necessary to test your change in the Playground-->
<details>
<summary>Add this code in <code>react/playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react'
import PageHeader from '../PageHeader'
import Layout from '../Layout'
const Playground = () => (
  <Layout fullWidth pageHeader={<PageHeader title="Playground" />}>
    {/* Add your code here, don't forget to delete after */}
  </Layout>
)
export default Playground
```

</details>

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
