### PR TITLE
Feat/ add noOptionsMessage to Conditions and pass to Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added 
+- **EXPERIMENTAL_Conditions** new prop `noOptionsMessage` to handle custom empty messages for **EXPERIMENTAL_Select**
+
 ## [9.146.4] - 2023-04-25
 
 ### Changed

--- a/react/components/EXPERIMENTAL_Conditions/Atoms/SubjectAtom.js
+++ b/react/components/EXPERIMENTAL_Conditions/Atoms/SubjectAtom.js
@@ -17,6 +17,7 @@ class SubjectAtom extends React.Component {
       isFullWidth,
       statementIndex,
       placeholder,
+      noOptionsMessage,
     } = this.props
     const condition = statements[statementIndex]
 
@@ -71,6 +72,9 @@ class SubjectAtom extends React.Component {
             this.handleChangeStatement(subject, 'subject')
           }}
           multi={false}
+          noOptionsMessage={() => {
+            return noOptionsMessage
+          }}
         />
       </div>
     )
@@ -103,6 +107,8 @@ SubjectAtom.propTypes = {
   statementIndex: PropTypes.number,
   /** Value changed callback */
   onChangeStatement: PropTypes.func,
+  /** Value showed when has no options */
+  noOptionsMessage: PropTypes.string,
 }
 
 export default withForwardedRef(SubjectAtom)

--- a/react/components/EXPERIMENTAL_Conditions/Statement.js
+++ b/react/components/EXPERIMENTAL_Conditions/Statement.js
@@ -69,6 +69,7 @@ class Statement extends React.Component {
       statementIndex,
       labels,
       onChangeObjectCallback,
+      noOptionsMessage,
     } = this.props
     const condition = statements[statementIndex]
     const atomProps = {
@@ -76,6 +77,7 @@ class Statement extends React.Component {
       options: options,
       isFullWidth: isFullWidth,
       statementIndex: statementIndex,
+      noOptionsMessage,
       onChangeObjectCallback,
     }
 
@@ -161,6 +163,7 @@ Statement.defaultProps = {
   isFullWidth: false,
   statementIndex: 0,
   labels: { delete: 'DELETE' },
+  noOptionsMessage: 'No Options',
 }
 
 Statement.propTypes = {
@@ -197,6 +200,8 @@ Statement.propTypes = {
   }),
   /** Please use the following one with caution, I did not test it, so it can break everything */
   onChangeObjectCallback: PropTypes.func,
+  /** Value showed when has no options in subject, verb and object*/
+  noOptionsMessage: PropTypes.string,
 }
 
 export default Statement

--- a/react/components/EXPERIMENTAL_Conditions/index.js
+++ b/react/components/EXPERIMENTAL_Conditions/index.js
@@ -18,6 +18,7 @@ class EXPERIMENTAL_Conditions extends React.Component {
     statements: [],
     onChangeOperator: () => {},
     onChangeStatements: () => {},
+    noOptionsMessage: 'No Options',
     labels: {
       operatorAll: 'all',
       operatorAnd: 'and',
@@ -100,6 +101,7 @@ class EXPERIMENTAL_Conditions extends React.Component {
       labels,
       showOperator,
       operator,
+      noOptionsMessage,
     } = this.props
 
     return (
@@ -147,6 +149,7 @@ class EXPERIMENTAL_Conditions extends React.Component {
                       statements={statements}
                       statementIndex={statementIndex}
                       labels={labels}
+                      noOptionsMessage={noOptionsMessage}
                     />
 
                     {statementIndex !== statements.length - 1 && (
@@ -221,6 +224,8 @@ EXPERIMENTAL_Conditions.propTypes = {
   isRtl: PropTypes.bool,
   /** Show or hide the header that selects the operator (any vs all) */
   showOperator: PropTypes.bool,
+  /** Value showed when has no options in subject, verb and object*/
+  noOptionsMessage: PropTypes.string,
   /** Labels for the controls and texts, default is english */
   labels: PropTypes.shape({
     addNewCondition: PropTypes.string,


### PR DESCRIPTION
#### What is the purpose of this pull request?

With this we are able to pass a custom message to Subject, Verb and Object when they are empty

#### What problem is this solving?


Currently we cannot set a custom message when they are empty, blocking the translations of this

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
* Switch to this branch and run
* Pass a custom message to `noOptionsMessage` in `Conditions` component and see the changes

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
