### PR TITLE
Release v9.146.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.146.4] - 2023-04-25
+
 ### Changed
 
 - Prevents `Slider` range from resetting when the min/max value changes.
@@ -4166,5 +4168,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Dropdown** and **Input** props `short` and `long`. Their widths should be defined by their parents.
 
 
-[Unreleased]: https://github.com/vtex/styleguide/compare/v9.146.1...HEAD
+[Unreleased]: https://github.com/vtex/styleguide/compare/v9.146.4...HEAD
 [9.146.1]: https://github.com/vtex/styleguide/compare/v9.146.0...v9.146.1
+
+[9.146.4]: https://github.com/vtex/styleguide/compare/v9.146.3...v9.146.4

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.146.3",
+  "version": "9.146.4",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.146.3",
+  "version": "9.146.4",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",


### PR DESCRIPTION
## [9.146.4](https://github.com/vtex/styleguide/compare/v9.146.3...v9.146.4) - 2023-04-25

### Changed

- Prevents `Slider` range from resetting when the min/max value changes.