### PR TITLE
Feature/select for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Add searchable option to Select component so it can better be used on mobile
 
 ## [9.144.0] - 2021-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
 
-- Add searchable option to Select component so it can better be used on mobile
+- **EXPERIMENTAL_Select** `searchable` option so it can be better used on mobile.
 
 ## [9.144.0] - 2021-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.145.0] - 2021-07-12
+
 ### Added
 
 - **EXPERIMENTAL_Select** `searchable` option so it can be better used on mobile.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.144.0",
+  "version": "9.145.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.144.0",
+  "version": "9.145.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/EXPERIMENTAL_Select/README.md
+++ b/react/components/EXPERIMENTAL_Select/README.md
@@ -272,6 +272,33 @@ const options = [
 </div>
 ```
 
+Without search input (good for mobile experience)
+
+```js
+const options = [
+  {
+    value: 'first-option',
+    label: 'First Option',
+  },
+  {
+    value: 'second-option',
+    label: 'Second Option',
+  },
+]
+
+;<div>
+  <Select
+    label="Label"
+    options={options}
+    multi={false}
+    searchable={false}
+    onChange={values => {
+      console.log(`[Select] Selected: ${JSON.stringify(values, null, 2)}`)
+    }}
+  />
+</div>
+```
+
 Loading state
 
 ```js

--- a/react/components/EXPERIMENTAL_Select/index.js
+++ b/react/components/EXPERIMENTAL_Select/index.js
@@ -41,6 +41,7 @@ class Select extends Component {
       formatCreateLabel,
       label,
       loading,
+      searchable,
       multi,
       noOptionsMessage,
       onChange,
@@ -80,6 +81,7 @@ class Select extends Component {
       isClearable: clearable,
       isDisabled: disabled,
       isLoading: loading,
+      isSearchable: searchable,
       isMulti: multi,
       noOptionsMessage,
       inputId: this.inputId,
@@ -204,6 +206,7 @@ class Select extends Component {
 
 Select.defaultProps = {
   multi: true,
+  searchable: true,
   placeholder: 'Select...',
   size: 'regular',
   clearable: true,
@@ -255,6 +258,8 @@ Select.propTypes = {
   loading: PropTypes.bool,
   /** Text to display when loading options */
   loadingMessage: PropTypes.string,
+  /** Support disabling search input and only allow select to change values. */
+  searchable: PropTypes.bool,
   /** Support multiple selected options. */
   multi: PropTypes.bool,
   /** Text to display when there are no options. ({inputValue}) => string | null */


### PR DESCRIPTION
#### What is the purpose of this pull request?

To allow Select component to be able to work without the search, so on mobile it doesn't open the keyboard

#### How should this be manually tested?

By passing prop searchable={false} on the element

#### Screenshots or example usage

### Select with search:

![MobileWithSearch](https://user-images.githubusercontent.com/1321766/125193858-0cb83c00-e225-11eb-9fc6-7390a6c313c8.jpeg)


### Select without search:

![SelectWithoutSearch](https://user-images.githubusercontent.com/1321766/125193846-fd38f300-e224-11eb-83b4-e99354822238.jpeg)

### How a real use mobile can zoom when clicking on this Select with the search:

![PrintOnRealCustomerMobile](https://user-images.githubusercontent.com/1321766/125193872-23f72980-e225-11eb-88f3-0048b9431030.png)



#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
