### PR TITLE
Fixing window scroll not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Modal** sometimes not loading `window.scroll` polyfill after the browser hard refresh.
+
 ## [9.142.0] - 2021-05-19
 
 ### Added

--- a/react/components/Modal/index.js
+++ b/react/components/Modal/index.js
@@ -8,8 +8,13 @@ import TopBar from './TopBar'
 import BottomBar from './BottomBar'
 import styles from './modal.css'
 
-import '../../modules/scrollPollyfill'
 import './modal.global.css'
+
+function isFunction(functionToCheck) {
+  return (
+    functionToCheck && {}.toString.call(functionToCheck) === '[object Function]'
+  )
+}
 
 class Modal extends PureComponent {
   constructor(props) {
@@ -23,6 +28,9 @@ class Modal extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
+    if (!isFunction(window.scroll)) {
+      window.scroll = window.scrollTo
+    }
     const scrollTop = get(this, 'contentContainerReference.current.scrollTop')
     if (
       prevProps.isOpen !== this.props.isOpen ||

--- a/react/modules/scrollPollyfill.js
+++ b/react/modules/scrollPollyfill.js
@@ -1,9 +1,0 @@
-function isFunction(functionToCheck) {
-  return (
-    functionToCheck && {}.toString.call(functionToCheck) === '[object Function]'
-  )
-}
-
-if (!isFunction(window.scroll)) {
-  window.scroll = window.scrollTo
-}


### PR DESCRIPTION
#### What is the purpose of this pull request?

This is related to the fix done here https://github.com/vtex/styleguide/pull/1371 - if you're installing the current version of the app on a workspace where Modal is used, on hard refresh (CTRL + Shift + R) the window.scroll stays undefined during componentDidUpdate.  For some reason the file is not imported properly on hard refresh, after moving the function to Modal/index.js and calling it right before the logic in ComponentDidUpdate the problem was fixed

#### What problem is this solving?

Can't provide a workspace link because the functionality requires for you to have an account and some dummy data inserted in master data for your email in order for the contracts to show up in your account, but here's a video that describes the issue and shows the fix.

https://user-images.githubusercontent.com/71461884/120172465-c1654380-c20b-11eb-848b-dd2c3a6beb39.mp4

#### How should this be manually tested?

1. Install the latest version of styleguide on a workspace that uses Modal and hard refresh on that page to get the error 
2. Link this fixed version on the same workspace and repeat 1) -> the error will no longer appear

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
