### PR TITLE
Adding disabled attr to dropdown select options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **Modal** sometimes not loading `window.scroll` polyfill after the browser hard refresh.
 
+### Added 
+
+- **Dropdown** `disabled` prop added to options
+
 ## [9.142.0] - 2021-05-19
 
 ### Added

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -290,6 +290,7 @@ Dropdown.propTypes = {
   /** Dropdown options list */
   options: PropTypes.arrayOf(
     PropTypes.shape({
+      disabled: PropTypes.bool,
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
         .isRequired,
       label: PropTypes.oneOfType([PropTypes.string, PropTypes.number])

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -244,7 +244,7 @@ class Dropdown extends Component {
                 </option>
               )}
               {options.map(option => (
-                <option key={option.value} value={option.value}>
+                <option disabled={option.disabled} key={option.value} value={option.value}>
                   {option.label}
                 </option>
               ))}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds the disabled attribute to an option in the dropdown to allow the developer to show disabled items as well

#### What problem is this solving?

The problem it's solving and the motivation behind this PR are detailed here: https://github.com/vtex-apps/store-components/pull/953

#### How should this be manually tested?

See the testing steps here: https://github.com/vtex-apps/store-components/pull/953 - it depends on the whether or not the options parameter contains the "disabled" key, if it doesn't, it defaults to "false" and has no impact on the functionality.  It will only affect stores that specifically provide that key

#### Screenshots or example usage

Uploading disable_select_options.mp4…

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
