### PR TITLE
Make date-fns dependency explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Make date-fns dependency explicit so it doesn't conflict when using from npm together with other projects
+- `date-fns` dependency to be explicit so it doesn't conflict when using from npm together with other projects.
 
 ## [9.138.2] - 2021-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Make date-fns dependency explicit so it doesn't conflict when using from npm together with other projects
+
 ## [9.138.2] - 2021-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.138.3] - 2021-04-20
+
 ### Fixed
 
 - `date-fns` dependency to be explicit so it doesn't conflict when using from npm together with other projects.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.138.2",
+  "version": "9.138.3",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.138.2",
+  "version": "9.138.3",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "fromentries": "^1.1.0",
     "react-color": "^2.17.0",
     "react-datepicker": "^2.3.0",
+    "date-fns": "^2.0.1",
     "react-docgen-displayname-handler": "^2.1.1",
     "react-dropzone": "^10.2.1",
     "react-icons": "^3.7.0",

--- a/react/package.json
+++ b/react/package.json
@@ -4,6 +4,7 @@
     "lodash": "^4.17.19",
     "react-color": "^2.17.0",
     "react-datepicker": "^2.0.0",
+    "date-fns": "^2.0.1",
     "react-dropzone": "^10.1.8",
     "react-number-format": "^4.0.6",
     "react-outside-click-handler": "^1.2.2",


### PR DESCRIPTION
#### What is the purpose of this pull request?

#trivial like the title says

#### What problem is this solving?

Explained here: https://vtex.slack.com/archives/C1MCRG7CK/p1618931965010400

"
Hi all! :worry-wave:
Styleguide is using date-fns dependency, but it seems it wasn't explicit included in the package.json because react-datepicker already includes it.
The problem with that is that if you have other dependencies other than styleguide that also depends on date-fns, than the styleguide package might not be using the one that it though it would (since it is asking for the one on the root of the node_modules, instead of being an dependency) and that can cause build problems (my case with the latest version of Cypress + latest version of Styleguide)
I made the dependency on date-fns explicit on this PR
This doesn't change any code or yarn.lock, just the package.json for those using from npm be safer.
"

#### Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
