### PR TITLE
Fix: `NumericStepper` click event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **NumericStepper** not working after switching from touch devices.
+
 ## [9.146.1] - 2022-03-14
 
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.146.1",
+  "version": "9.146.2",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.146.1",
+  "version": "9.146.2",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -185,13 +185,13 @@ class NumericStepper extends Component {
   }
 
   handleIncreaseValue = event => {
+    event.stopPropagation()
     this.changeValue(this.state.value + 1, event, false)
-    event.preventDefault()
   }
 
   handleDecreaseValue = event => {
+    event.stopPropagation()
     this.changeValue(this.state.value - 1, event, false)
-    event.preventDefault()
   }
 
   handleFocusInput = e => {
@@ -283,11 +283,6 @@ class NumericStepper extends Component {
       lean ? 'outline-0' : ''
     } `
 
-    const touchDevice =
-      'ontouchstart' in window ||
-      (typeof navigator !== 'undefined' &&
-        (navigator?.maxTouchPoints || navigator?.msMaxTouchPoints))
-
     const content = (
       <React.Fragment>
         {label && (
@@ -328,8 +323,7 @@ class NumericStepper extends Component {
               disabled={readOnly || isMax}
               aria-label="+"
               tabIndex={0}
-              onClick={touchDevice ? undefined : this.handleIncreaseValue}
-              onTouchEnd={touchDevice ? this.handleIncreaseValue : undefined}>
+              onClick={this.handleIncreaseValue}>
               <div className="vtex-numeric-stepper__plus-button__text numeric-stepper__plus-button__text b">
                 {/* fullwidth plus sign (U+FF0B) http://graphemica.com/%EF%BC%8B */}
                 ＋
@@ -354,8 +348,7 @@ class NumericStepper extends Component {
               // which is the default keyboard character.
               // Used for screen readers.
               tabIndex={0}
-              onClick={touchDevice ? undefined : this.handleDecreaseValue}
-              onTouchEnd={touchDevice ? this.handleDecreaseValue : undefined}>
+              onClick={this.handleDecreaseValue}>
               <span className="vtex-numeric-stepper__minus-button__text numeric-stepper__minus-button__text b">
                 {/* fullwidth hyphen-minus (U+FF0D) http://graphemica.com/%EF%BC%8D */}
                 －


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR aims to solve  [this Known Issue (KI)](https://vtex-dev.atlassian.net/browse/SF-35):
[KI] Product Quantity Selector Error for high-resolution screens.

#### What problem is this solving?

Copied from Jira Issue:
When rendering high resolutions, the quantity selector doesn't work.

Simulation
 - Access the `storecomponents`;
 - Open the Chrome inspector
 - Set the screen size on 4000px X 2000px with the chrome's DevTools utility
 - Refresh the page;
 - Wait for the page to be loaded;
 - Close the inspector  WITHOUT REFRESHING THE PAGE;
 - Try to use the qty selector.

---

While investigating this issue, we noticed that this problem is not related to the high-resolution screens, but to the toggle device toolbar feature of devtools that simulates some touch devices.

<img width="113" alt="Screen Shot 2022-08-30 at 12 35 13" src="https://user-images.githubusercontent.com/11325562/187479800-a7141b16-e02a-4c5a-9963-eca3661d4890.png">

As we also have a [previous fix regarding](https://github.com/vtex/styleguide/pull/1381) the quantity selector inside the `autocomplete` component, we understand that when we use touch devices, the click event on quantity selector button is handled by the `onTouchEnd` event, instead of `onClick`, but the values that comes from the older `touchDevice` is not updated once we switch to touch devices.

For the sake of simplifying this, we are only handling the event using the `onClick` for all kinds of devices, and we are using the `event.stopPropagation` to keep the https://github.com/vtex/styleguide/pull/1381 working as expected.

#### Screenshots or example usage

|Before|After|
|-|-|
|![xUAtuZtIuh](https://user-images.githubusercontent.com/11325562/187482913-e38ec0a3-46ee-43c6-a3b4-6565a8d9038f.gif)|![ow68BiiYts](https://user-images.githubusercontent.com/11325562/187483695-eea3c9e5-7ead-4a2e-ac52-39d0d47454d4.gif)|

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
