### PR TITLE
Add onFocus, onBlur, onMouseEnter and onMouseLeave events to Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.146.0] - 2022-02-15
+
 ### Added
 
 - **Dropdown** `onFocus`, `onBlur`, `onMouseEnter` and `onMouseLeave` props.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Dropdown** `onFocus`, `onBlur`, `onMouseEnter` and `onMouseLeave` props.
+
 ## [9.145.2] - 2021-10-26
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.145.2",
+  "version": "9.146.0",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.145.2",
+  "version": "9.146.0",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Dropdown/README.md
+++ b/react/components/Dropdown/README.md
@@ -37,6 +37,10 @@ options = [
       options={options}
       value={state.selected1}
       onChange={(_, v) => setState({ selected1: v })}
+      onFocus={() => console.log('onFocus fired!')}
+      onBlur={() => console.log('onBlur fired!')}
+      onMouseEnter={() => console.log('onMouseEnter fired!')}
+      onMouseLeave={() => console.log('onMouseLeave fired!')}
     />
   </div>
 
@@ -46,6 +50,10 @@ options = [
       options={options}
       value={state.selected2}
       onChange={(_, v) => setState({ selected2: v })}
+      onFocus={() => console.log('onFocus fired!')}
+      onBlur={() => console.log('onBlur fired!')}
+      onMouseEnter={() => console.log('onMouseEnter fired!')}
+      onMouseLeave={() => console.log('onMouseLeave fired!')}
     />
   </div>
 
@@ -56,6 +64,10 @@ options = [
       options={options}
       value={state.selected3}
       onChange={(_, v) => setState({ selected3: v })}
+      onFocus={() => console.log('onFocus fired!')}
+      onBlur={() => console.log('onBlur fired!')}
+      onMouseEnter={() => console.log('onMouseEnter fired!')}
+      onMouseLeave={() => console.log('onMouseLeave fired!')}
     />
   </div>
 </div>

--- a/react/components/Dropdown/index.js
+++ b/react/components/Dropdown/index.js
@@ -75,10 +75,12 @@ class Dropdown extends Component {
 
   handleFocus = () => {
     this.setState({ active: true })
+    this.props.onFocus && this.props.onFocus(event)
   }
 
   handleBlur = () => {
     this.setState({ active: false })
+    this.props.onBlur && this.props.onBlur(event)
   }
 
   getValueLabel() {
@@ -219,6 +221,8 @@ class Dropdown extends Component {
               onChange={this.handleChange}
               onFocus={this.handleFocus}
               onBlur={this.handleBlur}
+              onMouseEnter={this.props.onMouseEnter}
+              onMouseLeave={this.props.onMouseLeave}
               ref={this.props.forwardedRef}
               // Check the comment on the constructor regarding nil values
               value={value == null ? '' : value}
@@ -324,6 +328,14 @@ Dropdown.propTypes = {
   required: PropTypes.bool,
   /** onChange event */
   onChange: PropTypes.func,
+  /** onFocus event */
+  onFocus: PropTypes.func,
+  /** onBlur event */
+  onBlur: PropTypes.func,
+  /** onMouseEnter event */
+  onMouseEnter: PropTypes.func,
+  /** onMouseLeave event */
+  onMouseLeave: PropTypes.func,
   /** onClose event */
   onClose: PropTypes.func,
   /** onOpen event */

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -287,12 +287,12 @@ module.exports = {
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-M4WMB9F');</script>
+})(window,document,'script','dataLayer','GTM-NCDTF39');</script>
 <!-- End Google Tag Manager -->`,
     },
     body: {
       raw: `<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M4WMB9F"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NCDTF39"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->`,
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says, these events were missing.

#### What problem is this solving?

No way for listening to these events on the Dropdown component.

#### How should this be manually tested?

They can be viewed by playing with the first Dropdown examples, which logs on the console when they're fired.

#### Screenshots or example usage

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/15948386/153641307-09f60dee-72ac-409c-b8eb-bc2177cb8a2c.png">

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
