### PR TITLE
Fix NumericStepper and Button behavior on touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.141.0] - 2021-05-13
+
 ### Fixed
 
 - **NumericStepper** closing the autocomplete on touch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **NumericStepper** closing the autocomplete on touch.
+
+### Added
+
+- **Button** `onTouchEnd` prop.
+
 ## [9.140.1] - 2021-05-06
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.140.1",
+  "version": "9.141.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.140.1",
+  "version": "9.141.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -343,6 +343,8 @@ Button.propTypes = {
   onFocus: PropTypes.func,
   /** onBlur event */
   onBlur: PropTypes.func,
+  /** onTouchEnd event */
+  onTouchEnd: PropTypes.func,
   /** tabIndex attribute of HTML */
   tabIndex: PropTypes.number,
   /** @ignore deprecated

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -233,6 +233,7 @@ class Button extends Component {
         onMouseDown={this.props.onMouseDown}
         onFocus={this.props.onFocus}
         onBlur={this.props.onBlur}
+        onTouchEnd={this.props.onTouchEnd}
         ref={this.props.forwardedRef}
         style={style}
         // Button-mode exclusive props

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -185,10 +185,12 @@ class NumericStepper extends Component {
   }
 
   handleIncreaseValue = event => {
+    event.preventDefault()
     this.changeValue(this.state.value + 1, event, false)
   }
 
   handleDecreaseValue = event => {
+    event.preventDefault()
     this.changeValue(this.state.value - 1, event, false)
   }
 
@@ -281,6 +283,8 @@ class NumericStepper extends Component {
       lean ? 'outline-0' : ''
     } `
 
+    const touchDevice = 'ontouchstart' in window || navigator.maxTouchPoints || navigator.msMaxTouchPoints
+
     const content = (
       <React.Fragment>
         {label && (
@@ -321,7 +325,8 @@ class NumericStepper extends Component {
               disabled={readOnly || isMax}
               aria-label="+"
               tabIndex={0}
-              onClick={this.handleIncreaseValue}>
+              onClick={touchDevice ? undefined : this.handleIncreaseValue}
+              onTouchEnd={touchDevice ? this.handleIncreaseValue : undefined}>
               <div className="vtex-numeric-stepper__plus-button__text numeric-stepper__plus-button__text b">
                 {/* fullwidth plus sign (U+FF0B) http://graphemica.com/%EF%BC%8B */}
                 ＋
@@ -346,7 +351,8 @@ class NumericStepper extends Component {
               // which is the default keyboard character.
               // Used for screen readers.
               tabIndex={0}
-              onClick={this.handleDecreaseValue}>
+              onClick={touchDevice ? undefined : this.handleDecreaseValue}
+              onTouchEnd={touchDevice ? this.handleDecreaseValue : undefined}>
               <span className="vtex-numeric-stepper__minus-button__text numeric-stepper__minus-button__text b">
                 {/* fullwidth hyphen-minus (U+FF0D) http://graphemica.com/%EF%BC%8D */}
                 －

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -283,7 +283,10 @@ class NumericStepper extends Component {
       lean ? 'outline-0' : ''
     } `
 
-    const touchDevice = 'ontouchstart' in window || navigator.maxTouchPoints || navigator.msMaxTouchPoints
+    const touchDevice =
+      'ontouchstart' in window ||
+      navigator.maxTouchPoints ||
+      navigator.msMaxTouchPoints
 
     const content = (
       <React.Fragment>

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -185,13 +185,13 @@ class NumericStepper extends Component {
   }
 
   handleIncreaseValue = event => {
-    event.preventDefault()
     this.changeValue(this.state.value + 1, event, false)
+    event.preventDefault()
   }
 
   handleDecreaseValue = event => {
-    event.preventDefault()
     this.changeValue(this.state.value - 1, event, false)
+    event.preventDefault()
   }
 
   handleFocusInput = e => {


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

when clicking on the add to cart or numeric stepper buttons on the mobile autocomplete, the autocomplete closes.
so the user is unable to include more items directly in the autocomplete

[Running workspace](https://thalyta--gigadigital.myvtex.com/)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- in the autocomplete, type a term and click the add to cart button of the suggested product or try to increase the quantity
- the autocomplete should not close

<!-- Add the code that is necessary to test your change in the Playground-->
<details>
<summary>Add this code in <code>react/playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react'
import PageHeader from '../PageHeader'
import Layout from '../Layout'
const Playground = () => (
  <Layout fullWidth pageHeader={<PageHeader title="Playground" />}>
    {/* Add your code here, don't forget to delete after */}
  </Layout>
)
export default Playground
```

</details>

#### Screenshots or example usage

https://user-images.githubusercontent.com/20840671/116931714-bed8f380-ac37-11eb-8f36-38d32ad366f4.mp4

https://user-images.githubusercontent.com/20840671/116931721-c0a2b700-ac37-11eb-84ef-4cc3525d0dce.mp4

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
