### PR TITLE
Add 'disableScroll' to EXPERIMENTAL_Table component root component, t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.140.0] - 2021-04-29
+
 ### Added
 
 - **EXPERIMENTAL_TableV2** `disableScroll` prop at the root component, to be used without the need of `composableSections`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **EXPERIMENTAL_TableV2** `disableScroll` prop at the root component, to be used without the need of `composableSections`.
+
 ## [9.139.1] - 2021-04-28
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.139.1",
+  "version": "9.140.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.139.1",
+  "version": "9.140.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Table/docs/Advanced.md
+++ b/react/components/EXPERIMENTAL_Table/docs/Advanced.md
@@ -246,9 +246,9 @@ As you can see in the "Customizing body" section sample, it's using the `<Table.
 
 ##### Sections Props
 
-| Property      | Type    | Required | Default | Description                              |
-|---------------|---------|----------|---------|------------------------------------------|
-| disableScroll | boolean | 🚫       | false   | Disable scroll overflow of the container |
+| Property      | Type    | Required | Default | Description                                                                                                  |
+|---------------|---------|----------|---------|--------------------------------------------------------------------------------------------------------------|
+| disableScroll | boolean | 🚫       | false   | Disable scroll overflow of the container. When not using composable sections, it can be a Table prop anyway. |
 
 ##### Cell Props
 

--- a/react/components/EXPERIMENTAL_Table/index.tsx
+++ b/react/components/EXPERIMENTAL_Table/index.tsx
@@ -44,6 +44,7 @@ function Table(
     testId,
     stickyHeader,
     composableSections,
+    disableScroll,
   }: Props,
   ref: Ref<HTMLTableElement>
 ) {
@@ -64,7 +65,7 @@ function Table(
                   ) : (
                     <Fragment>
                       {children}
-                      <Sections ref={ref}>
+                      <Sections ref={ref} disableScroll={disableScroll}>
                         <Sections.Head />
                         <Sections.Body />
                       </Sections>
@@ -123,6 +124,8 @@ interface SpecificProps {
   stickyHeader?: boolean
   /** Exposes table sections to be composable */
   composableSections?: boolean
+  /** Disable scroll in table sections when not using composable sections */
+  disableScroll?: boolean
 }
 
 interface Composites {


### PR DESCRIPTION
…o be used without the need of 'composableSections'

#### What is the purpose of this pull request?

As the title says, there's no way of using the `disableScroll` without `composableSections`

#### What problem is this solving?

This one

![image](https://user-images.githubusercontent.com/15948386/116288239-b11efc00-a767-11eb-8c2b-f9199511b6d1.png)


#### How should this be manually tested?

Can be tested on Vercel deploy or [here](https://inventory--qastore.myvtex.com/admin/inventory/?details=quantity&keyword=&minReservedQuantity=1&page=1&perPage=10&sku=401&warehouseId=1ccaeb6).

#### Screenshots or example usage

##### After the fix

![image](https://user-images.githubusercontent.com/15948386/116288384-d90e5f80-a767-11eb-8c85-f0e318a9d5f3.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
