### PR TITLE
Add 'fit-horizontally' and 'auto' sizes to EXPERIMENTAL_Modal component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.139.0] - 2021-04-27
+
 ### Added
 
 - **EXPERIMENTAL_Modal** `fit-horizontally` and `auto` sizes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **EXPERIMENTAL_Modal** `full` and `auto` sizes.
+
 ## [9.138.3] - 2021-04-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- **EXPERIMENTAL_Modal** `full` and `auto` sizes.
+- **EXPERIMENTAL_Modal** `fit-horizontally` and `auto` sizes.
 
 ## [9.138.3] - 2021-04-20
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.138.3",
+  "version": "9.139.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.138.3",
+  "version": "9.139.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Modal/README.md
+++ b/react/components/EXPERIMENTAL_Modal/README.md
@@ -34,7 +34,7 @@ The anatomy consists of an overlay to block user interaction below the Modal and
 | responsiveFullScreen    | `boolean` | 🚫       | false               | If true the modal will expand to fullscreen in small view ports                                                                                             |
 | showTopBar              | `boolean` | 🚫       | true                | If true, show top bar with title                                                                                                                            |
 | onCloseTransitionFinish | `func`    | 🚫       |                     | Event fired when the closing transition is finished                                                                                                         |
-| size                    | `enum`    | 🚫       | medium              | Modal Size. One of: "small", "medium", "large", "full" and "auto"                                                                                           |
+| size                    | `enum`    | 🚫       | medium              | Modal Size. One of: "small", "medium", "large", "fit-horizontally" and "auto"                                                                                           |
 | aria-label              | `string`  | 🚫       |                     | Acessible Modal name. If this name is visible on the screen, prefer to use aria-labelledby                                                                  |
 | aria-labelledby         | `string`  | 🚫       | `vtex-modal__title` | ID of the element that provides the Modal an accessible name. If aria-label and aria-albelledby is not defined, the default here will be the title element. |
 | aria-describedby        | `string`  | 🚫       |                     | ID of the element that provides the Modal an accessible description                                                                                         |
