### PR TITLE
Fix EXPERIMENTAL_Modal 'auto' size max width to avoid overflowing the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **EXPERIMENTAL_Modal** `auto` size should have `max-width` to avoid overflowing the screen.
+
 ## [9.139.0] - 2021-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.139.1] - 2021-04-28
+
 ### Fixed
 
 - **EXPERIMENTAL_Modal** `auto` size should have `max-width` to avoid overflowing the screen.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.139.0",
+  "version": "9.139.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.139.0",
+  "version": "9.139.1",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Modal/modal.css
+++ b/react/components/EXPERIMENTAL_Modal/modal.css
@@ -63,6 +63,7 @@
 @media screen and (min-width: 40em) {
   .autoWidthContent {
     width: auto;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says...

#### What problem is this solving?

This one:

![image](https://user-images.githubusercontent.com/15948386/116285930-0c9bba80-a765-11eb-9669-9890793680ae.png)


#### How should this be manually tested?

You can test it in the Vercel build or in [this workspace](https://inventory--qastore.myvtex.com/admin/inventory/?details=reservedQuantity&keyword=&minReservedQuantity=1&page=1&perPage=10&sku=401&warehouseId=1ccaeb6)

#### Screenshots or example usage

##### After the fix

![image](https://user-images.githubusercontent.com/15948386/116285893-ff7ecb80-a764-11eb-9603-fba8c4a5ef2a.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
