### PR TITLE
[accessibility] Adds aria-invalid="true" when Input has error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.146.16] - 2025-11-10
+
 ## [9.146.16-beta] - 2025-11-07
 
 ### Added
@@ -4208,9 +4210,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Dropdown** and **Input** props `short` and `long`. Their widths should be defined by their parents.
 
 
-[Unreleased]: https://github.com/vtex/styleguide/compare/v9.146.16-beta...HEAD
+[Unreleased]: https://github.com/vtex/styleguide/compare/v9.146.16...HEAD
 [9.146.1]: https://github.com/vtex/styleguide/compare/v9.146.0...v9.146.1
 
+[9.146.16]: https://github.com/vtex/styleguide/compare/v9.146.16-beta...v9.146.16
 [9.146.16-beta]: https://github.com/vtex/styleguide/compare/v9.146.15...v9.146.16-beta
 [9.146.15]: https://github.com/vtex/styleguide/compare/v9.146.14...v9.146.15
 [9.146.14]: https://github.com/vtex/styleguide/compare/v9.146.13...v9.146.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [9.146.16-beta] - 2025-11-07
+
 ### Added
 
 - **Input** adds aria-invalid="true" when element is in error to improve accessibility
@@ -4206,9 +4208,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **Dropdown** and **Input** props `short` and `long`. Their widths should be defined by their parents.
 
 
-[Unreleased]: https://github.com/vtex/styleguide/compare/v9.146.15...HEAD
+[Unreleased]: https://github.com/vtex/styleguide/compare/v9.146.16-beta...HEAD
 [9.146.1]: https://github.com/vtex/styleguide/compare/v9.146.0...v9.146.1
 
+[9.146.16-beta]: https://github.com/vtex/styleguide/compare/v9.146.15...v9.146.16-beta
 [9.146.15]: https://github.com/vtex/styleguide/compare/v9.146.14...v9.146.15
 [9.146.14]: https://github.com/vtex/styleguide/compare/v9.146.13...v9.146.14
 [9.146.13]: https://github.com/vtex/styleguide/compare/v9.146.12...v9.146.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Input** adds aria-invalid="true" when element is in error to improve accessibility
+
 ## [9.146.15] - 2025-10-30
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.146.16-beta",
+  "version": "9.146.16",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "styleguide",
   "title": "VTEX Styleguide",
-  "version": "9.146.15",
+  "version": "9.146.16-beta",
   "description": "The VTEX Styleguide components for the Render framework",
   "builders": {
     "react": "3.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.146.15",
+  "version": "9.146.16-beta",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/styleguide",
-  "version": "9.146.16-beta",
+  "version": "9.146.16",
   "scripts": {
     "lint": "eslint react --ext js,jsx,ts,tsx",
     "test": "node config/test.js",

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -94,6 +94,8 @@ class Input extends Component {
     } = this.props
     const { active } = this.state
 
+    const inputAriaInvalid = error || errorMessage ? true : undefined
+
     const suffix = suffixProp || suffixIcon
 
     const dataAttrs = {}
@@ -221,6 +223,7 @@ class Input extends Component {
             autoCorrect={this.props.autoCorrect}
             autoFocus={this.props.autoFocus}
             autoSave={this.props.autoSave}
+            aria-invalid={inputAriaInvalid}
             defaultValue={this.props.defaultValue}
             inputMode={this.props.inputMode}
             list={this.props.list}

--- a/react/components/Input/index.js
+++ b/react/components/Input/index.js
@@ -94,7 +94,7 @@ class Input extends Component {
     } = this.props
     const { active } = this.state
 
-    const inputAriaInvalid = error || errorMessage ? true : undefined
+    const inputAriaInvalid = error || errorMessage ? 'true' : undefined
 
     const suffix = suffixProp || suffixIcon
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds aria-invalid="true" when element is in error to improve accessibility

#### What problem is this solving?

Elements have no aria attribute to identify the error status of the 
element to screen readers

</details>

#### Screenshots or example usage


https://github.com/user-attachments/assets/994c485e-30a1-4dcc-8620-8b74addc296d



#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
