### PR TITLE
Release v9.146.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.146.1] - 2022-03-14
+
 ### Removed
 
 - **Dropdown** `onOpen` and `onClose` unused props.
@@ -4146,3 +4148,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Modal** props `title` & `style`
 - **Dropdown** and **Input** prop `block`. They are always block.
 - **Dropdown** and **Input** props `short` and `long`. Their widths should be defined by their parents.
+
+
+[Unreleased]: https://github.com/vtex/styleguide/compare/v9.146.1...HEAD
+[9.146.1]: https://github.com/vtex/styleguide/compare/v9.146.0...v9.146.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- **Dropdown** `onOpen` and `onClose` unused props.
+
 ## [9.146.0] - 2022-02-15
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.146.0",
+  "version": "9.146.1",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.146.0",
+  "version": "9.146.1",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",


### PR DESCRIPTION
ℹ️  Related to #1417 and #1418 

## [9.146.1] - 2022-03-14

### Removed

- **Dropdown** `onOpen` and `onClose` unused props.
