### PR TITLE
add checkbox attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- The option to place data attributes in the `Checkbox` component.
+
 ## [9.146.13] - 2024-08-20
 
 ## [9.146.12] - 2024-08-20

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.146.13",
+  "version": "9.146.14",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Checkbox/index.js
+++ b/react/components/Checkbox/index.js
@@ -41,7 +41,15 @@ class Checkbox extends PureComponent {
       value,
       partial,
       forwardedRef,
+      ...remainingProps
     } = this.props
+
+    const dataAttributes = Object.keys(remainingProps)
+      .filter(key => key.startsWith('data-'))
+      .reduce((obj, key) => {
+        obj[key] = remainingProps[key]
+        return obj
+      }, {})
 
     return (
       <div
@@ -115,6 +123,7 @@ class Checkbox extends PureComponent {
             onChange={this.handleChange}
             type="checkbox"
             value={value}
+            {...dataAttributes}
             tabIndex={0}
           />
         </div>
@@ -162,6 +171,14 @@ Checkbox.propTypes = {
   value: PropTypes.string,
   /** Partial state */
   partial: PropTypes.bool,
+
+  /** (Input spec attributes) */
+  initialQuery: PropTypes.string,
+  initialMap: PropTypes.string,
+  fullText: PropTypes.string,
+  facetKey: PropTypes.string,
+  facetValue: PropTypes.string,
+  isClicked: PropTypes.string,
 }
 
 export default withForwardedRef(Checkbox)


### PR DESCRIPTION
#### What is the purpose of this pull request?

We need to collect click data from the Checkbox in the Facets component. In order to this, We must have the ability to add data-attributes to the `Checkbox` component

Example:

```javascript
<Checkbox
        id={checkBoxId}
        checked={selected}
       ...
        data-full-text={searchQuery?.variables?.fullText}
        data-initial-query={initialquery}
        data-initial-map={initialmap}
        data-is-clicked={selected.toString()}
        data-facet-key={facet.key}
        data-facet-value={facet.value}
      />
```

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### How to test this change?

[Workspace](https://hiago--biggy.myvtex.com/)

![image](https://github.com/user-attachments/assets/5d64bcfc-837b-4cbd-903b-0ccea1f00587)


