### PR TITLE
fix: NumericStepper redirecting to product page when inside a shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+
+- **NumericStepper** redirecting to product page when inside a shelf, added a preventDefault.
+
 ## [9.146.2] - 2022-09-02
 
 ### Fixed

--- a/react/components/NumericStepper/index.js
+++ b/react/components/NumericStepper/index.js
@@ -186,11 +186,13 @@ class NumericStepper extends Component {
 
   handleIncreaseValue = event => {
     event.stopPropagation()
+    event.preventDefault()
     this.changeValue(this.state.value + 1, event, false)
   }
 
   handleDecreaseValue = event => {
     event.stopPropagation()
+    event.preventDefault()
     this.changeValue(this.state.value - 1, event, false)
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a preventDefault numeric steppericStepper to avoid other events triggered

#### What problem is this solving?

When interacting with the numeric stepper inside a shelf, we are being redirected to a product page

#### How should this be manually tested?

https://tiendaio--tiendamarco.myvtex.com/

Increase and decrease the product quantity

<img width="654" alt="image" src="https://user-images.githubusercontent.com/13649073/188914688-dc3df4df-92fa-4fa2-908e-5df0a16562d9.png">

Unlink this version and check again

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
