### PR TITLE
Add data attribute to checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [9.146.14] - 2025-02-19
-
 ### Changed
 
 - Added four new attributes to the checkbox component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.146.14] - 2025-02-19
+
+### Changed
+
+- Added four new attributes to the checkbox component
+
 ## [9.146.13] - 2024-08-20
 
 ## [9.146.12] - 2024-08-20

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.146.13",
+  "version": "9.146.14",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.146.13",
+  "version": "9.146.14",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -116,7 +116,7 @@ class Checkbox extends PureComponent {
             onChange={this.handleChange}
             type="checkbox"
             value={value}
-            data={data}
+            data-query={data}
             tabIndex={0}
           />
         </div>
@@ -165,7 +165,7 @@ Checkbox.propTypes = {
   /** Partial state */
   partial: PropTypes.bool,
   /** (Input spec attribute) */
-  data: PropTypes.arrayOf(PropTypes.string)
+  data: PropTypes.string
 }
 
 export default withForwardedRef(Checkbox)

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -41,8 +41,10 @@ class Checkbox extends PureComponent {
       value,
       partial,
       forwardedRef,
-      query,
-      isClicked
+      queryText,
+      isClicked,
+      queryCategory,
+      facetKey
     } = this.props
 
     return (
@@ -117,8 +119,10 @@ class Checkbox extends PureComponent {
             onChange={this.handleChange}
             type="checkbox"
             value={value}
-            data-query={query}
+            data-query-text={queryText}
+            data-query-category={queryCategory}
             data-is-clicked={isClicked}
+            data-facet-key={facetKey}
             tabIndex={0}
           />
         </div>
@@ -166,9 +170,13 @@ Checkbox.propTypes = {
   value: PropTypes.string,
   /** Partial state */
   partial: PropTypes.bool,
-  /** (Input spec attribute) */
-  query: PropTypes.array,
+
+  /** (Input spec attributes) */
+  queryText: PropTypes.string,
+  facetKey: PropTypes.string,
+  queryCategory: PropTypes.string,
   isClicked: PropTypes.string
+
 }
 
 export default withForwardedRef(Checkbox)

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -41,10 +41,11 @@ class Checkbox extends PureComponent {
       value,
       partial,
       forwardedRef,
-      queryText,
+      fullText,
       isClicked,
-      queryCategory,
-      facetKey
+      facetKey,
+      initialQuery,
+      initialMap
     } = this.props
 
     return (
@@ -119,8 +120,9 @@ class Checkbox extends PureComponent {
             onChange={this.handleChange}
             type="checkbox"
             value={value}
-            data-query-text={queryText}
-            data-query-category={queryCategory}
+            data-full-text={fullText}
+            data-initial-query={initialQuery}
+            data-initial-map={initialMap}
             data-is-clicked={isClicked}
             data-facet-key={facetKey}
             tabIndex={0}
@@ -172,9 +174,10 @@ Checkbox.propTypes = {
   partial: PropTypes.bool,
 
   /** (Input spec attributes) */
-  queryText: PropTypes.string,
+  initialQuery: PropTypes.string,
+  initialMap: PropTypes.string,
+  fullText: PropTypes.string,
   facetKey: PropTypes.string,
-  queryCategory: PropTypes.string,
   isClicked: PropTypes.string
 
 }

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -41,7 +41,7 @@ class Checkbox extends PureComponent {
       value,
       partial,
       forwardedRef,
-      query
+      data
     } = this.props
 
     return (
@@ -116,7 +116,7 @@ class Checkbox extends PureComponent {
             onChange={this.handleChange}
             type="checkbox"
             value={value}
-            query={query}
+            data={data}
             tabIndex={0}
           />
         </div>
@@ -165,7 +165,7 @@ Checkbox.propTypes = {
   /** Partial state */
   partial: PropTypes.bool,
   /** (Input spec attribute) */
-  query: PropTypes.string
+  data: PropTypes.arrayOf(PropTypes.string)
 }
 
 export default withForwardedRef(Checkbox)

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -41,6 +41,7 @@ class Checkbox extends PureComponent {
       value,
       partial,
       forwardedRef,
+      query
     } = this.props
 
     return (
@@ -115,6 +116,7 @@ class Checkbox extends PureComponent {
             onChange={this.handleChange}
             type="checkbox"
             value={value}
+            query={query}
             tabIndex={0}
           />
         </div>
@@ -162,6 +164,8 @@ Checkbox.propTypes = {
   value: PropTypes.string,
   /** Partial state */
   partial: PropTypes.bool,
+  /** (Input spec attribute) */
+  query: PropTypes.string
 }
 
 export default withForwardedRef(Checkbox)

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -44,6 +44,7 @@ class Checkbox extends PureComponent {
       fullText,
       isClicked,
       facetKey,
+      facetValue,
       initialQuery,
       initialMap
     } = this.props
@@ -125,6 +126,7 @@ class Checkbox extends PureComponent {
             data-initial-map={initialMap}
             data-is-clicked={isClicked}
             data-facet-key={facetKey}
+            data-facet-value={facetValue}
             tabIndex={0}
           />
         </div>
@@ -178,8 +180,8 @@ Checkbox.propTypes = {
   initialMap: PropTypes.string,
   fullText: PropTypes.string,
   facetKey: PropTypes.string,
+  facetValue: PropTypes.string,
   isClicked: PropTypes.string
-
 }
 
 export default withForwardedRef(Checkbox)

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -41,7 +41,8 @@ class Checkbox extends PureComponent {
       value,
       partial,
       forwardedRef,
-      data
+      query,
+      isClicked
     } = this.props
 
     return (
@@ -116,7 +117,8 @@ class Checkbox extends PureComponent {
             onChange={this.handleChange}
             type="checkbox"
             value={value}
-            data-query={data}
+            data-query={query}
+            data-is-clicked={isClicked}
             tabIndex={0}
           />
         </div>
@@ -140,7 +142,7 @@ Checkbox.defaultProps = {
   checked: false,
   disabled: false,
   required: false,
-  partial: false,
+  partial: false
 }
 
 Checkbox.propTypes = {
@@ -165,7 +167,8 @@ Checkbox.propTypes = {
   /** Partial state */
   partial: PropTypes.bool,
   /** (Input spec attribute) */
-  data: PropTypes.string
+  query: PropTypes.array,
+  isClicked: PropTypes.string
 }
 
 export default withForwardedRef(Checkbox)

--- a/react/components/Checkbox/index.test.js
+++ b/react/components/Checkbox/index.test.js
@@ -14,7 +14,7 @@ describe('Checkbox', () => {
         id="my-checkbox"
         onChange={() => {}}
         isClicked="false"
-        facetKey="Mykey"
+        facetKey="my-key"
       />
     )
 
@@ -30,6 +30,7 @@ describe('Checkbox', () => {
         name="checkme"
         id="my-checkbox"
         onChange={() => {}}
+        queryText="my-query"
       />
     )
     const inputElement = document.querySelector('input')
@@ -38,7 +39,7 @@ describe('Checkbox', () => {
   })
 
   it('should accept not passing a ref', () => {
-    render(<Checkbox name="checkme" id="my-checkbox" onChange={() => {}} />)
+    render(<Checkbox name="checkme" id="my-checkbox" onChange={() => {}} queryCategory="my-query"/>)
     const inputElement = document.querySelector('input')
 
     expect(inputElement).toBeTruthy()

--- a/react/components/Checkbox/index.test.js
+++ b/react/components/Checkbox/index.test.js
@@ -13,6 +13,8 @@ describe('Checkbox', () => {
         name="checkme"
         id="my-checkbox"
         onChange={() => {}}
+        isClicked="false"
+        facetKey="Mykey"
       />
     )
 
@@ -41,4 +43,5 @@ describe('Checkbox', () => {
 
     expect(inputElement).toBeTruthy()
   })
+
 })


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adding the following data attribute to the checkbox component for collection data on activity-flow.
This attributes are specifically added for usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### How to test this change?

1. Download this project and link it on VTEX IO to an account that uses the checkbox component.
(I am using hering, testing the filter's checkbox)

2. Create your project with the checkbox component — or download one that already uses it — and link it to VTEX IO.
(I am using the [search-result react app](https://github.com/vtex-apps/search-result) and altering the [FacetItem](https://github.com/vtex-apps/search-result/blob/master/react/components/FacetItem.js) component)

3. Add the desired attributes within the checkbox component following the template:

```
// Atribute will show as data-is-clicked
isClicked={YourValue}

// Atribute will show as data-facet-key
facetKey={YourValue}

// Atribute will show as data-query-text
queryText={YourValue}

// Atribute will show as data-query-category
queryCategory={YourValue}
```

**!!! Important information !!!
All values should be of type String**

Example of full code:
<img width="357" alt="image" src="https://github.com/user-attachments/assets/2408bcfd-2583-4d5a-8af6-dcfba2f5251b" />

4. After reloading the web page, right-click on the checkbox and select "Inspect"
5. Your values should show within the data attributes like in the following example:
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/98bb1579-4c0c-479d-a6fb-64f08449073a" />