### PR TITLE
Add handle callback on toggle fields visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Possibility to get callback on toggle fields visibility with `onToggleColumn`, `onHideAllColumns` and `onShowAllColumns`
+
 ## [9.143.0] - 2021-06-16
 
 ### Fixed
 
 - **Modal** sometimes not loading `window.scroll` polyfill after the browser hard refresh.
 
-### Added 
+### Added
 
 - **Dropdown** `disabled` prop added to options
 

--- a/react/components/Table/README.md
+++ b/react/components/Table/README.md
@@ -790,6 +790,12 @@ class ResourceListExample extends React.Component {
             label: 'Toggle visible fields',
             showAllLabel: 'Show All',
             hideAllLabel: 'Hide All',
+            onToggleColumn: (params) => {
+              console.log(params.toggledField)
+              console.log(params.activeFields)
+            },
+            onHideAllColumns: (activeFields) => console.log(activeFields),
+            onShowAllColumns: (activeFields) => console.log(activeFields),
           },
           extraActions: {
             label: 'More options',
@@ -1714,6 +1720,12 @@ class ResourceListExample extends React.Component {
             label: 'Toggle visible fields',
             showAllLabel: 'Show All',
             hideAllLabel: 'Hide All',
+            onToggleColumn: (params) => {
+              console.log(params.toggledField)
+              console.log(params.activeFields)
+            },
+            onHideAllColumns: (activeFields) => console.log(activeFields),
+            onShowAllColumns: (activeFields) => console.log(activeFields),
           },
           extraActions: {
             label: 'More options',

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -90,8 +90,9 @@ class Table extends PureComponent {
       newFieldsArray
     )
 
-    toolbar?.fields?.onToggleColumn &&
+    if (toolbar?.fields?.onToggleColumn) {
       toolbar.fields.onToggleColumn({ toggledField: key, activeFields })
+    }
   }
 
   handleShowAllColumns = () => {

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import reduce from 'lodash/reduce'
 import map from 'lodash/map'
 import isEmpty from 'lodash/isEmpty'
+import difference from 'lodash/difference'
 
 import Box from '../Box'
 import EmptyState from '../EmptyState'
@@ -81,14 +82,35 @@ class Table extends PureComponent {
     const index = hiddenFields.indexOf(key)
     index === -1 ? newFieldsArray.push(key) : newFieldsArray.splice(index, 1)
     this.setState({ hiddenFields: newFieldsArray })
+
+    const { toolbar } = this.props
+
+    const activeFields = difference(
+      Object.keys(this.props.schema.properties),
+      newFieldsArray
+    )
+
+    toolbar?.fields?.onToggleColumn &&
+      toolbar.fields.onToggleColumn({ toggledField: key, activeFields })
   }
 
   handleShowAllColumns = () => {
     this.setState({ hiddenFields: [] })
+
+    const { toolbar } = this.props
+
+    toolbar?.fields?.onShowAllColumns &&
+      toolbar.fields.onShowAllColumns(Object.keys(this.props.schema.properties))
   }
 
   handleHideAllColumns = () => {
-    this.setState({ hiddenFields: Object.keys(this.props.schema.properties) })
+    const newFieldsArray = Object.keys(this.props.schema.properties)
+
+    this.setState({ hiddenFields: newFieldsArray })
+
+    const { toolbar } = this.props
+
+    toolbar?.fields?.onHideAllColumns && toolbar.fields.onHideAllColumns([])
   }
 
   handleSelectionChange = () => {
@@ -441,6 +463,9 @@ Table.propTypes = {
       showAllLabel: PropTypes.string,
       hideAllLabel: PropTypes.string,
       alignMenu: PropTypes.oneOf(['right', 'left']),
+      onToggleColumn: PropTypes.func,
+      onHideAllColumns: PropTypes.func,
+      onShowAllColumns: PropTypes.func,
     }),
     download: PropTypes.shape({
       label: PropTypes.string,

--- a/react/components/Table/index.js
+++ b/react/components/Table/index.js
@@ -100,8 +100,9 @@ class Table extends PureComponent {
 
     const { toolbar } = this.props
 
-    toolbar?.fields?.onShowAllColumns &&
+    if (toolbar?.fields?.onShowAllColumns) {
       toolbar.fields.onShowAllColumns(Object.keys(this.props.schema.properties))
+    }
   }
 
   handleHideAllColumns = () => {
@@ -111,7 +112,9 @@ class Table extends PureComponent {
 
     const { toolbar } = this.props
 
-    toolbar?.fields?.onHideAllColumns && toolbar.fields.onHideAllColumns([])
+    if (toolbar?.fields?.onHideAllColumns) {
+      toolbar.fields.onHideAllColumns([])
+    }
   }
 
   handleSelectionChange = () => {


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->
Possibility to get callback on toggle fields visibility with `onToggleColumn`, `onHideAllColumns` and `onShowAllColumns`
The callback functions `onHideAllColumns` and `onShowAllColumns` returns a string array with active columns, and `onToggleColumn` returns the field changed and a string array with active columns.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

I needed to create a feature that save on localstorage a custom visibility created by user, but the controls handlers are not exposed to get a callback when the user did the visibility action.
Because of this I added 3 functions to get this actions and a callback with active fields, to solve my problem and for everyone who wants to use this callback to do something.


#### Screenshots or example usage

```jsx
toolbar={{
...
          fields: {
             ...
            onToggleColumn: (params) => {
              console.log(params.toggledField)
              console.log(params.activeFields)
            },
            onHideAllColumns: (activeFields) => console.log(activeFields),
            onShowAllColumns: (activeFields) => console.log(activeFields),
            ...
          },
...
}}
```

![image](https://user-images.githubusercontent.com/17439470/123112948-87efb480-d414-11eb-82e1-79dc955dda8c.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
