### PR TITLE
chore: STR-969 catalog platform-flow-id (CommDev#2, Merch#3)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -10,7 +10,7 @@ metadata:
     vtex.com/o11y-os-index: ""
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex/styleguide
-    vtex.com/platform-flow-id: ""
+    vtex.com/platform-flow-id: CommDev#2,Merch#3
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: T0WTW0H3
 spec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update DK Catalog platform-flow-id
+
 ## [9.146.16] - 2025-11-10
 
 ## [9.146.16-beta] - 2025-11-07


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Updates Backstage catalog metadata by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml` to match the **Platform Flows (Dark Kitchen)** classification for this component (initiative STR-969).

## Change

| Annotation | Value |
|------------|-------|
| `vtex.com/platform-flow-id` | `CommDev#2,Merch#3` |

**Convention:** multiple DK IDs are **comma-separated with no spaces**.

## Classification context (source artifact)

The following summary is taken from the internal classification table (Portuguese) used for STR-969:

> **Biblioteca:** design system React VTEX. **Decisão:** README/docs: componentes para produtos internos e extensões → **CommDev#2**; uso em admin/conta → **Merch#3**.

## Changelog

- `CHANGELOG.md` — **[Unreleased]** → **Changed**: Update DK Catalog platform-flow-id


---

Reviewers: @vmourac-vtex @iago1501
