### PR TITLE
feat: implement onFocus callback inside InputSearch

### DIFF
--- a/react/components/InputSearch/index.js
+++ b/react/components/InputSearch/index.js
@@ -55,8 +55,18 @@ class InputSearch extends Component {
     this.setState({ hover })
   }
 
-  handleFocus = focus => {
-    this.setState({ focus })
+  handleFocus = event => {
+    const { onFocus } = this.props
+
+    this.setState({ focus: true })
+
+    if (onFocus && typeof onFocus === 'function') {
+      onFocus(event)
+    }
+  }
+
+  handleBlur = () => {
+    this.setState({ focus: false })
   }
 
   render() {
@@ -67,8 +77,8 @@ class InputSearch extends Component {
     return (
       <Input
         {...this.props}
-        onFocus={() => this.handleFocus(true)}
-        onBlur={() => this.handleFocus(false)}
+        onFocus={this.handleFocus}
+        onBlur={this.handleBlur}
         onMouseEnter={() => this.handleHovering(true)}
         onMouseLeave={() => this.handleHovering(false)}
         onKeyUp={e => e.key === 'Enter' && this.handleSubmit(e)}
@@ -111,6 +121,7 @@ InputSearch.propTypes = {
   forwardedRef: refShape,
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
+  onFocus: PropTypes.func,
   onClear: PropTypes.func,
   size: PropTypes.string,
   value: PropTypes.string,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Related: https://github.com/vtex-apps/store-components/issues/1074

The `InputSearch` component is not calling the `onFocus` callback that can be set on the props. This creates an issue as described inside the store-components. When the `InputSearch` component is being rendered as the main searchbar, the autocomplete is not opened by default if this is configured. 

#### What problem is this solving?
This solves the issue of the non-appearing auto-complete bar when using the `inputType: search` configuration on the `searchbar` component. 

#### How should this be manually tested?
Steps to reproduce the behavior:
1. Place the store-components searchbar somewhere in your template with the following props:
```json
{
  "props": {
    "openAutocompleteOnFocus": true,
    "inputType": "search"
  }
}
```
3. Go to your store, put your cursor inside the input field so it receives focus
4. Autocomplete is not expanded

**Expected behavior**
The autocomplete should be expanded showing `top searches` and `search history`

#### Screenshots or example usage
**current result**
![searchbar-issue-actual](https://github.com/bgoyarts/vtex-keune-styleguide/assets/44701246/e151710e-e1a4-4fe2-9b88-e00a660e9b72)

**fix**
![searchbar-issue-fixed](https://github.com/bgoyarts/vtex-keune-styleguide/assets/44701246/e1c3af56-588c-4e82-ac6e-3790d54565e1)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
