### PR TITLE
Release v9.143.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.143.0] - 2021-06-16
+
 ### Fixed
 
 - **Modal** sometimes not loading `window.scroll` polyfill after the browser hard refresh.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.142.0",
+  "version": "9.143.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.142.0",
+  "version": "9.143.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -244,7 +244,10 @@ class Dropdown extends Component {
                 </option>
               )}
               {options.map(option => (
-                <option disabled={option.disabled} key={option.value} value={option.value}>
+                <option
+                  disabled={option.disabled}
+                  key={option.value}
+                  value={option.value}>
                   {option.label}
                 </option>
               ))}


### PR DESCRIPTION
## [9.143.0] - 2021-06-16

### Fixed

- **Modal** sometimes not loading `window.scroll` polyfill after the browser hard refresh.

### Added 

- **Dropdown** `disabled` prop added to options
