### PR TITLE
Add onTouchStart and onTouchMove to Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
 - **Button** `onTouchStart` and `onTouchMove` props.
 
 ## [9.141.1] - 2021-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.142.0] - 2021-05-19
+
 ### Added
 
 - **Button** `onTouchStart` and `onTouchMove` props.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- **Button** `onTouchStart` and `onTouchMove` props.
+
 ## [9.141.1] - 2021-05-17
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.141.1",
+  "version": "9.142.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.141.1",
+  "version": "9.142.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -234,6 +234,8 @@ class Button extends Component {
         onFocus={this.props.onFocus}
         onBlur={this.props.onBlur}
         onTouchEnd={this.props.onTouchEnd}
+        onTouchStart={this.props.onTouchStart}
+        onTouchMove={this.props.onTouchMove}
         ref={this.props.forwardedRef}
         style={style}
         // Button-mode exclusive props
@@ -343,6 +345,10 @@ Button.propTypes = {
   onFocus: PropTypes.func,
   /** onBlur event */
   onBlur: PropTypes.func,
+  /** onTouchStart event */
+  onTouchStart: PropTypes.func,
+  /** onTouchMove event */
+  onTouchMove: PropTypes.func,
   /** onTouchEnd event */
   onTouchEnd: PropTypes.func,
   /** tabIndex attribute of HTML */


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

We have a bug in the add to cart where the button performs click behavior when scrolling over it on mobile. This is because we use the `onTouchEnd` function (yes, we need this 🥺). 
To fix it, we need to check whether or not a scroll was made on the screen and then decide if there should be a click behavior or not. For this, we need the functions of `onTouchStart` and `onTouchMove`: https://github.com/vtex-apps/add-to-cart-button/pull/78

[Running workspace](https://thalyta--gigadigital.myvtex.com/refrigerante-coca-cola-pet-1l/p)

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

<!-- Add the code that is necessary to test your change in the Playground-->
<details>
<summary>Add this code in <code>react/playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react'
import PageHeader from '../PageHeader'
import Layout from '../Layout'
const Playground = () => (
  <Layout fullWidth pageHeader={<PageHeader title="Playground" />}>
    {/* Add your code here, don't forget to delete after */}
  </Layout>
)
export default Playground
```

</details>

#### Screenshots or example usage


https://user-images.githubusercontent.com/20840671/118701017-a1845780-b7e9-11eb-83f7-c7f8562d2636.mp4

https://user-images.githubusercontent.com/20840671/118701011-9fba9400-b7e9-11eb-9ba1-6ca00b33f537.mp4


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
