### PR TITLE
**EXPERIMENTAL_TableV2** search button click does not work if the onSubmit prop is not passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **EXPERIMENTAL_TableV2** search button click does not work if the onSubmit prop is not passed.
+
 ## [9.140.0] - 2021-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.140.1] - 2021-05-06
+
 ### Fixed
 
 - **EXPERIMENTAL_TableV2** search button click does not work if the onSubmit prop is not passed.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.140.0",
+  "version": "9.140.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.140.0",
+  "version": "9.140.1",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Table/Toolbar/InputSearch.tsx
+++ b/react/components/EXPERIMENTAL_Table/Toolbar/InputSearch.tsx
@@ -8,15 +8,17 @@ export type InputSearchProps = InputHTMLAttributes<HTMLInputElement> & {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void
 }
 
-const InputSearch: FC<InputSearchProps> = ({ onSubmit, ...inputProps }) => {
+const InputSearch: FC<InputSearchProps> = props => {
   const { testId } = useToolbarContext()
   return (
     <form
       id={NAMESPACES.TOOLBAR.INPUT_SEARCH}
       data-testid={`${testId}__search-form`}
       className={ORDER_CLASSNAMES.TOOLBAR_CHILD.INPUT}
-      onSubmit={onSubmit}>
-      <Input testId={`${testId}__search-form__input`} {...inputProps} />
+      onSubmit={e => {
+        e.preventDefault()
+      }}>
+      <Input testId={`${testId}__search-form__input`} {...props} />
     </form>
   )
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

**EXPERIMENTAL_TableV2** search button click does not work if the onSubmit prop is not passed. 

Solution: Pass onSubmit prop from `InputSearch Wrapper` to `InputSearch` in order to fix search button click. This problem is happing because the `InputSearch` component is using onSubmit `prop` in this [line](https://github.com/vtex/styleguide/blob/master/react/components/InputSearch/index.js#L98).   

<img width="1294" alt="Captura de Tela 2021-05-05 às 9 35 52 AM" src="https://user-images.githubusercontent.com/32311264/117151970-f22e9600-ad8f-11eb-8058-e374ef58cb0f.png">

#### What problem is this solving?

[Running workspace](https://storecomponents.myvtex.com/admin/new-cms/faststore/)
The problem happens in the styleguide [example](https://styleguide.vtex.com/#/Components/%F0%9F%91%BB%20Experimental/Table%20V2?id=section-components-1) too
 

#### How should this be manually tested?

I just linked these changes in the `pedrocms` workspace. You can test it [here](https://pedrocms--storecomponents.myvtex.com/admin/new-cms/faststore/). 

I linked the admin-cms (without changes) too. You can see the code [here](https://github.com/vtex/admin-cms/blob/master/react/components/ListActive/index.tsx#L257)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