@@ -430,7 +430,7 @@ const ModalExample = () => {
 ;<ModalExample />
 ```
 
-##### Full
+##### Fit Horizontally
 
 ```js
 const Button = require('../Button').default
@@ -447,7 +447,7 @@ const ModalExample = () => {
       <Modal
         isOpen={isOpen}
         onClose={onClose}
-        size="full"
+        size="fit-horizontally"
         title="Import products by CSV"
         aria-describedby="modal-description"
         bottomBar={

--- a/react/components/EXPERIMENTAL_Modal/README.md
+++ b/react/components/EXPERIMENTAL_Modal/README.md
@@ -34,7 +34,7 @@ The anatomy consists of an overlay to block user interaction below the Modal and
 | responsiveFullScreen    | `boolean` | 🚫       | false               | If true the modal will expand to fullscreen in small view ports                                                                                             |
 | showTopBar              | `boolean` | 🚫       | true                | If true, show top bar with title                                                                                                                            |
 | onCloseTransitionFinish | `func`    | 🚫       |                     | Event fired when the closing transition is finished                                                                                                         |
-| size                    | `enum`    | 🚫       | medium              | Modal Size. One of: Small, Medium and Large                                                                                                                 |
+| size                    | `enum`    | 🚫       | medium              | Modal Size. One of: "small", "medium", "large", "full" and "auto"                                                                                           |
 | aria-label              | `string`  | 🚫       |                     | Acessible Modal name. If this name is visible on the screen, prefer to use aria-labelledby                                                                  |
 | aria-labelledby         | `string`  | 🚫       | `vtex-modal__title` | ID of the element that provides the Modal an accessible name. If aria-label and aria-albelledby is not defined, the default here will be the title element. |
 | aria-describedby        | `string`  | 🚫       |                     | ID of the element that provides the Modal an accessible description                                                                                         |
@@ -396,6 +396,110 @@ const ModalExample = () => {
         isOpen={isOpen}
         onClose={onClose}
         size="large"
+        title="Import products by CSV"
+        aria-describedby="modal-description"
+        bottomBar={
+          <div className="nowrap">
+            <span className="mr4">
+              <Button variation="tertiary" onClick={onClose}>
+                Cancel
+              </Button>
+            </span>
+            <span>
+              <Button variation="primary" onClick={onClose}>
+                Upload
+              </Button>
+            </span>
+          </div>
+        }>
+        <Dropzone>
+          <div className="pt7">
+            <div id="modal-description">
+              <span className="f4">Drop here your CSV or </span>
+              <span className="f4 c-link" style={{ cursor: 'pointer' }}>
+                choose a file
+              </span>
+            </div>
+          </div>
+        </Dropzone>
+      </Modal>
+    </>
+  )
+}
+
+;<ModalExample />
+```
+
+##### Full
+
+```js
+const Button = require('../Button').default
+const Dropzone = require('../Dropzone').default
+const Modal = require('.').default
+const useDisclosure = require('../../utilities/useDisclosure').default
+
+const ModalExample = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  return (
+    <>
+      <Button onClick={onOpen}>Open modal</Button>
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        size="full"
+        title="Import products by CSV"
+        aria-describedby="modal-description"
+        bottomBar={
+          <div className="nowrap">
+            <span className="mr4">
+              <Button variation="tertiary" onClick={onClose}>
+                Cancel
+              </Button>
+            </span>
+            <span>
+              <Button variation="primary" onClick={onClose}>
+                Upload
+              </Button>
+            </span>
+          </div>
+        }>
+        <Dropzone>
+          <div className="pt7">
+            <div id="modal-description">
+              <span className="f4">Drop here your CSV or </span>
+              <span className="f4 c-link" style={{ cursor: 'pointer' }}>
+                choose a file
+              </span>
+            </div>
+          </div>
+        </Dropzone>
+      </Modal>
+    </>
+  )
+}
+
+;<ModalExample />
+```
+
+##### Auto
+
+```js
+const Button = require('../Button').default
+const Dropzone = require('../Dropzone').default
+const Modal = require('.').default
+const useDisclosure = require('../../utilities/useDisclosure').default
+
+const ModalExample = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  return (
+    <>
+      <Button onClick={onOpen}>Open modal</Button>
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        size="auto"
         title="Import products by CSV"
         aria-describedby="modal-description"
         bottomBar={

--- a/react/components/EXPERIMENTAL_Modal/index.tsx
+++ b/react/components/EXPERIMENTAL_Modal/index.tsx
@@ -23,7 +23,7 @@ export interface Props
   showBottomBarBorder?: boolean
   onCloseTransitionFinish?: () => unknown
   centered?: boolean
-  size?: 'small' | 'medium' | 'large'
+  size?: 'small' | 'medium' | 'large' | 'full' | 'auto'
   responsiveFullScreen?: boolean
 }
 
@@ -162,6 +162,7 @@ const ModalContent = forwardRef<HTMLDivElement, ContentProps>(
           `${size === 'small' ? styles.smallContent : ''}`,
           `${size === 'medium' ? styles.mediumContent : ''}`,
           `${size === 'large' ? styles.largeContent : ''}`,
+          `${size === 'auto' ? styles.autoWidthContent : ''}`,
           {
             'h-100 h-auto-ns vw-100': responsiveFullScreen,
             'vw-90': !responsiveFullScreen,

--- a/react/components/EXPERIMENTAL_Modal/index.tsx
+++ b/react/components/EXPERIMENTAL_Modal/index.tsx
@@ -23,7 +23,7 @@ export interface Props
   showBottomBarBorder?: boolean
   onCloseTransitionFinish?: () => unknown
   centered?: boolean
-  size?: 'small' | 'medium' | 'large' | 'full' | 'auto'
+  size?: 'small' | 'medium' | 'large' | 'fit-horizontally' | 'auto'
   responsiveFullScreen?: boolean
 }
 

--- a/react/components/EXPERIMENTAL_Modal/modal.css
+++ b/react/components/EXPERIMENTAL_Modal/modal.css
@@ -60,6 +60,12 @@
   }
 }
 
+@media screen and (min-width: 40em) {
+  .autoWidthContent {
+    width: auto;
+  }
+}
+
 @keyframes fade-in {
   0% {
     opacity: 0;

--- a/react/components/EXPERIMENTAL_Modal/modal.stories.tsx
+++ b/react/components/EXPERIMENTAL_Modal/modal.stories.tsx
@@ -7,7 +7,7 @@ import useDisclosure from '../../utilities/useDisclosure'
 import Button from '../Button'
 import Input from '../Input'
 
-const sizes = ['small', 'medium', 'large']
+const sizes = ['small', 'medium', 'large', 'full', 'auto']
 
 export default {
   title: 'Components/Modal V2',

--- a/react/components/EXPERIMENTAL_Modal/modal.stories.tsx
+++ b/react/components/EXPERIMENTAL_Modal/modal.stories.tsx
@@ -7,7 +7,7 @@ import useDisclosure from '../../utilities/useDisclosure'
 import Button from '../Button'
 import Input from '../Input'
 
-const sizes = ['small', 'medium', 'large', 'full', 'auto']
+const sizes = ['small', 'medium', 'large', 'fit-horizontally', 'auto']
 
 export default {
   title: 'Components/Modal V2',


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says...

Also, it doesn't affect the `responsiveFullScreen` feature.

#### What problem is this solving?

I need the modal to adjust its size based on the content and also to be able to horizontally fit the screen in some other cases.

#### How should this be manually tested?

You can check out Vercel's deployment of this branch :)

#### Screenshots or example usage

##### Fit horizontally modal

![image](https://user-images.githubusercontent.com/15948386/115741421-1f2d8280-a366-11eb-8d95-c25d17411041.png)

##### Auto sized modal

![image](https://user-images.githubusercontent.com/15948386/115741453-29e81780-a366-11eb-84e7-d42e2399fd52.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
